### PR TITLE
Refactor processes to standardize data types to 'datacube'

### DIFF
--- a/tests/fixtures/graphs/rgb.json
+++ b/tests/fixtures/graphs/rgb.json
@@ -11,7 +11,7 @@
         "description": "A PNG image with 3 bands (RGB).",
         "schema": {
             "type": "object",
-            "subtype": "imagedata"
+            "subtype": "datacube"
         }
     },
     "parameters": [

--- a/tests/test_lazy_raster_stack.py
+++ b/tests/test_lazy_raster_stack.py
@@ -36,5 +36,7 @@ def test_lazy_raster_stack():
     # Apply pixel selection
     result = apply_pixel_selection(lazy_stack, pixel_selection="first")
 
-    assert type(result) is ImageData
+    assert isinstance(result, dict)  # RasterStack is Dict[str, ImageData]
+    assert "data" in result
+    assert isinstance(result["data"], ImageData)
     assert lazy_stack._executed is True

--- a/tests/test_reduce_processes.py
+++ b/tests/test_reduce_processes.py
@@ -122,13 +122,17 @@ def test_apply_pixel_selection(sample_temporal_stack):
     # Apply pixel selection to combine temporal stack
     result = apply_pixel_selection(data=sample_temporal_stack, pixel_selection="mean")
 
-    # Result should be a single ImageData
-    assert isinstance(result, ImageData)
-    assert result.count == 1
+    # Result should be a RasterStack with a single ImageData
+    assert isinstance(result, dict)
+    assert len(result) == 1
+    assert "data" in result
+    img = result["data"]
+    assert isinstance(img, ImageData)
+    assert img.count == 1
 
     # The mean value should be (1+2+3)/3 = 2
-    assert np.allclose(result.array.mean(), 2.0)
+    assert np.allclose(img.array.mean(), 2.0)
 
     # Metadata should include the pixel selection method
-    assert "pixel_selection_method" in result.metadata
-    assert result.metadata["pixel_selection_method"] == "mean"
+    assert "pixel_selection_method" in img.metadata
+    assert img.metadata["pixel_selection_method"] == "mean"

--- a/titiler/openeo/processes/data/apply.json
+++ b/titiler/openeo/processes/data/apply.json
@@ -1,7 +1,7 @@
 {
     "id": "apply",
     "summary": "Apply a process to each value",
-    "description": "Applies a process to each value in the data cube/image.",
+    "description": "Applies a process to each value in the data cube.",
     "categories": [
         "cubes"
     ],
@@ -9,23 +9,14 @@
         {
             "name": "data",
             "description": "A data cube.",
-            "schema": [
-                {
-                    "type": "object",
-                    "subtype": "datacube"
-                },
-                {
-                    "type": "object",
-                    "subtype": "imagedata"
-                },
-                {
-                    "type": "array"
-                }
-            ]
+            "schema": {
+                "type": "object",
+                "subtype": "datacube"
+            }
         },
         {
             "name": "process",
-            "description": "A process that accepts and returns a single value and is applied on each individual value in the data cube/image. The process may consist of multiple sub-processes and could, for example, consist of processes such as `absolute()` or `linear_scale_range()`.",
+            "description": "A process that accepts and returns a single value and is applied on each individual value in the data cube. The process may consist of multiple sub-processes and could, for example, consist of processes such as `absolute()` or `linear_scale_range()`.",
             "schema": {
                 "type": "object",
                 "subtype": "process-graph",
@@ -67,19 +58,10 @@
     ],
     "returns": {
         "description": "A data cube with the newly computed values and the same dimensions. The dimension properties (name, type, labels, reference system and resolution) remain unchanged.",
-        "schema": [
-            {
-                "type": "object",
-                "subtype": "datacube"
-            },
-            {
-                "type": "object",
-                "subtype": "imagedata"
-            },
-            {
-                "type": "array"
-            }
-        ]
+        "schema": {
+            "type": "object",
+            "subtype": "datacube"
+        }
     },
     "links": []
 }

--- a/titiler/openeo/processes/data/apply_pixel_selection.json
+++ b/titiler/openeo/processes/data/apply_pixel_selection.json
@@ -1,7 +1,7 @@
 {
     "id": "apply_pixel_selection",
-    "summary": "Convert DataCube to ImageData.",
-    "description": "Apply `Pixel Selection` method on a DataCube to create an ImageData object",
+    "summary": "Apply pixel selection on a datacube.",
+    "description": "Apply `Pixel Selection` method on a datacube to create a new datacube",
     "categories": [
         "cubes",
         "aggregate",
@@ -37,10 +37,10 @@
         }
     ],
     "returns": {
-        "description": "An ImageData object for further processing.",
+        "description": "A datacube for further processing.",
         "schema": {
             "type": "object",
-            "subtype": "imagedata"
+            "subtype": "datacube"
         }
     },
     "exceptions": {},

--- a/titiler/openeo/processes/data/colormap.json
+++ b/titiler/openeo/processes/data/colormap.json
@@ -1,7 +1,7 @@
 {
     "id": "colormap",
-    "summary": "Apply a color formula to an image.",
-    "description": "Return Image data with a colormap applied.",
+    "summary": "Apply a color formula to a datacube.",
+    "description": "Return a datacube with a colormap applied.",
     "categories": [
         "images",
         "color"
@@ -9,10 +9,10 @@
     "parameters": [
         {
             "name": "data",
-            "description": "An image.",
+            "description": "A datacube.",
             "schema": {
                 "type": "object",
-                "subtype": "imagedata"
+                "subtype": "datacube"
             }
         },
         {
@@ -70,10 +70,10 @@
         }
     ],
     "returns": {
-        "description": "The image with the colormap applied.",
+        "description": "The datacube with the colormap applied.",
         "schema": {
             "type": "object",
-            "subtype": "imagedata"
+            "subtype": "datacube"
         }
     },
     "exceptions": {},

--- a/titiler/openeo/processes/data/hillshade.json
+++ b/titiler/openeo/processes/data/hillshade.json
@@ -13,7 +13,7 @@
             "description": "A raster data cube.",
             "schema": {
                 "type": "object",
-                "subtype": "imagedata"
+                "subtype": "datacube"
             }
         },
         {
@@ -57,7 +57,7 @@
         "description": "A raster image data cube containing the computed hillshade values.",
         "schema": {
             "type": "object",
-            "subtype": "imagedata"
+            "subtype": "datacube"
         }
     },
     "exceptions": {},

--- a/titiler/openeo/processes/data/image_indexes.json
+++ b/titiler/openeo/processes/data/image_indexes.json
@@ -1,7 +1,7 @@
 {
     "id": "image_indexes",
-    "summary": "Select indexes from an ImageData.",
-    "description": "Return Image data with only selected indexes.",
+    "summary": "Select indexes from a datacube.",
+    "description": "Return datacube with only selected indexes.",
     "categories": [
         "images",
         "reducer"
@@ -9,15 +9,15 @@
     "parameters": [
         {
             "name": "data",
-            "description": "An image.",
+            "description": "A datacube.",
             "schema": {
                 "type": "object",
-                "subtype": "imagedata"
+                "subtype": "datacube"
             }
         },
         {
             "name": "indexes",
-            "description": "The 1-based index of the image to retrieve.",
+            "description": "The 1-based index of the band to retrieve.",
             "schema":  {
                 "type": "array",
                 "minItems": 1,
@@ -29,10 +29,10 @@
         }
     ],
     "returns": {
-        "description": "The image with the selected indexes.",
+        "description": "The datacube with the selected indexes.",
         "schema": {
             "type": "object",
-            "subtype": "imagedata"
+            "subtype": "datacube"
         }
     },
     "exceptions": {

--- a/titiler/openeo/processes/data/load_collection_and_reduce.json
+++ b/titiler/openeo/processes/data/load_collection_and_reduce.json
@@ -1,7 +1,7 @@
 {
     "id": "load_collection_and_reduce",
-    "summary": "Load a collection and return an imagedata object",
-    "description": "Loads a collection from the current back-end by its id and returns it as a ImageData Object.",
+    "summary": "Load a collection and return a datacube",
+    "description": "Loads a collection from the current back-end by its id and returns it as a datacube.",
     "categories": [
         "cubes",
         "import"
@@ -220,10 +220,10 @@
         }
     ],
     "returns": {
-        "description": "An ImageData object for further processing.",
+        "description": "A datacube for further processing.",
         "schema": {
             "type": "object",
-            "subtype": "imagedata"
+            "subtype": "datacube"
         }
     },
     "exceptions": {

--- a/titiler/openeo/processes/data/ndvi.json
+++ b/titiler/openeo/processes/data/ndvi.json
@@ -13,7 +13,7 @@
             "description": "A raster data cube.",
             "schema": {
                 "type": "object",
-                "subtype": "imagedata"
+                "subtype": "datacube"
             }
         },
         {
@@ -35,7 +35,7 @@
         "description": "A raster data cube containing the computed NDVI values. The structure of the data cube differs depending on the value passed to `target_band`:\n\n* `target_band` is `null`: The data cube does not contain the dimension of type `bands`, the number of dimensions decreases by one. The dimension properties (name, type, labels, reference system and resolution) for all other dimensions remain unchanged.\n* `target_band` is a string: The data cube keeps the same dimensions. The dimension properties remain unchanged, but the number of dimension labels for the dimension of type `bands` increases by one. The additional label is named as specified in `target_band`.",
         "schema": {
             "type": "object",
-            "subtype": "imagedata"
+            "subtype": "datacube"
         }
     },
     "exceptions": {},

--- a/titiler/openeo/processes/data/save_result.json
+++ b/titiler/openeo/processes/data/save_result.json
@@ -9,15 +9,10 @@
         {
             "name": "data",
             "description": "The data to deliver in the given file format.",
-            "schema": [
-                {
-                    "type": "object",
-                    "subtype": "imagedata"
-                },
-                {
-                    "type": "array"
-                }
-            ]
+            "schema": {
+                "type": "object",
+                "subtype": "datacube"
+            }
         },
         {
             "name": "format",

--- a/titiler/openeo/processes/data/to_array.json
+++ b/titiler/openeo/processes/data/to_array.json
@@ -1,7 +1,7 @@
 {
   "id": "to_array",
-  "summary": "Convert ImageData to array.",
-  "description": "Convert an ImageData object to numpy.array.",
+  "summary": "Convert datacube to array.",
+  "description": "Convert a datacube to numpy.array.",
   "categories": [
     "images",
     "arrays"
@@ -9,15 +9,15 @@
   "parameters": [
     {
       "name": "data",
-      "description": "An ImageData object.",
+      "description": "A datacube.",
       "schema": {
         "type": "object",
-        "subtype": "imagedata"
+        "subtype": "datacube"
       }
     }
   ],
   "returns": {
-    "description": "The array from the ImageData object.",
+    "description": "The array from the datacube.",
     "schema": {
       "type": "array"
     }

--- a/titiler/openeo/processes/data/to_image.json
+++ b/titiler/openeo/processes/data/to_image.json
@@ -1,7 +1,7 @@
 {
   "id": "to_image",
-  "summary": "Convert array to ImageData.",
-  "description": "Convert a 2 or 3 dimensional array to an ImageData object.",
+  "summary": "Convert array to datacube.",
+  "description": "Convert a 2 or 3 dimensional array to a datacube.",
   "categories": [
     "images",
     "arrays"
@@ -9,17 +9,17 @@
   "parameters": [
     {
       "name": "data",
-      "description": "The array from the ImageData object.",
+      "description": "The array to convert to a datacube.",
       "schema": {
         "type": "array"
       }
     }
   ],
   "returns": {
-    "description": "An ImageData object.",
+    "description": "A datacube.",
     "schema": {
       "type": "object",
-      "subtype": "imagedata"
+      "subtype": "datacube"
     }
   },
   "exceptions": {},

--- a/titiler/openeo/processes/implementations/arrays.py
+++ b/titiler/openeo/processes/implementations/arrays.py
@@ -51,6 +51,6 @@ def array_element(
         return numpy.take(data, index, axis=0)
 
 
-def to_image(data: Union[numpy.ndarray, numpy.ma.MaskedArray]) -> ImageData:
-    """Create an ImageData object from an array."""
-    return ImageData(data)
+def to_image(data: Union[numpy.ndarray, numpy.ma.MaskedArray]) -> RasterStack:
+    """Create a RasterStack from an array."""
+    return {"data": ImageData(data)}

--- a/titiler/openeo/processes/implementations/indices.py
+++ b/titiler/openeo/processes/implementations/indices.py
@@ -33,7 +33,7 @@ def ndvi(data: RasterStack, nir: int, red: int) -> RasterStack:
         red: Index of the red band (1-based)
 
     Returns:
-        RasterStack with NDVI results
+        RasterStack (Dict[str, ImageData]) containing NDVI results
     """
     # Apply NDVI to each item in the stack
     result: Dict[str, ImageData] = {}

--- a/titiler/openeo/processes/implementations/reduce.py
+++ b/titiler/openeo/processes/implementations/reduce.py
@@ -42,7 +42,7 @@ def apply_pixel_selection(
     pixel_selection: str = "first",
 ) -> RasterStack:
     """Apply PixelSelection method on a RasterStack.
-    
+
     Returns:
         RasterStack: A single-image RasterStack containing the result of pixel selection
     """

--- a/titiler/openeo/processes/implementations/reduce.py
+++ b/titiler/openeo/processes/implementations/reduce.py
@@ -40,8 +40,12 @@ class DimensionNotAvailable(Exception):
 def apply_pixel_selection(
     data: RasterStack,
     pixel_selection: str = "first",
-) -> ImageData:
-    """Apply PixelSelection method on a RasterStack."""
+) -> RasterStack:
+    """Apply PixelSelection method on a RasterStack.
+    
+    Returns:
+        RasterStack: A single-image RasterStack containing the result of pixel selection
+    """
     pixsel_method = PixelSelectionMethod[pixel_selection].value()
 
     assets_used: List = []
@@ -90,30 +94,34 @@ def apply_pixel_selection(
         assets_used.append(datetime)
 
         if pixsel_method.is_done and pixsel_method.data is not None:
-            return ImageData(
-                pixsel_method.data,
-                assets=assets_used,
-                crs=crs,
-                bounds=bounds,
-                band_names=band_names if band_names is not None else [],
-                metadata={
-                    "pixel_selection_method": pixel_selection,
-                },
-            )
+            return {
+                "data": ImageData(
+                    pixsel_method.data,
+                    assets=assets_used,
+                    crs=crs,
+                    bounds=bounds,
+                    band_names=band_names if band_names is not None else [],
+                    metadata={
+                        "pixel_selection_method": pixel_selection,
+                    },
+                )
+            }
 
     if pixsel_method.data is None:
         raise ValueError("Method returned an empty array")
 
-    return ImageData(
-        pixsel_method.data,
-        assets=assets_used,
-        crs=crs,
-        bounds=bounds,
-        band_names=band_names if band_names is not None else [],
-        metadata={
-            "pixel_selection_method": pixel_selection,
-        },
-    )
+    return {
+        "data": ImageData(
+            pixsel_method.data,
+            assets=assets_used,
+            crs=crs,
+            bounds=bounds,
+            band_names=band_names if band_names is not None else [],
+            metadata={
+                "pixel_selection_method": pixel_selection,
+            },
+        )
+    }
 
 
 def _reduce_temporal_dimension(


### PR DESCRIPTION
Update the codebase to consistently use 'datacube' as the data type, replacing instances of 'imagedata'. Adjust related tests and functions to reflect this change.

Fixes #57