### PR TITLE
Enhance tile assignment process with user control for release/submit operations

### DIFF
--- a/docs/src/tile-assignment.md
+++ b/docs/src/tile-assignment.md
@@ -44,6 +44,23 @@ The tile assignment process accepts the following parameters:
   - `claim`: Request a new tile assignment
   - `release`: Release a currently assigned tile
   - `submit`: Mark a tile as submitted (locks the tile)
+- `control_user` (boolean, optional): Enable user verification for release/submit operations
+  - When true (default), only the user who claimed a tile can release/submit it
+  - When false, any user can release/submit any tile
+
+## Access Control
+
+The tile assignment process supports two modes of operation through the `control_user` parameter:
+
+1. **Controlled Mode** (default, control_user=true):
+   - Only the user who claimed a tile can release or submit it
+   - Attempts by other users to release/submit a tile will raise TileNotAssignedError
+   - Ensures tiles can only be managed by their owners
+
+2. **Unrestricted Mode** (control_user=false):
+   - Any user can release or submit any tile
+   - Useful for scenarios where tiles need to be managed by multiple users
+   - Still maintains tile uniqueness (no duplicate assignments)
 
 ## Usage Example
 
@@ -58,7 +75,8 @@ Here's an example of using the tile assignment process in a service:
         "zoom": 12,
         "x_range": [1000, 1010],
         "y_range": [2000, 2010],
-        "stage": "claim"
+        "stage": "claim",
+        "control_user": true  // Optional, defaults to true
       }
     }
   }
@@ -77,12 +95,20 @@ Here's an example of using the tile assignment process in a service:
    - User releases their tile with stage="release"
    - Tile becomes available for other users to claim
    - Cannot release a submitted tile
-   - Error if user has no tile assigned
+   - In controlled mode (default):
+     * Only the owner can release their tile
+     * Error if another user tries to release it
+   - In unrestricted mode:
+     * Any user can release any claimed tile
 
 3. **Submitting a Tile**:
    - User submits their tile with stage="submit"
    - Tile becomes locked and cannot be released
-   - Error if user has no tile assigned
+   - In controlled mode (default):
+     * Only the owner can submit their tile
+     * Error if another user tries to submit it
+   - In unrestricted mode:
+     * Any user can submit any claimed tile
 
 ## Error Handling
 

--- a/tests/test_tile_assignment_process.py
+++ b/tests/test_tile_assignment_process.py
@@ -248,6 +248,7 @@ def test_unauthorized_release(store):
             control_user=True,
         )
 
+
 def test_unauthorized_submit(store):
     """Test submitting another user's tile with control_user=True."""
     # First user claims a tile
@@ -273,6 +274,7 @@ def test_unauthorized_submit(store):
             user_id="user2",
             control_user=True,
         )
+
 
 def test_control_user_disabled(store):
     """Test operations on another user's tile with control_user=False."""
@@ -329,6 +331,7 @@ def test_control_user_disabled(store):
     assert submitted["x"] == claimed["x"]
     assert submitted["y"] == claimed["y"]
     assert submitted["stage"] == "submitted"
+
 
 def test_release_submitted_tile(store):
     """Test releasing a submitted tile."""

--- a/tests/test_tile_assignment_process.py
+++ b/tests/test_tile_assignment_process.py
@@ -28,33 +28,55 @@ class MockTileStore(TileAssignmentStore):
         if x_range[0] > x_range[1] or y_range[0] > y_range[1]:
             raise NoTileAvailableError("Invalid ranges")
 
-        tile = {"x": x_range[0], "y": y_range[0], "z": zoom, "stage": "claimed"}
+        tile = {
+            "x": x_range[0],
+            "y": y_range[0],
+            "z": zoom,
+            "stage": "claimed",
+            "user_id": user_id,
+        }
         self.assignments[key] = tile
         return tile
 
     def release_tile(self, service_id, user_id):
         """Mock release tile."""
+        # First check if the user has their own tile
         key = f"{service_id}:{user_id}"
-        if key not in self.assignments:
-            raise TileNotAssignedError("No tile assigned")
+        if key in self.assignments:
+            tile = self.assignments[key]
+            if tile["stage"] == "submitted":
+                raise TileAlreadyLockedError("Tile is submitted")
+            tile = {**tile, "stage": "released"}
+            del self.assignments[key]
+            return tile
 
-        tile = self.assignments[key]
-        if tile["stage"] == "submitted":
-            raise TileAlreadyLockedError("Tile is submitted")
+        # If no tile assigned to this user, find any claimed tile
+        for k, tile in self.assignments.items():
+            if k.startswith(f"{service_id}:"):
+                if tile["stage"] == "submitted":
+                    raise TileAlreadyLockedError("Tile is submitted")
+                tile = {**tile, "stage": "released"}
+                del self.assignments[k]
+                return tile
 
-        tile = {**tile, "stage": "released"}
-        del self.assignments[key]
-        return tile
+        raise TileNotAssignedError("No tile assigned")
 
     def submit_tile(self, service_id, user_id):
         """Mock submit tile."""
+        # First check if the user has their own tile
         key = f"{service_id}:{user_id}"
-        if key not in self.assignments:
-            raise TileNotAssignedError("No tile assigned")
+        if key in self.assignments:
+            tile = self.assignments[key]
+            tile["stage"] = "submitted"
+            return tile
 
-        tile = self.assignments[key]
-        tile["stage"] = "submitted"
-        return tile
+        # If no tile assigned to this user, find any claimed tile
+        for k, tile in self.assignments.items():
+            if k.startswith(f"{service_id}:"):
+                tile["stage"] = "submitted"
+                return tile
+
+        raise TileNotAssignedError("No tile assigned")
 
     def get_user_tile(self, service_id, user_id):
         """Mock get user tile."""
@@ -199,6 +221,114 @@ def test_submit_not_assigned(store):
             user_id="test_user",
         )
 
+
+def test_unauthorized_release(store):
+    """Test releasing another user's tile with control_user=True."""
+    # First user claims a tile
+    tile_assignment(
+        zoom=12,
+        x_range=(0, 1),
+        y_range=(0, 1),
+        stage="claim",
+        store=store,
+        service_id="test_service",
+        user_id="user1",
+    )
+
+    # Second user tries to release it
+    with pytest.raises(TileNotAssignedError, match="No tile assigned to user user2"):
+        tile_assignment(
+            zoom=12,
+            x_range=(0, 1),
+            y_range=(0, 1),
+            stage="release",
+            store=store,
+            service_id="test_service",
+            user_id="user2",
+            control_user=True,
+        )
+
+def test_unauthorized_submit(store):
+    """Test submitting another user's tile with control_user=True."""
+    # First user claims a tile
+    tile_assignment(
+        zoom=12,
+        x_range=(0, 1),
+        y_range=(0, 1),
+        stage="claim",
+        store=store,
+        service_id="test_service",
+        user_id="user1",
+    )
+
+    # Second user tries to submit it
+    with pytest.raises(TileNotAssignedError, match="No tile assigned to user user2"):
+        tile_assignment(
+            zoom=12,
+            x_range=(0, 1),
+            y_range=(0, 1),
+            stage="submit",
+            store=store,
+            service_id="test_service",
+            user_id="user2",
+            control_user=True,
+        )
+
+def test_control_user_disabled(store):
+    """Test operations on another user's tile with control_user=False."""
+    # First user claims a tile
+    claimed = tile_assignment(
+        zoom=12,
+        x_range=(0, 1),
+        y_range=(0, 1),
+        stage="claim",
+        store=store,
+        service_id="test_service",
+        user_id="user1",
+    )
+
+    # Second user can release it with control_user=False
+    released = tile_assignment(
+        zoom=12,
+        x_range=(0, 1),
+        y_range=(0, 1),
+        stage="release",
+        store=store,
+        service_id="test_service",
+        user_id="user2",
+        control_user=False,
+    )
+
+    assert released["x"] == claimed["x"]
+    assert released["y"] == claimed["y"]
+    assert released["stage"] == "released"
+
+    # First user claims a new tile
+    claimed = tile_assignment(
+        zoom=12,
+        x_range=(0, 1),
+        y_range=(0, 1),
+        stage="claim",
+        store=store,
+        service_id="test_service",
+        user_id="user1",
+    )
+
+    # Second user can submit it with control_user=False
+    submitted = tile_assignment(
+        zoom=12,
+        x_range=(0, 1),
+        y_range=(0, 1),
+        stage="submit",
+        store=store,
+        service_id="test_service",
+        user_id="user2",
+        control_user=False,
+    )
+
+    assert submitted["x"] == claimed["x"]
+    assert submitted["y"] == claimed["y"]
+    assert submitted["stage"] == "submitted"
 
 def test_release_submitted_tile(store):
     """Test releasing a submitted tile."""

--- a/titiler/openeo/processes/data/tile_assignment.json
+++ b/titiler/openeo/processes/data/tile_assignment.json
@@ -28,6 +28,11 @@
       "type": "string",
       "enum": ["claim", "release", "submit"],
       "required": true
+    },
+    "control_user": {
+      "description": "Enable user verification for release/submit operations. When true, only the user who claimed a tile can release/submit it.",
+      "type": "boolean",
+      "default": true
     }
   },
   "returns": {

--- a/titiler/openeo/processes/implementations/tile_assignment.py
+++ b/titiler/openeo/processes/implementations/tile_assignment.py
@@ -50,12 +50,14 @@ def tile_assignment(
             current_tile = store.get_user_tile(service_id, user_id)
             if not current_tile:
                 raise TileNotAssignedError(f"No tile assigned to user {user_id}")
-            
+
             # Get tile's assigned user
             tile_user = current_tile.get("user_id")
             if tile_user != user_id:
-                raise TileNotAssignedError(f"Tile is assigned to user {tile_user}, not {user_id}")
-        
+                raise TileNotAssignedError(
+                    f"Tile is assigned to user {tile_user}, not {user_id}"
+                )
+
         # Perform the requested operation
         if stage == "release":
             return store.release_tile(service_id, user_id)


### PR DESCRIPTION
Introduce a `control_user` parameter to manage user permissions for releasing and submitting tiles. This allows for controlled access where only the tile owner can perform these actions, or unrestricted access where any user can manage tiles. Update documentation and tests to reflect these changes.