### PR TITLE
Add OpenID Connect support to authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,4 @@ node_modules
 cdk.context.json
 *.nc
 .claud*
+openapi.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.3.0
+    rev: v1.15.0
     hooks:
       - id: mypy
         language_version: python
@@ -26,4 +26,4 @@ repos:
         additional_dependencies:
         - pydantic~=2.0
         - types-cachetools
-        - types-attrs
+        - attrs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,12 +24,7 @@ docker compose up
    - Username: `admin`
    - Password: `admin`
 
-3. Create a new realm for testing:
-   - Click "Create Realm"
-   - Name it `titiler-openeo`
-   - Click "Create"
-
-4. Create a new client:
+3. Create a new client:
    - Go to "Clients" → "Create client"
    - Client ID: `titiler-openeo`
    - Client type: `OpenID Connect`
@@ -38,16 +33,12 @@ docker compose up
    - Enable "Authorization"
    - Click "Save"
 
-5. Configure client settings:
-   - Valid redirect URIs: `http://localhost:8081/*`
-   - Web origins: `http://localhost:8081`
+4. Configure client settings:
+   - Valid redirect URIs: `http://localhost:8081/*` and `http://localhost:8080/*` for the openEO editor
+   - Web origins: `http://localhost:8081` and `http://localhost:8080` for the openEO editor
    - Click "Save"
 
-6. Get client credentials:
-   - Go to "Clients" → "titiler-openeo" → "Credentials" tab
-   - Copy the "Client secret"
-
-7. Create a test user:
+5. Create a test user:
    - Go to "Users" → "Add user"
    - Username: `test`
    - Email: `test@example.com`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,54 @@ cd titiler
 python -m pip install -e ".[test,dev]"
 ```
 
+**Authentication Testing with Keycloak**
+
+The project includes a Keycloak instance for testing OpenID Connect authentication:
+
+1. Start the development environment:
+```bash
+docker compose up
+```
+
+2. Access Keycloak admin console at http://localhost:8082/admin
+   - Username: `admin`
+   - Password: `admin`
+
+3. Create a new realm for testing:
+   - Click "Create Realm"
+   - Name it `titiler-openeo`
+   - Click "Create"
+
+4. Create a new client:
+   - Go to "Clients" → "Create client"
+   - Client ID: `titiler-openeo`
+   - Client type: `OpenID Connect`
+   - Click "Next"
+   - Enable "Client authentication"
+   - Enable "Authorization"
+   - Click "Save"
+
+5. Configure client settings:
+   - Valid redirect URIs: `http://localhost:8081/*`
+   - Web origins: `http://localhost:8081`
+   - Click "Save"
+
+6. Get client credentials:
+   - Go to "Clients" → "titiler-openeo" → "Credentials" tab
+   - Copy the "Client secret"
+
+7. Create a test user:
+   - Go to "Users" → "Add user"
+   - Username: `test`
+   - Email: `test@example.com`
+   - Click "Create"
+   - Go to "Credentials" tab
+   - Set password: `test123`
+   - Disable "Temporary"
+   - Click "Save password"
+
+The Keycloak server will be available at http://localhost:8082 for testing OIDC authentication flows.
+
 **pre-commit**
 
 This repo is set to use `pre-commit` to run *isort*, *flake8*, *pydocstring*, *black* ("uncompromising Python code formatter") and mypy when committing new code.
@@ -44,4 +92,3 @@ Actions deploys automatically for new commits.):
 
 ```bash
 mkdocs gh-deploy -f docs/mkdocs.yml
-```

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ COPY --from=builder /opt/venv /opt/venv
 
 # Create non-root user
 RUN useradd -m -s /bin/bash titiler && \
-    mkdir -p /data /config &&
+    mkdir -p /data /config
 COPY log_config.yaml /config/log_config.yaml
 RUN chown -R titiler:titiler /data /config
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
     CMD curl --fail http://localhost:8000/api || exit 1
 
 # Set default command
-CMD ["uvicorn", "titiler.openeo.main:app", "--host", "0.0.0.0", "--port", "8000", "--log-config", "/config/log_config.yaml", "--workers", "4"]
+CMD ["uvicorn", "titiler.openeo.main:app", "--host", "0.0.0.0", "--port", "80", "--log-config", "/config/log_config.yaml", "--workers", "4"]
 
 # Expose port
-EXPOSE 8000
+EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,8 +58,9 @@ COPY --from=builder /opt/venv /opt/venv
 
 # Create non-root user
 RUN useradd -m -s /bin/bash titiler && \
-    mkdir -p /data && \
-    chown -R titiler:titiler /data
+    mkdir -p /data /config &&
+COPY log_config.yaml /config/log_config.yaml
+RUN chown -R titiler:titiler /data /config
 
 WORKDIR /app
 USER titiler
@@ -68,7 +69,6 @@ USER titiler
 VOLUME /data
 # Create config directory and copy default config
 VOLUME /config
-COPY log_config.yaml /config/log_config.yaml
 
 # Add healthcheck
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,81 @@
-# Dockerfile for running titiler application with uvicorn server
+# syntax=docker/dockerfile:1
 ARG PYTHON_VERSION=3.11
 
+# Build stage
+FROM python:${PYTHON_VERSION}-slim AS builder
+
+# Set build labels
+LABEL stage=builder
+LABEL org.opencontainers.image.source="https://github.com/developmentseed/titiler-openeo"
+LABEL org.opencontainers.image.description="TiTiler OpenEO API"
+LABEL org.opencontainers.image.licenses="MIT"
+
+# Set environment variables
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# Install build dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    libexpat1 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create and activate virtual environment
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Install application
+WORKDIR /tmp
+COPY titiler/ titiler/
+COPY pyproject.toml .
+COPY README.md .
+RUN pip install --no-cache-dir --upgrade uvicorn PyYAML ".[pystac,oidc,postgres]"
+
+# Runtime stage
 FROM python:${PYTHON_VERSION}-slim
 
-RUN apt update && apt upgrade -y
+# Set runtime labels
+LABEL org.opencontainers.image.source="https://github.com/developmentseed/titiler-openeo"
+LABEL org.opencontainers.image.description="TiTiler OpenEO API"
+LABEL org.opencontainers.image.licenses="MIT"
 
-# ref: https://github.com/rasterio/rasterio-wheels/issues/136, https://github.com/docker-library/python/issues/989
-RUN apt install -y libexpat1
+# Set environment variables
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PATH="/opt/venv/bin:$PATH"
 
-RUN python -m pip install uvicorn gunicorn uvicorn worker
+# Install runtime dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    libexpat1 \
+    curl && \
+    rm -rf /var/lib/apt/lists/*
 
-# Copy files and install titiler.openeo
-WORKDIR /tmp
+# Copy virtual environment from builder
+COPY --from=builder /opt/venv /opt/venv
 
-COPY titiler/ titiler/
-COPY pyproject.toml pyproject.toml
-COPY README.md README.md
-
-RUN python -m pip install --no-cache-dir --upgrade ".[pystac,oidc,postgres]"
-RUN rm -rf /tmp/titiler pyproject.toml README.md
-
-RUN mkdir /data
+# Create non-root user
+RUN useradd -m -s /bin/bash titiler && \
+    mkdir -p /data && \
+    chown -R titiler:titiler /data
 
 WORKDIR /app
+USER titiler
+
+# Create data directory
+VOLUME /data
+# Create config directory and copy default config
+VOLUME /config
+COPY log_config.yaml /config/log_config.yaml
+
+# Add healthcheck
+HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
+    CMD curl --fail http://localhost:8000/api || exit 1
+
+# Set default command
+CMD ["uvicorn", "titiler.openeo.main:app", "--host", "0.0.0.0", "--port", "8000", "--log-config", "/config/log_config.yaml", "--workers", "4"]
+
+# Expose port
+EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,5 @@ COPY titiler/ titiler/
 COPY pyproject.toml pyproject.toml
 COPY README.md README.md
 
-RUN python -m pip install --no-cache-dir --upgrade ".[pystac]"
+RUN python -m pip install --no-cache-dir --upgrade ".[pystac,oidc]"
 RUN rm -rf /tmp/titiler pyproject.toml README.md

--- a/deployment/k8s/charts/Chart.yaml
+++ b/deployment/k8s/charts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.1.0
 description: OpenEO by TiTiler
 name: titiler-openeo
-version: 0.4.0
+version: 0.5.0
 icon: https://raw.githubusercontent.com/developmentseed/titiler/main/docs/logos/TiTiler_logo_small.png
 maintainers:
   - name: DevelopmentSeed

--- a/deployment/k8s/charts/files/log_config.yaml
+++ b/deployment/k8s/charts/files/log_config.yaml
@@ -1,0 +1,34 @@
+version: 1
+disable_existing_loggers: False
+formatters:
+  default:
+    # "()": uvicorn.logging.DefaultFormatter
+    format: '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+  access:
+    # "()": uvicorn.logging.AccessFormatter
+    format: '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+handlers:
+  default:
+    formatter: default
+    class: logging.StreamHandler
+    stream: ext://sys.stderr
+  access:
+    formatter: access
+    class: logging.StreamHandler
+    stream: ext://sys.stdout
+loggers:
+  uvicorn.error:
+    level: INFO
+    handlers:
+      - default
+    propagate: no
+  uvicorn.access:
+    level: INFO
+    handlers:
+      - access
+    propagate: no
+root:
+  level: DEBUG
+  handlers:
+    - default
+  propagate: no

--- a/deployment/k8s/charts/files/log_config.yaml
+++ b/deployment/k8s/charts/files/log_config.yaml
@@ -28,7 +28,7 @@ loggers:
       - access
     propagate: no
 root:
-  level: DEBUG
+  level: INFO
   handlers:
     - default
   propagate: no

--- a/deployment/k8s/charts/templates/configmap.yaml
+++ b/deployment/k8s/charts/templates/configmap.yaml
@@ -6,6 +6,8 @@ data:
   {{- if .Values.netrc }}
   netrc: {{ tpl (.Values.netrc) . | quote }}
   {{- end }}
+  log_config.yaml: |-
+    {{ .Files.Get .Values.logging.configFile | nindent 4 }}
   {{- if .Values.persistence.localStoreSeed }}
   init_store.json: |-
     {{ .Files.Get .Values.persistence.localStoreSeed | nindent 4 }}

--- a/deployment/k8s/charts/templates/deployment.yaml
+++ b/deployment/k8s/charts/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       initContainers:
-      {{- if .Values.persistence.localStoreSeed }}
+      {{- if and .Values.persistence.enabled .Values.persistence.localStoreSeed }}
         - name: init-store
           image: busybox
           command:

--- a/deployment/k8s/charts/templates/hpa.yaml
+++ b/deployment/k8s/charts/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "titiler.fullname" . }}
+  labels:
+    {{- include "titiler.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "titiler.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deployment/k8s/charts/values.yaml
+++ b/deployment/k8s/charts/values.yaml
@@ -113,7 +113,10 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1001
 
-podSecurityContext: {}
+podSecurityContext:
+  sysctls:              
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "0"
   # fsGroup: 1001
   # runAsNonRoot: true
   # runAsUser: 1001

--- a/deployment/k8s/charts/values.yaml
+++ b/deployment/k8s/charts/values.yaml
@@ -13,9 +13,11 @@ image:
     - "--port"
     - "80"
     - "--workers"
-    - "1"
+    - "4"
     - "--forwarded-allow-ips"  # to make sure it works behind a reverse proxy
     - "*"  # Allow all
+    - "--log-config"
+    - "/config/log_config.yaml"
 
 nameOverride: ""
 fullnameOverride: ""
@@ -75,6 +77,10 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# logging configuration
+logging:
+  configFile: "files/log_config.yaml"
 
 # Persistent storage configuration for the local database file
 persistence:

--- a/deployment/k8s/charts/values.yaml
+++ b/deployment/k8s/charts/values.yaml
@@ -124,7 +124,7 @@ securityContext: {}
   # runAsUser: 1001
 
 podSecurityContext:
-  sysctls:              
+  sysctls:
     - name: net.ipv4.ip_unprivileged_port_start
       value: "0"
   # fsGroup: 1001

--- a/deployment/k8s/charts/values.yaml
+++ b/deployment/k8s/charts/values.yaml
@@ -1,5 +1,5 @@
 # Default values for titiler-openeo.
-replicaCount: 1
+
 
 image:
   repository: ghcr.io/sentinel-hub/titiler-openeo
@@ -40,6 +40,16 @@ ingress:
   #  - secretName: titiler-tls
   #    hosts:
   #      - titiler.local
+
+# Autoscaling configuration
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+replicaCount: 1
 
 extraHostPathMounts: []
   # - name: map-sources

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,3 +50,43 @@ services:
     env_file:
       - path: .env
         required: false
+
+  keycloak_db:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_DB: keycloak
+      POSTGRES_USER: keycloak
+      POSTGRES_PASSWORD: keycloak
+    volumes:
+      - keycloak_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U keycloak"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:22.0
+    environment:
+      KC_DB: postgres
+      KC_DB_URL: jdbc:postgresql://keycloak_db:5432/keycloak
+      KC_DB_USERNAME: keycloak
+      KC_DB_PASSWORD: keycloak
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_HOSTNAME: localhost
+      KC_HOSTNAME_PORT: 8082
+    ports:
+      - "8082:8080"
+    depends_on:
+      keycloak_db:
+        condition: service_healthy
+    command: start-dev
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health/ready"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+volumes:
+  keycloak_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,8 +33,15 @@ services:
       # - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       # TiTiler STAC API Config
       - TITILER_OPENEO_API_DEBUG=TRUE
-      # - TITILER_OPENEO_STAC_API_URL=https://stac.eoapi.dev
-      # - TITILER_OPENEO_SERVICE_STORE_URL=/tmp/services/eoapi.json
+      - TITILER_OPENEO_STAC_API_URL=https://stac.eoapi.dev
+      - TITILER_OPENEO_SERVICE_STORE_URL=/tmp/services/eoapi.json
+      # Keycloak Config
+      - TITILER_OPENEO_AUTH_METHOD=oidc
+      - TITILER_OPENEO_AUTH_OIDC_CLIENT_ID=titiler-openeo
+      - TITILER_OPENEO_AUTH_OIDC_WK_URL=http://keycloak:8080/realms/master/.well-known/openid-configuration
+      - TITILER_OPENEO_AUTH_OIDC_REDIRECT_URL=http://localhost:8080/
+      - TITILER_OPENEO_AUTH_OIDC_SCOPES=openid profile email
+      - TITILER_OPENEO_AUTH_OIDC_NAME_CLAIM=preferred_username
     env_file:
       - path: .env
         required: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     build:
       context: .
     ports:
-      - "8081:8081"
+      - "8081:8000"
     environment:
       # GDAL Config
       # This option controls the default GDAL raster block cache size.
@@ -45,7 +45,7 @@ services:
     env_file:
       - path: .env
         required: false
-    command: ["uvicorn", "titiler.openeo.main:app", "--host", "0.0.0.0", "--port", "8081", "--workers", "4"]
+    # command: ["uvicorn", "titiler.openeo.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "4"]
     volumes:
       - ./services:/tmp/services
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     build:
       context: .
     ports:
-      - "8081:8000"
+      - "8081:80"
     environment:
       # GDAL Config
       # This option controls the default GDAL raster block cache size.

--- a/log_config.yaml
+++ b/log_config.yaml
@@ -1,0 +1,34 @@
+version: 1
+disable_existing_loggers: False
+formatters:
+  default:
+    # "()": uvicorn.logging.DefaultFormatter
+    format: '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+  access:
+    # "()": uvicorn.logging.AccessFormatter
+    format: '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+handlers:
+  default:
+    formatter: default
+    class: logging.StreamHandler
+    stream: ext://sys.stderr
+  access:
+    formatter: access
+    class: logging.StreamHandler
+    stream: ext://sys.stdout
+loggers:
+  uvicorn.error:
+    level: INFO
+    handlers:
+      - default
+    propagate: no
+  uvicorn.access:
+    level: INFO
+    handlers:
+      - access
+    propagate: no
+root:
+  level: DEBUG
+  handlers:
+    - default
+  propagate: no

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ docs = [
 server = ["uvicorn[standard]>=0.12.0,<0.19.0"]
 duckdb = ["duckdb"]
 postgres = ["sqlalchemy>=2.0.0", "psycopg2-binary"]
+oidc = ["cryptography"]
 
 [project.urls]
 Homepage = "https://developmentseed.org/titiler-openeo/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ test = [
     "brotlipy",
     "duckdb",
     "sqlalchemy>=2.0.0",
+    "cryptography",
 ]
 dev = ["pre-commit", "bump-my-version"]
 docs = [
@@ -60,6 +61,7 @@ docs = [
 server = ["uvicorn[standard]>=0.12.0,<0.19.0"]
 duckdb = ["duckdb"]
 postgres = ["sqlalchemy>=2.0.0", "psycopg[pool]"]
+oidc = ["cryptography"]
 
 [project.urls]
 Homepage = "https://developmentseed.org/titiler-openeo/"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import pytest
 from fastapi import Header
 from starlette.testclient import TestClient
 
-from titiler.openeo.auth import TestBasicAuth, User
+from titiler.openeo.auth import Auth, User
 
 StoreType = Literal["local", "duckdb", "sqlalchemy"]
 
@@ -38,7 +38,6 @@ def app_with_auth(monkeypatch, store_path, store_type) -> TestClient:
     """Create App with authentication for testing."""
     monkeypatch.setenv("TITILER_OPENEO_STAC_API_URL", "https://stac.eoapi.dev")
     monkeypatch.setenv("TITILER_OPENEO_SERVICE_STORE_URL", f"{store_path}")
-    monkeypatch.setenv("TITILER_OPENEO_REQUIRE_AUTH", "true")
 
     from titiler.openeo.main import create_app
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import pytest
 from fastapi import Header
 from starlette.testclient import TestClient
 
-from titiler.openeo.auth import Auth, User
+from titiler.openeo.auth import TestBasicAuth, User
 
 StoreType = Literal["local", "duckdb", "sqlalchemy"]
 
@@ -42,22 +42,11 @@ def app(monkeypatch, store_path, store_type) -> TestClient:
     from titiler.openeo.main import app, endpoints
 
     # Override the auth dependency with the mock auth
-    mock_auth = MockAuth()
-    app.dependency_overrides[endpoints.auth.validate] = mock_auth.validate
+    test_auth = TestBasicAuth()
+    app.dependency_overrides[endpoints.auth.validate] = test_auth.validate
 
     return TestClient(app)
 
-
-class MockAuth(Auth):
-    """Mock authentication class for testing."""
-
-    def login(self, authorization: str = Header(default=None)) -> Any:
-        """Mock login method."""
-        return {"access_token": "mock_token"}
-
-    def validate(self, authorization: str = Header(default=None)) -> User:
-        """Mock validate method."""
-        return User(user_id="test_user")
 
 
 @pytest.fixture

--- a/tests/fixtures/graphs/rgb.json
+++ b/tests/fixtures/graphs/rgb.json
@@ -1,0 +1,147 @@
+{
+    "id": "d55ae9e5-83d7-41c2-ae56-e6c72d3b7da5",
+    "summary": "sentinel-2 global mosaics 3 bands RGB",
+    "description": "This service provides a global mosaic of Sentinel-2 data with 3 bands (RGB).",
+    "categories": [
+        "raster"
+    ],
+    "links": [
+    ],
+    "returns": {
+        "description": "A PNG image with 3 bands (RGB).",
+        "schema": {
+            "type": "object",
+            "subtype": "imagedata"
+        }
+    },
+    "parameters": [
+        {
+            "description": "The east boundary of the spatial extent.",
+            "name": "spatial_extent_east",
+            "schema": {
+                "type": "number"
+            },
+            "default": -73.90
+        },
+        {
+            "description": "The north boundary of the spatial extent.",
+            "name": "spatial_extent_north",
+            "schema": {
+                "type": "number"
+            },
+            "default": 40.93
+        },
+        {
+            "description": "The south boundary of the spatial extent.",
+            "name": "spatial_extent_south",
+            "schema": {
+                "type": "number"
+            },
+            "default": 40.92
+        },
+        {
+            "description": "The west boundary of the spatial extent.",
+            "name": "spatial_extent_west",
+            "schema": {
+                "type": "number"
+            },
+            "default": -73.91
+        },
+        {
+            "description": "The CRS of the spatial extent.",
+            "name": "spatial_extent_crs",
+            "schema": {
+                "type": "string"
+            },
+            "default": "EPSG:4326"
+        }
+    ],
+    "process_graph": {
+        "1": {
+            "arguments": {
+                "bands": [
+                    "B04",
+                    "B03",
+                    "B02"
+                ],
+                "id": "sentinel-2-global-mosaics",
+                "spatial_extent": {
+                    "east": {
+                        "from_parameter": "spatial_extent_east"
+                    },
+                    "north": {
+                        "from_parameter": "spatial_extent_north"
+                    },
+                    "south": {
+                        "from_parameter": "spatial_extent_south"
+                    },
+                    "west": {
+                        "from_parameter": "spatial_extent_west"
+                    },
+                    "crs": {
+                        "from_parameter": "spatial_extent_crs"
+                    }
+                },
+                "temporal_extent": [
+                    "2024-06-01T00:00:00Z",
+                    "2024-07-30T23:59:59Z"
+                ]
+            },
+            "process_id": "load_collection_and_reduce"
+        },
+        "2": {
+            "arguments": {
+                "data": {
+                    "from_node": "color"
+                },
+                "format": "PNG",
+                "options": {
+                    "datatype": "byte"
+                }
+            },
+            "process_id": "save_result",
+            "result": true
+        },
+        "color": {
+            "arguments": {
+                "data": {
+                    "from_node": "3"
+                },
+                "formula": "Gamma RGB 1.5 Sigmoidal RGB 10 0.3 Saturation 1"
+            },
+            "process_id": "color_formula"
+        },
+        "3": {
+            "arguments": {
+                "data": {
+                    "from_node": "1"
+                },
+                "process": {
+                    "process_graph": {
+                        "1": {
+                            "arguments": {
+                                "inputMax": 10000,
+                                "inputMin": 0,
+                                "outputMax": 255,
+                                "x": {
+                                    "from_parameter": "x"
+                                }
+                            },
+                            "process_id": "linear_scale_range"
+                        },
+                        "2": {
+                            "process_id": "trunc",
+                            "arguments": {
+                                "x": {
+                                    "from_node": "1"
+                                }
+                            },
+                            "result": true
+                        }
+                    }
+                }
+            },
+            "process_id": "apply"
+        }
+    }
+}

--- a/titiler/openeo/auth.py
+++ b/titiler/openeo/auth.py
@@ -96,7 +96,7 @@ class OIDCAuth(Auth):
         """Get OIDC configuration."""
         if self._config_cache is None:
             with httpx.Client() as client:
-                response = client.get(str(self._oidc_config.openid_configuration_url))
+                response = client.get(str(self._oidc_config.wk_url))
                 response.raise_for_status()
                 self._config_cache = response.json()
         return self._config_cache

--- a/titiler/openeo/auth.py
+++ b/titiler/openeo/auth.py
@@ -317,7 +317,7 @@ class BasicAuth(Auth):
 
         # Check if user exists and password matches
         user = self.settings.users.get(username)
-        if not user or user.password != password:
+        if not user or user["password"] != password:
             raise HTTPException(
                 status_code=HTTP_401_UNAUTHORIZED,
                 detail="Invalid username or password",
@@ -339,12 +339,11 @@ class BasicAuth(Auth):
 
         parsed_token = AuthToken.from_token(authorization)
 
-        if parsed_token.method != self.method:
+        if parsed_token.method != self.method.name:
             raise HTTPException(
                 status_code=HTTP_403_FORBIDDEN,
                 detail="Invalid authentication credentials",
             )
 
-        new_authorization = f"basic {parsed_token.token}"
-        user = self._get_user_from_base64(new_authorization)
+        user = self._get_user_from_base64(parsed_token.token)
         return User(user_id=user.user_id)

--- a/titiler/openeo/auth.py
+++ b/titiler/openeo/auth.py
@@ -3,24 +3,26 @@
 import abc
 from base64 import b64decode
 from enum import Enum
-from typing import Any, Literal, Optional
+import base64
+import json
+import time
+from typing import Any, Dict, Literal, Optional
+from urllib.parse import urljoin
 
+import httpx
 from attrs import define, field
-from .settings import AuthSettings
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicNumbers
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives import hashes
+from cryptography.exceptions import InvalidSignature
+from .settings import AuthSettings, OIDCConfig
 from fastapi import Header
 from fastapi.exceptions import HTTPException
 from fastapi.security.utils import get_authorization_scheme_param
 from pydantic import BaseModel, Field, ValidationError, field_validator
 from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_403_FORBIDDEN
 from typing_extensions import Self
-
-
-def get_auth(settings: AuthSettings) -> 'Auth':
-    """Get Auth instance."""
-    if settings.method == AuthMethod.basic.value:
-        return BasicAuth(settings=settings)
-    else:
-        raise NotImplementedError(f"Auth method {settings.method} not implemented")
 
 
 class AuthMethod(Enum):
@@ -34,6 +36,8 @@ class User(BaseModel, extra="allow"):
     """User Model."""
 
     user_id: str
+    email: Optional[str] = None
+    name: Optional[str] = None
 
 
 class BasicAuthUser(User):
@@ -59,6 +63,164 @@ class Auth(metaclass=abc.ABCMeta):
         ...
 
 
+def get_auth(settings: AuthSettings) -> 'Auth':
+    """Get Auth instance."""
+    if settings.method == AuthMethod.basic.value:
+        return BasicAuth(settings=settings)
+    elif settings.method == AuthMethod.oidc.value:
+        if not settings.oidc:
+            raise ValueError("OIDC configuration required")
+        return OIDCAuth(settings=settings)
+    else:
+        raise NotImplementedError(f"Auth method {settings.method} not implemented")
+
+
+@define(kw_only=True)
+class OIDCAuth(Auth):
+    """OpenID Connect authentication implementation."""
+
+    method: AuthMethod = field(default=AuthMethod("oidc"), init=False)
+    settings: AuthSettings = field()
+    _config_cache: Optional[Dict] = field(default=None, init=False)
+    _jwks_cache: Optional[Dict] = field(default=None, init=False)
+    _oidc_config: OIDCConfig = field(init=False)
+
+    def __attrs_post_init__(self):
+        """Validate OIDC configuration on initialization."""
+        if not self.settings.oidc:
+            raise ValueError("OIDC configuration required")
+        self._oidc_config = self.settings.oidc
+
+    @property
+    def config(self) -> Dict:
+        """Get OIDC configuration."""
+        if self._config_cache is None:
+            with httpx.Client() as client:
+                response = client.get(str(self._oidc_config.openid_configuration_url))
+                response.raise_for_status()
+                self._config_cache = response.json()
+        return self._config_cache
+
+    def get_jwks(self) -> Dict:
+        """Get JSON Web Key Set."""
+        if self._jwks_cache is None:
+            with httpx.Client() as client:
+                response = client.get(self.config["jwks_uri"])
+                response.raise_for_status()
+                self._jwks_cache = response.json()
+        return self._jwks_cache
+
+    def _get_key(self, kid: str):
+        """Get public key from JWKS."""
+        jwks = self.get_jwks()
+        for jwk in jwks["keys"]:
+            if jwk["kid"] == kid:
+                if jwk["kty"] != "RSA":
+                    raise ValueError(f"Unsupported key type: {jwk['kty']}")
+                
+                # Convert JWK to public key
+                numbers = RSAPublicNumbers(
+                    e=int.from_bytes(base64.urlsafe_b64decode(jwk["e"] + "=" * (-len(jwk["e"]) % 4)), byteorder="big"),
+                    n=int.from_bytes(base64.urlsafe_b64decode(jwk["n"] + "=" * (-len(jwk["n"]) % 4)), byteorder="big")
+                )
+                return numbers.public_key()
+        
+        raise HTTPException(
+            status_code=HTTP_401_UNAUTHORIZED,
+            detail="Unable to find appropriate key",
+        )
+
+    def _verify_token(self, token: str, key) -> Dict:
+        """Verify JWT token signature and return payload."""
+        try:
+            # Split the JWT
+            header_b64, payload_b64, signature_b64 = token.split(".")
+            
+            # Decode header and payload
+            header = json.loads(base64.urlsafe_b64decode(header_b64 + "=" * (-len(header_b64) % 4)))
+            payload = json.loads(base64.urlsafe_b64decode(payload_b64 + "=" * (-len(payload_b64) % 4)))
+            
+            # Verify signature
+            signature = base64.urlsafe_b64decode(signature_b64 + "=" * (-len(signature_b64) % 4))
+            key.verify(
+                signature,
+                f"{header_b64}.{payload_b64}".encode(),
+                padding.PKCS1v15(),
+                hashes.SHA256()
+            )
+            
+            # Verify claims
+            if payload.get("aud") != self._oidc_config.client_id:
+                raise ValueError("Invalid audience")
+            
+            current_time = time.time()
+            if payload.get("exp") and payload["exp"] < current_time:
+                raise ValueError("Token expired")
+            
+            return payload
+            
+        except (ValueError, InvalidSignature) as e:
+            raise HTTPException(
+                status_code=HTTP_401_UNAUTHORIZED,
+                detail=str(e),
+            )
+
+    def login(self, authorization: str = Header()) -> Any:
+        """OIDC doesn't support direct login - must be done through provider."""
+        raise HTTPException(
+            status_code=HTTP_401_UNAUTHORIZED,
+            detail="OIDC authentication requires token from provider",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    def validate(self, authorization: str = Header()) -> User:
+        """Validate Bearer Token."""
+        if not authorization:
+            raise HTTPException(
+                status_code=HTTP_401_UNAUTHORIZED,
+                detail="Authorization header missing",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
+        parsed_token = AuthToken.from_token(authorization)
+
+        if parsed_token.method != self.method.value:
+            raise HTTPException(
+                status_code=HTTP_403_FORBIDDEN,
+                detail="Invalid authentication method",
+            )
+
+        # Check the provider
+        if parsed_token.provider != self._config_cache["issuer"]:
+            raise HTTPException(
+                status_code=HTTP_403_FORBIDDEN,
+                detail="Invalid authentication provider",
+            )
+
+        try:
+            # Get the key id from token header
+            header_b64 = parsed_token.token.split('.')[0]
+            header = json.loads(base64.urlsafe_b64decode(header_b64 + "=" * (-len(header_b64) % 4)))
+            key = self._get_key(header["kid"])
+
+            # Verify token and get payload
+            payload = self._verify_token(parsed_token.token, key)
+
+            # Create user from payload
+            return User(
+                user_id=payload["sub"],
+                email=payload.get("email"),
+                name=payload.get("name"),
+            )
+
+        except Exception as e:
+            raise HTTPException(
+                status_code=HTTP_401_UNAUTHORIZED,
+                detail=str(e),
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
+
 class CredentialsBasic(BaseModel):
     """HTTP Basic Access Token."""
 
@@ -76,12 +238,6 @@ class AuthToken(BaseModel):
     method: Literal["basic", "oidc"]
     provider: Optional[str] = None
     token: str
-
-    # @field_validator("provider")
-    # def check_provider(cls, v):
-    #     if not v:
-    #         raise ValidationError("Empty provider string.")
-    #     return v
 
     @field_validator("token")
     def check_token(cls, v):
@@ -121,9 +277,7 @@ class BasicAuth(Auth):
         self._get_user_from_base64(param)
         return CredentialsBasic(access_token=param)
 
-
     def _get_user_from_base64(self, param: str) -> BasicAuthUser:
-
         try:
             data = b64decode(param).decode("ascii")
         except Exception:

--- a/titiler/openeo/auth.py
+++ b/titiler/openeo/auth.py
@@ -50,7 +50,6 @@ class Auth(metaclass=abc.ABCMeta):
     """Auth BaseClass."""
 
     method: AuthMethod = field(init=False)
-    settings: AuthSettings = field()
 
     @abc.abstractmethod
     def login(self, authorization: str = Header()) -> Any:

--- a/titiler/openeo/auth.py
+++ b/titiler/openeo/auth.py
@@ -2,7 +2,7 @@
 
 import abc
 from base64 import b64decode
-import enum
+from enum import Enum
 from typing import Any, Literal, Optional
 
 from attrs import define, field
@@ -17,13 +17,13 @@ from typing_extensions import Self
 
 def get_auth(settings: AuthSettings) -> 'Auth':
     """Get Auth instance."""
-    if settings.method == AuthMethod.basic:
+    if settings.method == AuthMethod.basic.value:
         return BasicAuth(settings=settings)
     else:
         raise NotImplementedError(f"Auth method {settings.method} not implemented")
 
 
-class AuthMethod(enum.Enum):
+class AuthMethod(Enum):
     """Authentication Method."""
 
     basic = "basic"
@@ -33,7 +33,7 @@ class AuthMethod(enum.Enum):
 class User(BaseModel, extra="allow"):
     """User Model."""
 
-    username: str
+    user_id: str
 
 
 class BasicAuthUser(User):
@@ -151,7 +151,7 @@ class BasicAuth(Auth):
             )
 
         # return the user
-        return BasicAuthUser(username=username, password=password)
+        return BasicAuthUser(user_id=username, password=password)
 
     def validate(self, authorization: str = Header(default=None)) -> User:
         """Bearer Token or Basic Auth validation."""
@@ -173,4 +173,4 @@ class BasicAuth(Auth):
 
         new_authorization = f"basic {parsed_token.token}"
         user = self._get_user_from_base64(new_authorization)
-        return User(username=user.username)
+        return User(user_id=user.user_id)

--- a/titiler/openeo/errors.py
+++ b/titiler/openeo/errors.py
@@ -4,8 +4,8 @@ This module implements the OpenEO API error handling specification.
 See: https://api.openeo.org/#section/API-Principles/Error-Handling
 """
 
-from typing import Optional
 import logging
+from typing import Optional
 
 from fastapi import HTTPException, Request
 from fastapi.exceptions import RequestValidationError
@@ -87,7 +87,9 @@ class ExceptionHandler:
             },
         )
 
-    def http_exception_handler(self, request: Request, exc: HTTPException) -> JSONResponse:
+    def http_exception_handler(
+        self, request: Request, exc: HTTPException
+    ) -> JSONResponse:
         """Handle HTTP exceptions."""
         self.logger.error(f"HTTP Exception: {exc.detail}", exc_info=exc)
         return JSONResponse(
@@ -98,7 +100,9 @@ class ExceptionHandler:
             },
         )
 
-    def general_exception_handler(self, request: Request, exc: Exception) -> JSONResponse:
+    def general_exception_handler(
+        self, request: Request, exc: Exception
+    ) -> JSONResponse:
         """Handle general exceptions."""
         self.logger.error(f"General Exception: {str(exc)}", exc_info=exc)
         if isinstance(exc, ValueError):

--- a/titiler/openeo/errors.py
+++ b/titiler/openeo/errors.py
@@ -85,6 +85,19 @@ class OpenEOException(Exception):
             },
         )
 
+    @staticmethod
+    def general_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+        """Handle general exceptions."""
+        if isinstance(exc, ValueError):
+            return OpenEOException.validation_exception_handler(request, exc)
+        return JSONResponse(
+            status_code=500,
+            content={
+                "code": "ServerError",
+                "message": str(exc),
+            },
+        )
+
 
 class ProcessParameterMissing(OpenEOException):
     """Invalid Parameters."""

--- a/titiler/openeo/factory.py
+++ b/titiler/openeo/factory.py
@@ -152,76 +152,77 @@ class EndpointsFactory(BaseFactory):
                 },
             }
 
-        @self.router.get(
-            "/credentials/oidc",
-            response_class=JSONResponse,
-            summary="OpenID Connect authentication",
-            response_model=models.OIDCProviders,
-            response_model_exclude_none=True,
-            operation_id="authenticate-oidc",
-            responses={
-                200: {
-                    "content": {
-                        "application/json": {},
+        if isinstance(self.auth, OIDCAuth):
+            @self.router.get(
+                "/credentials/oidc",
+                response_class=JSONResponse,
+                summary="OpenID Connect authentication",
+                response_model=models.OIDCProviders,
+                response_model_exclude_none=True,
+                operation_id="authenticate-oidc",
+                responses={
+                    200: {
+                        "content": {
+                            "application/json": {},
+                        },
+                        "description": "Lists the OpenID Connect Providers.",
                     },
-                    "description": "Lists the OpenID Connect Providers.",
                 },
-            },
-            tags=["Account Management"],
-        )
-        def openeo_credentials_oidc():
-            """Lists the supported OpenID Connect providers (OP)."""
-            if not isinstance(self.auth, OIDCAuth):
-                raise HTTPException(
-                    status_code=501,
-                    detail="OpenID Connect authentication not supported",
-                )
-
-            return models.OIDCProviders(
-                providers=[
-                    models.OIDCProvider(
-                        id="oidc",
-                        issuer=self.auth.config["issuer"],
-                        title="OpenID Connect",
-                        scopes=self.auth.settings.oidc.scopes,
-                        default_clients=[
-                            models.OIDCDefaultClient(
-                                id=self.auth.settings.oidc.client_id,
-                                grant_types=[
-                                    "authorization_code+pkce",
-                                    "urn:ietf:params:oauth:grant-type:device_code+pkce",
-                                    "refresh_token",
-                                ],
-                                redirect_urls=[self.auth.settings.oidc.redirect_url],
-                            )
-                        ],
-                    )
-                ]
+                tags=["Account Management"],
             )
+            def openeo_credentials_oidc():
+                """Lists the supported OpenID Connect providers (OP)."""
+                if not isinstance(self.auth, OIDCAuth):
+                    raise HTTPException(
+                        status_code=501,
+                        detail="OpenID Connect authentication not supported",
+                    )
 
-        @self.router.get(
-            "/credentials/basic",
-            response_class=JSONResponse,
-            summary="HTTP Basic authentication",
-            response_model=CredentialsBasic,
-            response_model_exclude_none=True,
-            operation_id="authenticate-basic",
-            responses={
-                200: {
-                    "content": {
-                        "application/json": {},
+                return models.OIDCProviders(
+                    providers=[
+                        models.OIDCProvider(
+                            id="oidc",
+                            issuer=self.auth.config["issuer"],
+                            title="OpenID Connect",
+                            scopes=self.auth.settings.oidc.scopes,
+                            default_clients=[
+                                models.OIDCDefaultClient(
+                                    id=self.auth.settings.oidc.client_id,
+                                    grant_types=[
+                                        "authorization_code+pkce",
+                                        "urn:ietf:params:oauth:grant-type:device_code+pkce",
+                                        "refresh_token",
+                                    ],
+                                    redirect_urls=[self.auth.settings.oidc.redirect_url],
+                                )
+                            ],
+                        )
+                    ]
+                )
+        else:
+            @self.router.get(
+                "/credentials/basic",
+                response_class=JSONResponse,
+                summary="HTTP Basic authentication",
+                response_model=CredentialsBasic,
+                response_model_exclude_none=True,
+                operation_id="authenticate-basic",
+                responses={
+                    200: {
+                        "content": {
+                            "application/json": {},
+                        },
                     },
                 },
-            },
-            tags=["Account Management"],
-        )
-        def openeo_credentials_basic(token=Depends(self.auth.login)):
-            """Checks the credentials provided through [HTTP Basic Authentication
-            according to RFC 7617](https://www.rfc-editor.org/rfc/rfc7617.html) and returns
-            an access token for valid credentials.
+                tags=["Account Management"],
+            )
+            def openeo_credentials_basic(token=Depends(self.auth.login)):
+                """Checks the credentials provided through [HTTP Basic Authentication
+                according to RFC 7617](https://www.rfc-editor.org/rfc/rfc7617.html) and returns
+                an access token for valid credentials.
 
-            """
-            return token
+                """
+                return token
 
         @self.router.get(
             "/me",
@@ -554,7 +555,7 @@ class EndpointsFactory(BaseFactory):
                 status_code=201,
                 headers={
                     "Location": service_url,
-                    "OpenEO-Identifier": service["id"],
+                    "openeo-identifier": service["id"],
                 },
             )
 

--- a/titiler/openeo/factory.py
+++ b/titiler/openeo/factory.py
@@ -18,7 +18,7 @@ from typing_extensions import Annotated
 from titiler.core.factory import BaseFactory
 from titiler.openeo import __version__ as titiler_version
 from titiler.openeo import models
-from titiler.openeo.auth import Auth, CredentialsBasic, FakeBasicAuth
+from titiler.openeo.auth import Auth, CredentialsBasic
 from titiler.openeo.errors import InvalidProcessGraph
 from titiler.openeo.models import OPENEO_VERSION, ServiceInput
 from titiler.openeo.services import ServicesStore

--- a/titiler/openeo/factory.py
+++ b/titiler/openeo/factory.py
@@ -35,7 +35,7 @@ class EndpointsFactory(BaseFactory):
     services_store: ServicesStore
     stac_client: stacApiBackend
     process_registry: ProcessRegistry
-    auth: Auth = field(factory=FakeBasicAuth)
+    auth: Auth
 
     def register_routes(self):  # noqa: C901
         """Register Routes."""

--- a/titiler/openeo/factory.py
+++ b/titiler/openeo/factory.py
@@ -153,6 +153,7 @@ class EndpointsFactory(BaseFactory):
             }
 
         if isinstance(self.auth, OIDCAuth):
+
             @self.router.get(
                 "/credentials/oidc",
                 response_class=JSONResponse,
@@ -193,13 +194,16 @@ class EndpointsFactory(BaseFactory):
                                         "urn:ietf:params:oauth:grant-type:device_code+pkce",
                                         "refresh_token",
                                     ],
-                                    redirect_urls=[self.auth.settings.oidc.redirect_url],
+                                    redirect_urls=[
+                                        self.auth.settings.oidc.redirect_url
+                                    ],
                                 )
                             ],
                         )
                     ]
                 )
         else:
+
             @self.router.get(
                 "/credentials/basic",
                 response_class=JSONResponse,

--- a/titiler/openeo/main.py
+++ b/titiler/openeo/main.py
@@ -1,6 +1,7 @@
 """titiler-openeo app."""
 
 import logging
+
 from fastapi import FastAPI, HTTPException
 from fastapi.exceptions import RequestValidationError
 from openeo_pg_parser_networkx.process_registry import Process
@@ -10,7 +11,7 @@ from starlette_cramjam.middleware import CompressionMiddleware
 from titiler.core.middleware import CacheControlMiddleware
 from titiler.openeo import __version__ as titiler_version
 from titiler.openeo.auth import get_auth
-from titiler.openeo.errors import OpenEOException, ExceptionHandler
+from titiler.openeo.errors import ExceptionHandler, OpenEOException
 from titiler.openeo.factory import EndpointsFactory
 from titiler.openeo.processes import PROCESS_SPECIFICATIONS, process_registry
 from titiler.openeo.services import get_store
@@ -113,8 +114,12 @@ def create_app():
     exception_handler = ExceptionHandler(logger=logging.getLogger(__name__))
 
     # Add OpenEO-specific exception handlers
-    app.add_exception_handler(OpenEOException, exception_handler.openeo_exception_handler)
-    app.add_exception_handler(RequestValidationError, exception_handler.validation_exception_handler)
+    app.add_exception_handler(
+        OpenEOException, exception_handler.openeo_exception_handler
+    )
+    app.add_exception_handler(
+        RequestValidationError, exception_handler.validation_exception_handler
+    )
     app.add_exception_handler(HTTPException, exception_handler.http_exception_handler)
     app.add_exception_handler(Exception, exception_handler.general_exception_handler)
 

--- a/titiler/openeo/main.py
+++ b/titiler/openeo/main.py
@@ -12,16 +12,25 @@ from titiler.openeo.errors import DEFAULT_STATUS_CODES
 from titiler.openeo.factory import EndpointsFactory
 from titiler.openeo.processes import PROCESS_SPECIFICATIONS, process_registry
 from titiler.openeo.services import get_store
-from titiler.openeo.settings import ApiSettings, BackendSettings
+from titiler.openeo.settings import ApiSettings, AuthSettings, BackendSettings
+from titiler.openeo.auth import get_auth
 from titiler.openeo.stacapi import LoadCollection, stacApiBackend
 
 STAC_VERSION = "1.0.0"
 
 api_settings = ApiSettings()
-backend_settings = BackendSettings()
+backend_settings = BackendSettings(
+    stac_api_url="https://stac.eoapi.dev",  # Default from test config
+    service_store_url="services.json",  # Default local file
+)
+auth_settings = AuthSettings(
+    method="basic",  # Default from test config
+    users={"anonymous": {"password": "test"}},  # Default from test config
+)
 
 stac_client = stacApiBackend(str(backend_settings.stac_api_url))  # type: ignore
 service_store = get_store(str(backend_settings.service_store_url))
+auth = get_auth(auth_settings)
 
 ###############################################################################
 
@@ -90,6 +99,7 @@ endpoints = EndpointsFactory(
     services_store=service_store,
     stac_client=stac_client,
     process_registry=process_registry,
+    auth=auth,
 )
 app.include_router(endpoints.router)
 

--- a/titiler/openeo/main.py
+++ b/titiler/openeo/main.py
@@ -67,6 +67,7 @@ def create_app():
             allow_credentials=True,
             allow_methods=api_settings.cors_allow_methods,
             allow_headers=["*"],
+            expose_headers=["*"]
         )
 
     app.add_middleware(

--- a/titiler/openeo/main.py
+++ b/titiler/openeo/main.py
@@ -19,14 +19,8 @@ from titiler.openeo.stacapi import LoadCollection, stacApiBackend
 STAC_VERSION = "1.0.0"
 
 api_settings = ApiSettings()
-backend_settings = BackendSettings(
-    stac_api_url="https://stac.eoapi.dev",  # Default from test config
-    service_store_url="services.json",  # Default local file
-)
-auth_settings = AuthSettings(
-    method="basic",  # Default from test config
-    users={"anonymous": {"password": "test"}},  # Default from test config
-)
+backend_settings = BackendSettings()
+auth_settings = AuthSettings()
 
 stac_client = stacApiBackend(str(backend_settings.stac_api_url))  # type: ignore
 service_store = get_store(str(backend_settings.service_store_url))

--- a/titiler/openeo/main.py
+++ b/titiler/openeo/main.py
@@ -67,7 +67,7 @@ def create_app():
             allow_credentials=True,
             allow_methods=api_settings.cors_allow_methods,
             allow_headers=["*"],
-            expose_headers=["*"]
+            expose_headers=["*"],
         )
 
     app.add_middleware(

--- a/titiler/openeo/models.py
+++ b/titiler/openeo/models.py
@@ -21,22 +21,24 @@ class OIDCDefaultClient(BaseModel):
 
     id: str = Field(
         ...,
-        description="The OpenID Connect Client ID to be used in the authentication procedure."
+        description="The OpenID Connect Client ID to be used in the authentication procedure.",
     )
-    grant_types: List[Literal[
-        "implicit",
-        "authorization_code",
-        "authorization_code+pkce",
-        "urn:ietf:params:oauth:grant-type:device_code",
-        "urn:ietf:params:oauth:grant-type:device_code+pkce",
-        "refresh_token"
-    ]] = Field(
+    grant_types: List[
+        Literal[
+            "implicit",
+            "authorization_code",
+            "authorization_code+pkce",
+            "urn:ietf:params:oauth:grant-type:device_code",
+            "urn:ietf:params:oauth:grant-type:device_code+pkce",
+            "refresh_token",
+        ]
+    ] = Field(
         ...,
-        description="List of authorization grant types (flows) supported by the OpenID Connect client."
+        description="List of authorization grant types (flows) supported by the OpenID Connect client.",
     )
     redirect_urls: Optional[List[AnyUrl]] = Field(
         None,
-        description="List of redirect URLs that are whitelisted by the OpenID Connect client."
+        description="List of redirect URLs that are whitelisted by the OpenID Connect client.",
     )
 
 
@@ -46,31 +48,30 @@ class OIDCProvider(BaseModel):
     id: str = Field(
         ...,
         pattern=r"[\d\w]{1,20}",
-        description="A per-backend unique identifier for the OpenID Connect Provider to be as prefix for the Bearer token."
+        description="A per-backend unique identifier for the OpenID Connect Provider to be as prefix for the Bearer token.",
     )
     issuer: AnyUrl = Field(
         ...,
-        description="The issuer location (also referred to as 'authority' in some client libraries) is the URL of the OpenID Connect provider."
+        description="The issuer location (also referred to as 'authority' in some client libraries) is the URL of the OpenID Connect provider.",
     )
     title: str = Field(
         ...,
-        description="The name that is publicly shown in clients for this OpenID Connect provider."
+        description="The name that is publicly shown in clients for this OpenID Connect provider.",
     )
     description: Optional[str] = Field(
         None,
-        description="A description that explains how the authentication procedure works."
+        description="A description that explains how the authentication procedure works.",
     )
     scopes: Optional[List[str]] = Field(
         None,
-        description="A list of OpenID Connect scopes that the client MUST at least include when requesting authorization."
+        description="A list of OpenID Connect scopes that the client MUST at least include when requesting authorization.",
     )
     default_clients: Optional[List[OIDCDefaultClient]] = Field(
         None,
-        description="List of default OpenID Connect clients that can be used by an openEO client for OpenID Connect based authentication."
+        description="List of default OpenID Connect clients that can be used by an openEO client for OpenID Connect based authentication.",
     )
     links: Optional[List[Link]] = Field(
-        None,
-        description="Links related to this provider."
+        None, description="Links related to this provider."
     )
 
 
@@ -79,7 +80,7 @@ class OIDCProviders(BaseModel):
 
     providers: List[OIDCProvider] = Field(
         ...,
-        description="The list of OpenID Connect Providers. The first provider in this list is the default provider for authentication."
+        description="The list of OpenID Connect Providers. The first provider in this list is the default provider for authentication.",
     )
 
 

--- a/titiler/openeo/models.py
+++ b/titiler/openeo/models.py
@@ -16,6 +16,73 @@ from typing_extensions import Self
 OPENEO_VERSION = "1.2.0"
 
 
+class OIDCDefaultClient(BaseModel):
+    """Default OpenID Connect Client."""
+
+    id: str = Field(
+        ...,
+        description="The OpenID Connect Client ID to be used in the authentication procedure."
+    )
+    grant_types: List[Literal[
+        "implicit",
+        "authorization_code",
+        "authorization_code+pkce",
+        "urn:ietf:params:oauth:grant-type:device_code",
+        "urn:ietf:params:oauth:grant-type:device_code+pkce",
+        "refresh_token"
+    ]] = Field(
+        ...,
+        description="List of authorization grant types (flows) supported by the OpenID Connect client."
+    )
+    redirect_urls: Optional[List[AnyUrl]] = Field(
+        None,
+        description="List of redirect URLs that are whitelisted by the OpenID Connect client."
+    )
+
+
+class OIDCProvider(BaseModel):
+    """OpenID Connect Provider."""
+
+    id: str = Field(
+        ...,
+        pattern=r"[\d\w]{1,20}",
+        description="A per-backend unique identifier for the OpenID Connect Provider to be as prefix for the Bearer token."
+    )
+    issuer: AnyUrl = Field(
+        ...,
+        description="The issuer location (also referred to as 'authority' in some client libraries) is the URL of the OpenID Connect provider."
+    )
+    title: str = Field(
+        ...,
+        description="The name that is publicly shown in clients for this OpenID Connect provider."
+    )
+    description: Optional[str] = Field(
+        None,
+        description="A description that explains how the authentication procedure works."
+    )
+    scopes: Optional[List[str]] = Field(
+        None,
+        description="A list of OpenID Connect scopes that the client MUST at least include when requesting authorization."
+    )
+    default_clients: Optional[List[OIDCDefaultClient]] = Field(
+        None,
+        description="List of default OpenID Connect clients that can be used by an openEO client for OpenID Connect based authentication."
+    )
+    links: Optional[List[Link]] = Field(
+        None,
+        description="Links related to this provider."
+    )
+
+
+class OIDCProviders(BaseModel):
+    """OpenID Connect Providers Response."""
+
+    providers: List[OIDCProvider] = Field(
+        ...,
+        description="The list of OpenID Connect Providers. The first provider in this list is the default provider for authentication."
+    )
+
+
 class Link(BaseModel):
     rel: str = Field(
         ...,

--- a/titiler/openeo/services/local.py
+++ b/titiler/openeo/services/local.py
@@ -47,7 +47,6 @@ class LocalStore(ServicesStore):
             for service_id, data in self.store.items()
             if data["user_id"] == user_id
         ]
-        assert services, f"Could not find service for user: {user_id}"
         return services
 
     def add_service(self, user_id: str, service: Dict, **kwargs) -> str:

--- a/titiler/openeo/settings.py
+++ b/titiler/openeo/settings.py
@@ -97,7 +97,12 @@ class AuthSettings(BaseSettings):
 
     # Dictionary of users with access
     # Only used if method is set to "basic"
-    users: Dict[str, Any] = {}
+    users: Dict[str, Any] = {
+        "test": {
+            "password": "test",
+            "roles": ["user"],
+        }
+    }
 
     # OIDC configuration
     # Only used if method is set to "oidc"

--- a/titiler/openeo/settings.py
+++ b/titiler/openeo/settings.py
@@ -1,10 +1,30 @@
 """Titiler-openEO API settings."""
 
-from typing import Union
+from typing import Dict, Optional, Union
 
 from pydantic import AnyHttpUrl, Field, PostgresDsn, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing_extensions import Annotated
+
+from titiler.openeo.auth import AuthMethod, BasicAuthUser
+
+
+
+class AuthSettings(BaseSettings):
+    """Authentication settings."""
+
+    # Authentication method
+    method: AuthMethod = AuthMethod("basic")
+
+    # Dictionary of users with access
+    # Only used if method is set to "basic"
+    users: Dict[str, BasicAuthUser] = {}
+
+    model_config = SettingsConfigDict(
+        env_prefix="TITILER_OPENEO_AUTH_",
+        env_file=".env",
+        extra="ignore",
+    )
 
 
 class ApiSettings(BaseSettings):

--- a/titiler/openeo/settings.py
+++ b/titiler/openeo/settings.py
@@ -12,7 +12,8 @@ class OIDCConfig(BaseSettings):
 
     client_id: str = ""
     client_secret: str = ""
-    openid_configuration_url: AnyHttpUrl
+    wk_url: str = ""
+    redirect_url: str = ""
     scopes: list[str] = ["openid", "email", "profile"]
 
     model_config = SettingsConfigDict(
@@ -41,6 +42,11 @@ class AuthSettings(BaseSettings):
         env_file=".env",
         extra="ignore",
     )
+    
+    def __init__(self, *args, **kwargs):
+        """Initialize settings."""
+        kwargs['oidc'] = OIDCConfig()
+        super().__init__(*args, **kwargs)
 
     @model_validator(mode="after")
     def validate_oidc_config(self):

--- a/titiler/openeo/settings.py
+++ b/titiler/openeo/settings.py
@@ -1,24 +1,21 @@
 """Titiler-openEO API settings."""
 
-from typing import Dict, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 from pydantic import AnyHttpUrl, Field, PostgresDsn, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing_extensions import Annotated
-
-from titiler.openeo.auth import AuthMethod, BasicAuthUser
-
 
 
 class AuthSettings(BaseSettings):
     """Authentication settings."""
 
     # Authentication method
-    method: AuthMethod = AuthMethod("basic")
+    method: str = "basic"
 
     # Dictionary of users with access
     # Only used if method is set to "basic"
-    users: Dict[str, BasicAuthUser] = {}
+    users: Dict[str, Any] = {}
 
     model_config = SettingsConfigDict(
         env_prefix="TITILER_OPENEO_AUTH_",

--- a/titiler/openeo/settings.py
+++ b/titiler/openeo/settings.py
@@ -127,7 +127,7 @@ class ApiSettings(BaseSettings):
 
     name: str = "TiTiler-OpenEO"
     cors_origins: str = "*"
-    cors_allow_methods: str = "GET,POST,OPTIONS"
+    cors_allow_methods: str = "GET,POST,DELETE,OPTIONS"
     cachecontrol: str = "public, max-age=3600"
     root_path: str = ""
 

--- a/titiler/openeo/stacapi.py
+++ b/titiler/openeo/stacapi.py
@@ -37,18 +37,20 @@ class stacApiBackend:
     """PySTAC-Client Backend."""
 
     url: str = field()
-    client: Client = field(default=None)
+    _client_cache: Client = field(default=None, init=False)
 
-    def __attrs_post_init__(self) -> None:
-        """Create Client."""
-        if not self.client:
+    @property
+    def client(self) -> Client:
+        """Return a PySTAC-Client."""
+        if not self._client_cache:
             stac_api_io = StacApiIO(
                 max_retries=Retry(
                     total=pystac_settings.retry,
                     backoff_factor=pystac_settings.retry_factor,
                 ),
             )
-            self.client = Client.open(self.url, stac_io=stac_api_io)
+            self._client_cache = Client.open(self.url, stac_io=stac_api_io)
+        return self._client_cache
 
     @cached(  # type: ignore
         TTLCache(maxsize=cache_config.maxsize, ttl=cache_config.ttl),


### PR DESCRIPTION
This implements #43

- Add oidc auth module and settings
- add `/credentials/oid` and `/me` endpoints
- Add keycloak in docker compose to test with oidc
- Remove assertion for user services in LocalStore
- Add general exception handler to OpenEOException
- Refactor stacApiBackend to use a cached client
- Improve error handling for missing environment variables in BackendSettings
- Customize settings sources for OIDCConfig to support space-separated scopes
- Update CORS methods in ApiSettings