### PR TITLE
Fix load_collection to properly handle items from same date

### DIFF
--- a/tests/test_stacapi.py
+++ b/tests/test_stacapi.py
@@ -263,16 +263,21 @@ def test_resolution_based_dimension_calculation(monkeypatch):
     monkeypatch.setattr("titiler.openeo.reader.SimpleSTACReader", MockReader)
     monkeypatch.setattr(LoadCollection, "_get_items", mock_get_items)
 
-    # Override task processing to capture the width/height values
+    # Override mosaic_reader to capture the width/height values
     captured_params = {}
 
-    def mock_create_tasks(reader_function, items, max_threads, bbox, **kwargs):
+    def mock_mosaic_reader(items, reader, bbox, **kwargs):
         # Capture the parameters for later inspection
         captured_params.update(kwargs)
-        # Pass through to the original function
-        return create_tasks(reader_function, items, max_threads, bbox, **kwargs)
+        # Return a mock ImageData
+        import numpy
+        return ImageData(
+            numpy.zeros((1, 100, 100), dtype="uint8"),
+            assets=kwargs.get("assets", ["B01"]),
+            crs=kwargs.get("dst_crs", "EPSG:4326"),
+        ), None
 
-    monkeypatch.setattr("titiler.openeo.stacapi.create_tasks", mock_create_tasks)
+    monkeypatch.setattr("titiler.openeo.stacapi.mosaic_reader", mock_mosaic_reader)
 
     # Setup and run the test
     backend = stacApiBackend(url="https://example.com")
@@ -290,5 +295,7 @@ def test_resolution_based_dimension_calculation(monkeypatch):
 
     # Check that calculated dimensions are close to expected (1000x1000)
     # Allow some flexibility due to rounding
-    assert 950 <= captured_params.get("width", 0) <= 1050
-    assert 950 <= captured_params.get("height", 0) <= 1050
+    width = captured_params.get("width", 0)
+    height = captured_params.get("height", 0)
+    assert 950 <= width <= 1050, f"Width {width} is not within expected range"
+    assert 950 <= height <= 1050, f"Height {height} is not within expected range"

--- a/tests/test_stacapi.py
+++ b/tests/test_stacapi.py
@@ -3,7 +3,6 @@
 import pytest
 from openeo_pg_parser_networkx.pg_schema import BoundingBox
 from rio_tiler.models import ImageData
-from rio_tiler.tasks import create_tasks
 
 from titiler.openeo.settings import ProcessingSettings
 from titiler.openeo.stacapi import LoadCollection, stacApiBackend
@@ -271,6 +270,7 @@ def test_resolution_based_dimension_calculation(monkeypatch):
         captured_params.update(kwargs)
         # Return a mock ImageData
         import numpy
+
         return ImageData(
             numpy.zeros((1, 100, 100), dtype="uint8"),
             assets=kwargs.get("assets", ["B01"]),

--- a/titiler/openeo/stacapi.py
+++ b/titiler/openeo/stacapi.py
@@ -524,7 +524,7 @@ class LoadCollection:
         crs = dimensions["crs"]
 
         # Group items by date
-        items_by_date = {}
+        items_by_date: dict[str, list[dict]] = {}
         for item in items:
             date = _props_to_datename(item["properties"])
             if date not in items_by_date:


### PR DESCRIPTION
The `load_collection` function was missing proper handling of items from the same date, which is important for maintaining a strictly temporal dimension as described in our data model. While `load_collection_and_reduce` correctly merged items from the same date using mosaic_reader, `load_collection` was treating each item independently.

This change ensures that:

1. Items from the same date are merged using mosaic_reader, just like in load_collection_and_reduce
2. The temporal dimension is strictly maintained, with each unique date as a key in the RasterStack
3. Spatial dimensions remain compatible across all rasters in the stack, as required by our data model

This aligns with our core concept of dimension handling where:

- The temporal dimension is properly represented in the data cube (e.g., "2021-01", "2021-02")
- All rasters in the stack maintain compatible spatial dimensions
- Items from the same date are merged to avoid duplicate temporal keys

The change makes load_collection more consistent with our data model documentation and ensures proper handling of the temporal dimension while maintaining spatial compatibility.
 cc @dthiex