### PR TITLE
Update CI workflow to enhance Docker image tagging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         if: ${{ matrix.python-version == env.LATEST_PY_VERSION }}
         uses: codecov/codecov-action@v5
         with:
-          files: ./coverage.xml
+          file: ./coverage.xml
           flags: unittests
           name: ${{ matrix.python-version }}
           fail_ci_if_error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         if: ${{ matrix.python-version == env.LATEST_PY_VERSION }}
         uses: codecov/codecov-action@v5
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           flags: unittests
           name: ${{ matrix.python-version }}
           fail_ci_if_error: false
@@ -93,11 +93,23 @@ jobs:
   publish-docker:
     needs: [tests]
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
 
     steps:
       - name: checkout code
         uses: actions/checkout@v4
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=sha
+            type=ref,event=branch
+            type=ref,event=tag
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
 
       - name: set up docker buildx
         uses: docker/setup-buildx-action@v2
@@ -109,10 +121,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.github_token }}
 
-      - name: build docker image
-        run: |
-          docker build -t ghcr.io/${{ github.repository }}:${{ github.sha }} .
-
-      - name: push docker image
-        run: |
-          docker push ghcr.io/${{ github.repository }}:${{ github.sha }}
+      - name: build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This PR allows to build with standard tags (`dev` and `latest`) upon main and release tags