### PR TITLE
 Improve error handling for output size limits

### DIFF
--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,22 +1,22 @@
 """Tests for reader module."""
 
 import pytest
-from openeo_pg_parser_networkx.pg_schema import BoundingBox
 import rasterio
+from openeo_pg_parser_networkx.pg_schema import BoundingBox
 
 from titiler.openeo.errors import (
+    MixedCRSError,
     OutputLimitExceeded,
     ProcessParameterMissing,
-    MixedCRSError,
 )
 from titiler.openeo.reader import (
-    _validate_input_parameters,
-    _get_item_resolutions,
-    _reproject_resolution,
+    SimpleSTACReader,
     _calculate_dimensions,
     _check_pixel_limit,
     _estimate_output_dimensions,
-    SimpleSTACReader,
+    _get_item_resolutions,
+    _reproject_resolution,
+    _validate_input_parameters,
 )
 
 
@@ -63,7 +63,9 @@ def test_get_item_resolutions(sample_stac_item, sample_spatial_extent):
     """Test resolution extraction from STAC item."""
     # Test with proj:transform
     with SimpleSTACReader(sample_stac_item) as src_dst:
-        x_res, y_res = _get_item_resolutions(sample_stac_item, src_dst, sample_spatial_extent)
+        x_res, y_res = _get_item_resolutions(
+            sample_stac_item, src_dst, sample_spatial_extent
+        )
         assert len(x_res) > 0
         assert len(y_res) > 0
         assert x_res[0] == 10  # From proj:transform
@@ -81,7 +83,9 @@ def test_get_item_resolutions(sample_stac_item, sample_spatial_extent):
         },
     }
     with SimpleSTACReader(item_with_shape) as src_dst:
-        x_res, y_res = _get_item_resolutions(item_with_shape, src_dst, sample_spatial_extent)
+        x_res, y_res = _get_item_resolutions(
+            item_with_shape, src_dst, sample_spatial_extent
+        )
         assert len(x_res) > 0
         assert len(y_res) > 0
         assert x_res[0] == 0.1  # 10/100
@@ -98,7 +102,9 @@ def test_get_item_resolutions(sample_stac_item, sample_spatial_extent):
         },
     }
     with SimpleSTACReader(item_without_metadata) as src_dst:
-        x_res, y_res = _get_item_resolutions(item_without_metadata, src_dst, sample_spatial_extent)
+        x_res, y_res = _get_item_resolutions(
+            item_without_metadata, src_dst, sample_spatial_extent
+        )
         assert len(x_res) > 0
         assert len(y_res) > 0
         assert x_res[0] == 1024  # Default resolution
@@ -120,7 +126,7 @@ def test_reproject_resolution():
 def test_calculate_dimensions():
     """Test dimension calculation."""
     bbox = [0, 0, 10, 10]
-    
+
     # Test with specified dimensions
     width, height = _calculate_dimensions(bbox, None, None, width=100, height=200)
     assert width == 100
@@ -161,7 +167,9 @@ def test_check_pixel_limit():
     # Test with None dimensions (should convert to 0)
     width_int, height_int = None, None
     items = [{"id": "item1"}, {"id": "item2"}]
-    _check_pixel_limit(width_int, height_int, items)  # Should not raise error for 0 pixels
+    _check_pixel_limit(
+        width_int, height_int, items
+    )  # Should not raise error for 0 pixels
 
 
 def test_estimate_output_dimensions(sample_stac_item, sample_spatial_extent):

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,0 +1,245 @@
+"""Tests for reader module."""
+
+import pytest
+from openeo_pg_parser_networkx.pg_schema import BoundingBox
+import rasterio
+
+from titiler.openeo.errors import (
+    OutputLimitExceeded,
+    ProcessParameterMissing,
+    MixedCRSError,
+)
+from titiler.openeo.reader import (
+    _validate_input_parameters,
+    _get_item_resolutions,
+    _reproject_resolution,
+    _calculate_dimensions,
+    _check_pixel_limit,
+    _estimate_output_dimensions,
+    SimpleSTACReader,
+)
+
+
+@pytest.fixture
+def sample_stac_item():
+    """Create a sample STAC item."""
+    return {
+        "id": "test-item",
+        "bbox": [0, 0, 10, 10],
+        "assets": {
+            "B01": {
+                "href": "https://example.com/B01.tif",
+                "proj:transform": [10, 0, 0, 0, -10, 0],
+            }
+        },
+    }
+
+
+@pytest.fixture
+def sample_spatial_extent():
+    """Create a sample spatial extent."""
+    return BoundingBox(west=0, south=0, east=10, north=10, crs="EPSG:4326")
+
+
+def test_validate_input_parameters(sample_spatial_extent, sample_stac_item):
+    """Test input parameter validation."""
+    # Test valid inputs
+    _validate_input_parameters(sample_spatial_extent, [sample_stac_item], ["B01"])
+
+    # Test missing spatial extent
+    with pytest.raises(ProcessParameterMissing, match="spatial_extent"):
+        _validate_input_parameters(None, [sample_stac_item], ["B01"])
+
+    # Test empty items list
+    with pytest.raises(ProcessParameterMissing, match="items"):
+        _validate_input_parameters(sample_spatial_extent, [], ["B01"])
+
+    # Test missing bands
+    with pytest.raises(ProcessParameterMissing, match="bands"):
+        _validate_input_parameters(sample_spatial_extent, [sample_stac_item], None)
+
+
+def test_get_item_resolutions(sample_stac_item, sample_spatial_extent):
+    """Test resolution extraction from STAC item."""
+    # Test with proj:transform
+    with SimpleSTACReader(sample_stac_item) as src_dst:
+        x_res, y_res = _get_item_resolutions(sample_stac_item, src_dst, sample_spatial_extent)
+        assert len(x_res) > 0
+        assert len(y_res) > 0
+        assert x_res[0] == 10  # From proj:transform
+        assert y_res[0] == 10  # From proj:transform
+
+    # Test with proj:shape
+    item_with_shape = {
+        "id": "test-item",
+        "bbox": [0, 0, 10, 10],
+        "assets": {
+            "B01": {
+                "href": "https://example.com/B01.tif",
+                "proj:shape": [100, 100],
+            }
+        },
+    }
+    with SimpleSTACReader(item_with_shape) as src_dst:
+        x_res, y_res = _get_item_resolutions(item_with_shape, src_dst, sample_spatial_extent)
+        assert len(x_res) > 0
+        assert len(y_res) > 0
+        assert x_res[0] == 0.1  # 10/100
+        assert y_res[0] == 0.1  # 10/100
+
+    # Test fallback to default resolution
+    item_without_metadata = {
+        "id": "test-item",
+        "bbox": [0, 0, 10, 10],
+        "assets": {
+            "B01": {
+                "href": "https://example.com/B01.tif",
+            }
+        },
+    }
+    with SimpleSTACReader(item_without_metadata) as src_dst:
+        x_res, y_res = _get_item_resolutions(item_without_metadata, src_dst, sample_spatial_extent)
+        assert len(x_res) > 0
+        assert len(y_res) > 0
+        assert x_res[0] == 1024  # Default resolution
+        assert y_res[0] == 1024  # Default resolution
+
+
+def test_reproject_resolution():
+    """Test resolution reprojection."""
+    src_crs = rasterio.crs.CRS.from_epsg(4326)
+    dst_crs = rasterio.crs.CRS.from_epsg(3857)
+    bbox = [0, 0, 1, 1]
+    x_res, y_res = _reproject_resolution(src_crs, dst_crs, bbox, 0.1, 0.1)
+    assert x_res is not None
+    assert y_res is not None
+    assert x_res != 0.1  # Should be different after reprojection
+    assert y_res != 0.1  # Should be different after reprojection
+
+
+def test_calculate_dimensions():
+    """Test dimension calculation."""
+    bbox = [0, 0, 10, 10]
+    
+    # Test with specified dimensions
+    width, height = _calculate_dimensions(bbox, None, None, width=100, height=200)
+    assert width == 100
+    assert height == 200
+
+    # Test with resolution
+    width, height = _calculate_dimensions(bbox, x_resolution=0.1, y_resolution=0.1)
+    assert width == 100  # 10 / 0.1
+    assert height == 100  # 10 / 0.1
+
+    # Test default fallback
+    width, height = _calculate_dimensions(bbox, None, None)
+    assert width == 1024
+    assert height == 1024
+
+
+def test_check_pixel_limit():
+    """Test pixel count limit check."""
+    # Test within limit
+    _check_pixel_limit(100, 100, [{"id": "item1"}, {"id": "item2"}])
+
+    # Test exceeding limit with multiple items
+    with pytest.raises(OutputLimitExceeded) as exc_info:
+        _check_pixel_limit(10000, 10000, [{"id": "item1"}, {"id": "item2"}])
+    error_msg = str(exc_info.value)
+    assert "10000x10000 pixels x 2 items" in error_msg
+    assert "200,000,000 total pixels" in error_msg  # Test thousands separator
+    assert "max allowed: 100,000,000 pixels" in error_msg
+
+    # Test exceeding limit with single item
+    with pytest.raises(OutputLimitExceeded) as exc_info:
+        _check_pixel_limit(15000, 15000, [{"id": "item1"}])  # 225 million pixels
+    error_msg = str(exc_info.value)
+    assert "15000x15000 pixels" in error_msg
+    assert "225,000,000 total pixels" in error_msg
+    assert "max allowed: 100,000,000 pixels" in error_msg
+
+    # Test with None dimensions (should convert to 0)
+    width_int, height_int = None, None
+    items = [{"id": "item1"}, {"id": "item2"}]
+    _check_pixel_limit(width_int, height_int, items)  # Should not raise error for 0 pixels
+
+
+def test_estimate_output_dimensions(sample_stac_item, sample_spatial_extent):
+    """Test complete output dimension estimation."""
+    # Test successful estimation
+    result = _estimate_output_dimensions(
+        [sample_stac_item],
+        sample_spatial_extent,
+        ["B01"],
+    )
+    assert "width" in result
+    assert "height" in result
+    assert "crs" in result
+    assert "bbox" in result
+
+    # Test mixed CRS error
+    item2 = {
+        "id": "test-item-2",
+        "bbox": [0, 0, 10, 10],
+        "proj": {
+            "epsg": 3857,
+            "transform": [10, 0, 0, 0, -10, 0, 0, 0, 1],
+            "shape": [100, 100],
+        },
+        "assets": {
+            "B01": {
+                "href": "https://example.com/B01.tif",
+                "proj:transform": [10, 0, 0, 0, -10, 0, 0, 0, 1],
+            }
+        },
+    }
+    with pytest.raises(MixedCRSError) as exc_info:
+        _estimate_output_dimensions(
+            [sample_stac_item, item2],
+            sample_spatial_extent,
+            ["B01"],
+        )
+    assert "Mixed CRS in items" in str(exc_info.value)
+    assert "found EPSG:3857" in str(exc_info.value)
+    assert "expected EPSG:4326" in str(exc_info.value)
+
+    # Test output size limit with single item
+    with pytest.raises(OutputLimitExceeded) as exc_info:
+        _estimate_output_dimensions(
+            [sample_stac_item],
+            sample_spatial_extent,
+            ["B01"],
+            width=15000,
+            height=15000,
+        )
+    error_msg = str(exc_info.value)
+    assert "15000x15000 pixels" in error_msg
+    assert "225,000,000 total pixels" in error_msg
+    assert "max allowed: 100,000,000 pixels" in error_msg
+
+    # Test output size limit with multiple items
+    with pytest.raises(OutputLimitExceeded) as exc_info:
+        _estimate_output_dimensions(
+            [sample_stac_item, sample_stac_item.copy()],
+            sample_spatial_extent,
+            ["B01"],
+            width=10000,
+            height=10000,
+        )
+    error_msg = str(exc_info.value)
+    assert "10000x10000 pixels x 2 items" in error_msg
+    assert "200,000,000 total pixels" in error_msg
+    assert "max allowed: 100,000,000 pixels" in error_msg
+
+    # Test with default dimensions
+    result = _estimate_output_dimensions(
+        [sample_stac_item],
+        sample_spatial_extent,
+        ["B01"],
+        width=None,
+        height=None,
+    )
+    assert isinstance(result["width"], int)
+    assert isinstance(result["height"], int)
+    assert result["width"] > 0
+    assert result["height"] > 0

--- a/tests/test_stacapi.py
+++ b/tests/test_stacapi.py
@@ -88,7 +88,7 @@ def test_load_collection_pixel_threshold(monkeypatch):
     loader = LoadCollection(stac_api=backend)
 
     # Test with dimensions exceeding threshold
-    with pytest.raises(OutputLimitExceeded) as exc_info:
+    with pytest.raises(OutputLimitExceeded):
         loader.load_collection(
             id="test",
             spatial_extent=BoundingBox(
@@ -177,7 +177,7 @@ def test_load_collection_and_reduce_pixel_threshold(monkeypatch):
     loader = LoadCollection(stac_api=backend)
 
     # Test with dimensions exceeding threshold
-    with pytest.raises(OutputLimitExceeded) as exc_info:
+    with pytest.raises(OutputLimitExceeded):
         loader.load_collection_and_reduce(
             id="test",
             spatial_extent=BoundingBox(

--- a/tests/test_stacapi.py
+++ b/tests/test_stacapi.py
@@ -4,6 +4,7 @@ import pytest
 from openeo_pg_parser_networkx.pg_schema import BoundingBox
 from rio_tiler.models import ImageData
 
+from titiler.openeo.errors import OutputLimitExceeded
 from titiler.openeo.settings import ProcessingSettings
 from titiler.openeo.stacapi import LoadCollection, stacApiBackend
 
@@ -87,18 +88,16 @@ def test_load_collection_pixel_threshold(monkeypatch):
     loader = LoadCollection(stac_api=backend)
 
     # Test with dimensions exceeding threshold
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(OutputLimitExceeded) as exc_info:
         loader.load_collection(
             id="test",
             spatial_extent=BoundingBox(
                 west=0, south=0, east=1, north=1, crs="EPSG:4326"
             ),
             bands=["B01"],
-            width=5000,
-            height=5000,
+            width=15000,
+            height=15000,
         )
-    assert "Estimated output size too large" in str(exc_info.value)
-    assert "max allowed: 10000000" in str(exc_info.value)
 
     # Test with acceptable dimensions
     result = loader.load_collection(
@@ -178,17 +177,15 @@ def test_load_collection_and_reduce_pixel_threshold(monkeypatch):
     loader = LoadCollection(stac_api=backend)
 
     # Test with dimensions exceeding threshold
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(OutputLimitExceeded) as exc_info:
         loader.load_collection_and_reduce(
             id="test",
             spatial_extent=BoundingBox(
                 west=0, south=0, east=1, north=1, crs="EPSG:4326"
             ),
-            width=5000,
-            height=5000,
+            width=15000,
+            height=15000,
         )
-    assert "Estimated output size too large" in str(exc_info.value)
-    assert "max allowed: 10000000" in str(exc_info.value)
 
     # Test with acceptable dimensions
     result = loader.load_collection_and_reduce(

--- a/titiler/openeo/errors.py
+++ b/titiler/openeo/errors.py
@@ -247,7 +247,13 @@ class ServiceUnavailable(OpenEOException):
 class OutputLimitExceeded(OpenEOException):
     """The output size exceeds the maximum allowed limit."""
 
-    def __init__(self, width: int, height: int, max_pixels: int, items_count: Optional[int] = None):
+    def __init__(
+        self,
+        width: int,
+        height: int,
+        max_pixels: int,
+        items_count: Optional[int] = None,
+    ):
         """Initialize error with output size limit exceeded."""
         total_pixels = width * height * (items_count or 1)
         message = (

--- a/titiler/openeo/errors.py
+++ b/titiler/openeo/errors.py
@@ -242,3 +242,69 @@ class ServiceUnavailable(OpenEOException):
             code="ServiceUnavailable",
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
         )
+
+
+class OutputLimitExceeded(OpenEOException):
+    """The output size exceeds the maximum allowed limit."""
+
+    def __init__(self, width: int, height: int, max_pixels: int, items_count: Optional[int] = None):
+        """Initialize error with output size limit exceeded."""
+        total_pixels = width * height * (items_count or 1)
+        message = (
+            f"Estimated output size too large: {width}x{height} pixels"
+            + (f" x {items_count} items" if items_count else "")
+            + f" = {total_pixels:,} total pixels (max allowed: {max_pixels:,} pixels)"
+        )
+        super().__init__(
+            message=message,
+            code="OutputLimitExceeded",
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+
+class MixedCRSError(OpenEOException):
+    """The input data contains mixed coordinate reference systems."""
+
+    def __init__(self, found_crs: str, expected_crs: str):
+        """Initialize error with mixed CRS details."""
+        super().__init__(
+            message=f"Mixed CRS in items: found {found_crs} but expected {expected_crs}",
+            code="MixedCRSError",
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+
+class ItemsLimitExceeded(OpenEOException):
+    """The number of items exceeds the maximum allowed limit."""
+
+    def __init__(self, items_count: int, max_items: int):
+        """Initialize error with items limit exceeded."""
+        super().__init__(
+            message=f"Number of items in the workflow pipeline exceeds maximum allowed: {items_count} (max allowed: {max_items})",
+            code="ItemsLimitExceeded",
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+
+class UnsupportedSTACObject(OpenEOException):
+    """The STAC object type is not supported."""
+
+    def __init__(self, object_type: str):
+        """Initialize error with unsupported STAC object type."""
+        super().__init__(
+            message=f"Unsupported STAC object type: {object_type}",
+            code="UnsupportedSTACObject",
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+
+class STACLoadError(OpenEOException):
+    """Failed to load STAC object from URL."""
+
+    def __init__(self, url: str, error: str):
+        """Initialize error with STAC loading failure details."""
+        super().__init__(
+            message=f"Failed to read STAC from URL: {url}. Error: {error}",
+            code="STACLoadError",
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )

--- a/titiler/openeo/reader.py
+++ b/titiler/openeo/reader.py
@@ -19,11 +19,6 @@ from rio_tiler.errors import (
     InvalidAssetName,
     MissingAssets,
 )
-from titiler.openeo.errors import (
-    OutputLimitExceeded,
-    ProcessParameterMissing,
-    MixedCRSError,
-)
 from rio_tiler.io import Reader
 from rio_tiler.io.base import BaseReader, MultiBaseReader
 from rio_tiler.models import ImageData
@@ -31,6 +26,12 @@ from rio_tiler.tasks import multi_arrays
 from rio_tiler.types import AssetInfo, BBox, Indexes
 from rio_tiler.utils import cast_to_sequence
 from typing_extensions import TypedDict
+
+from titiler.openeo.errors import (
+    MixedCRSError,
+    OutputLimitExceeded,
+    ProcessParameterMissing,
+)
 
 
 class Dims(TypedDict):
@@ -40,179 +41,6 @@ class Dims(TypedDict):
     height: int
     crs: rasterio.crs.CRS
     bbox: List[float]
-
-
-def _estimate_output_dimensions(
-    items: List[Dict],
-    spatial_extent: BoundingBox,
-    bands: Optional[list[str]],
-    width: Optional[int] = None,
-    height: Optional[int] = None,
-) -> Dims:
-    """
-    Estimate output dimensions based on items and spatial extent.
-
-    Args:
-        items: List of STAC items
-        spatial_extent: Bounding box for the output
-        bands: List of band names to include
-        width: Optional user-specified width
-        height: Optional user-specified height
-
-    Returns:
-        Dictionary containing:
-            - width: Estimated or specified width
-            - height: Estimated or specified height
-            - crs: Target CRS to use
-            - bbox: Bounding box as a list [west, south, east, north]
-    """
-    from .settings import ProcessingSettings
-
-    processing_settings = ProcessingSettings()
-
-    if not spatial_extent:
-        raise ProcessParameterMissing("spatial_extent")
-
-    # Test if items are empty
-    if not items:
-        raise ProcessParameterMissing("items")
-
-    # Check if bands are empty
-    if not bands:
-        raise ProcessParameterMissing("bands")
-
-    # Extract CRS and resolution information from items
-    item_crs: rasterio.crs.CRS = None
-    x_resolutions = []
-    y_resolutions = []
-
-    for item in items:
-        with SimpleSTACReader(item) as src_dst:
-            if item_crs is None:
-                item_crs = src_dst.crs
-            elif item_crs != src_dst.crs:
-                raise MixedCRSError(found_crs=str(src_dst.crs), expected_crs=str(item_crs))
-
-            # Get resolution information at item level first if available
-            if src_dst.transform:
-                x_resolutions.append(abs(src_dst.transform.a))
-                y_resolutions.append(abs(src_dst.transform.e))
-
-            # If no transform, check for assets metadata
-            else:
-                for _, asset in item.get("assets", {}).items():
-                    # Get resolution from asset metadata
-                    if asset_transform := asset.get("proj:transform"):
-                        x_resolutions.append(abs(asset_transform[0]))
-                        y_resolutions.append(abs(asset_transform[4]))
-                    elif asset_shape := asset.get("proj:shape"):
-                        # Get resolution from asset shape
-                        if asset_shape[0] > 0 and asset_shape[1] > 0:
-                            x_resolutions.append(
-                                abs((spatial_extent.east - spatial_extent.west) / asset_shape[0])
-                            )
-                            y_resolutions.append(
-                                abs((spatial_extent.north - spatial_extent.south) / asset_shape[1])
-                            )
-                    else:
-                        # Default to 1024x1024 if no resolution is found
-                        x_resolutions.append(1024)
-                        y_resolutions.append(1024)
-
-    # Get the highest resolution (smallest pixel size)
-    x_resolution = min(x_resolutions) if x_resolutions else None
-    y_resolution = min(y_resolutions) if y_resolutions else None
-
-    # Get target CRS and bounds
-    crs = rasterio.crs.CRS.from_user_input(spatial_extent.crs or "epsg:4326")
-
-    # Convert bounds to the same CRS if needed
-    bbox = [
-        spatial_extent.west,
-        spatial_extent.south,
-        spatial_extent.east,
-        spatial_extent.north,
-    ]
-
-    # If item CRS is different from spatial_extent CRS, we need to reproject the resolution
-    if item_crs and item_crs != crs:
-        # Calculate approximate resolution in target CRS
-        # Get reprojected resolution using a small 1x1 degree box at the center of the bbox
-        center_x = (bbox[0] + bbox[2]) / 2
-        center_y = (bbox[1] + bbox[3]) / 2
-        src_box = [
-            center_x,
-            center_y,
-            center_x + x_resolution,
-            center_y + y_resolution,
-        ]
-        dst_box = transform_bounds(item_crs, crs, *src_box, densify_pts=21)
-
-        x_resolution = abs(dst_box[2] - dst_box[0])
-        y_resolution = abs(dst_box[3] - dst_box[1])
-
-    # Calculate dimensions based on bounds and resolution if not specified
-    if not width and not height:
-        if x_resolution and y_resolution:
-            width = int(round((bbox[2] - bbox[0]) / x_resolution))
-            height = int(round((bbox[3] - bbox[1]) / y_resolution))
-        else:
-            # Fallback to a reasonable default if resolution can't be determined
-            width = 1024
-            height = 1024
-
-    # Check if estimated pixel count exceeds maximum allowed
-    # Multiply by number of items since each item will be loaded into memory
-    pixel_count = int(width or 0) * int(height or 0) * len(items)
-    if pixel_count > processing_settings.max_pixels:
-        raise OutputLimitExceeded(
-            width, 
-            height, 
-            processing_settings.max_pixels,
-            items_count=len(items)
-        )
-
-    # Return all information needed for rendering
-    return Dims(
-        width=width,  # type: ignore
-        height=height,  # type: ignore
-        crs=crs,
-        bbox=bbox,
-    )
-
-
-def _reader(item: Dict[str, Any], bbox: BBox, **kwargs: Any) -> ImageData:
-    """
-    Read a STAC item and return an ImageData object.
-
-    Args:
-        item: STAC item dictionary
-        bbox: Bounding box to read
-        **kwargs: Additional keyword arguments to pass to the reader
-
-    Returns:
-        ImageData object
-    """
-    max_retries = 4
-    retry_delay = 1.0  # seconds
-    retries = 0
-
-    while True:
-        try:
-            with SimpleSTACReader(item) as src_dst:
-                return src_dst.part(bbox, **kwargs)
-        except RasterioIOError as e:
-            retries += 1
-            if retries >= max_retries:
-                # If we've reached max retries, re-raise the exception
-                raise
-            # Log the error and retry after a delay
-            print(
-                f"RasterioIOError encountered: {str(e)}. Retrying in {retry_delay} seconds... (Attempt {retries}/{max_retries})"
-            )
-            time.sleep(retry_delay)
-            # Increase delay for next retry (exponential backoff)
-            retry_delay *= 2
 
 
 @attr.s
@@ -255,7 +83,11 @@ class SimpleSTACReader(MultiBaseReader):
         self.crs = WGS84_CRS  # Per specification STAC items are in WGS84
 
         if proj := self.input.get("proj"):
-            crs_string = proj.get("code") or proj.get("epsg") or proj.get("wkt")
+            crs_string = str(
+                proj.get("code")
+                or (f"epsg:{proj.get('epsg')}" if proj.get("epsg") else None)
+                or proj.get("wkt")
+            )
             if all(
                 [
                     proj.get("transform"),
@@ -266,7 +98,7 @@ class SimpleSTACReader(MultiBaseReader):
                 self.height, self.width = proj.get("shape")
                 self.transform = proj.get("transform")
                 self.bounds = array_bounds(self.height, self.width, self.transform)
-                self.crs = rasterio.crs.CRS.from_string(crs_string)
+                self.crs = rasterio.crs.CRS.from_user_input(crs_string)
 
         self.minzoom = self.minzoom if self.minzoom is not None else self._minzoom
         self.maxzoom = self.maxzoom if self.maxzoom is not None else self._maxzoom
@@ -429,3 +261,236 @@ class SimpleSTACReader(MultiBaseReader):
             return img.apply_expression(expression)
 
         return img
+
+
+def _validate_input_parameters(
+    spatial_extent: BoundingBox,
+    items: List[Dict],
+    bands: Optional[list[str]],
+) -> None:
+    """Validate required input parameters."""
+    if not spatial_extent:
+        raise ProcessParameterMissing("spatial_extent")
+    if not items:
+        raise ProcessParameterMissing("items")
+    if not bands:
+        raise ProcessParameterMissing("bands")
+
+
+def _get_item_resolutions(
+    item: Dict,
+    src_dst: SimpleSTACReader,
+    spatial_extent: BoundingBox,
+) -> tuple[list[float], list[float]]:
+    """Get x and y resolutions from a STAC item."""
+    x_resolutions = []
+    y_resolutions = []
+
+    if src_dst.transform:
+        x_resolutions.append(abs(src_dst.transform.a))
+        y_resolutions.append(abs(src_dst.transform.e))
+    else:
+        for _, asset in item.get("assets", {}).items():
+            if asset_transform := asset.get("proj:transform"):
+                x_resolutions.append(abs(asset_transform[0]))
+                y_resolutions.append(abs(asset_transform[4]))
+            elif asset_shape := asset.get("proj:shape"):
+                if asset_shape[0] > 0 and asset_shape[1] > 0:
+                    x_resolutions.append(
+                        abs(
+                            (spatial_extent.east - spatial_extent.west) / asset_shape[0]
+                        )
+                    )
+                    y_resolutions.append(
+                        abs(
+                            (spatial_extent.north - spatial_extent.south)
+                            / asset_shape[1]
+                        )
+                    )
+            else:
+                x_resolutions.append(1024)
+                y_resolutions.append(1024)
+
+    return x_resolutions, y_resolutions
+
+
+def _reproject_resolution(
+    item_crs: rasterio.crs.CRS,
+    crs: rasterio.crs.CRS,
+    bbox: List[float],
+    x_resolution: Optional[float],
+    y_resolution: Optional[float],
+) -> tuple[Optional[float], Optional[float]]:
+    """Reproject resolution if CRS differs."""
+    if not (item_crs and item_crs != crs):
+        return x_resolution, y_resolution
+
+    center_x = (bbox[0] + bbox[2]) / 2
+    center_y = (bbox[1] + bbox[3]) / 2
+    src_box = [
+        center_x,
+        center_y,
+        center_x + x_resolution if x_resolution else 0,
+        center_y + y_resolution if y_resolution else 0,
+    ]
+    dst_box = transform_bounds(item_crs, crs, *src_box, densify_pts=21)
+
+    return (
+        abs(dst_box[2] - dst_box[0]) if x_resolution else None,
+        abs(dst_box[3] - dst_box[1]) if y_resolution else None,
+    )
+
+
+def _calculate_dimensions(
+    bbox: List[float],
+    x_resolution: Optional[float],
+    y_resolution: Optional[float],
+    width: Optional[int] = None,
+    height: Optional[int] = None,
+) -> tuple[int, int]:
+    """Calculate output dimensions."""
+    if width and height:
+        return width, height
+
+    if x_resolution and y_resolution:
+        width = int(round((bbox[2] - bbox[0]) / x_resolution))
+        height = int(round((bbox[3] - bbox[1]) / y_resolution))
+    else:
+        width = 1024
+        height = 1024
+
+    return width, height
+
+
+def _check_pixel_limit(
+    width: Optional[int],
+    height: Optional[int],
+    items: List[Dict],
+) -> None:
+    """Check if pixel count exceeds maximum allowed."""
+    from .settings import ProcessingSettings
+
+    processing_settings = ProcessingSettings()
+
+    width_int = int(width or 0)
+    height_int = int(height or 0)
+    pixel_count = width_int * height_int * len(items)
+    if pixel_count > processing_settings.max_pixels:
+        raise OutputLimitExceeded(
+            width_int,
+            height_int,
+            processing_settings.max_pixels,
+            items_count=len(items),
+        )
+
+
+def _estimate_output_dimensions(
+    items: List[Dict],
+    spatial_extent: BoundingBox,
+    bands: Optional[list[str]],
+    width: Optional[int] = None,
+    height: Optional[int] = None,
+) -> Dims:
+    """
+    Estimate output dimensions based on items and spatial extent.
+
+    Args:
+        items: List of STAC items
+        spatial_extent: Bounding box for the output
+        bands: List of band names to include
+        width: Optional user-specified width
+        height: Optional user-specified height
+
+    Returns:
+        Dictionary containing:
+            - width: Estimated or specified width
+            - height: Estimated or specified height
+            - crs: Target CRS to use
+            - bbox: Bounding box as a list [west, south, east, north]
+    """
+    _validate_input_parameters(spatial_extent, items, bands)
+
+    # Extract CRS and resolution information from items
+    item_crs: rasterio.crs.CRS = None
+    all_x_resolutions = []
+    all_y_resolutions = []
+
+    for item in items:
+        with SimpleSTACReader(item) as src_dst:
+            if item_crs is None:
+                item_crs = src_dst.crs
+            elif item_crs != src_dst.crs:
+                raise MixedCRSError(
+                    found_crs=str(src_dst.crs), expected_crs=str(item_crs)
+                )
+
+            x_res, y_res = _get_item_resolutions(item, src_dst, spatial_extent)
+            all_x_resolutions.extend(x_res)
+            all_y_resolutions.extend(y_res)
+
+    # Get the highest resolution (smallest pixel size)
+    x_resolution = min(all_x_resolutions) if all_x_resolutions else None
+    y_resolution = min(all_y_resolutions) if all_y_resolutions else None
+
+    # Get target CRS and bounds
+    crs = rasterio.crs.CRS.from_user_input(spatial_extent.crs or "epsg:4326")
+    bbox = [
+        spatial_extent.west,
+        spatial_extent.south,
+        spatial_extent.east,
+        spatial_extent.north,
+    ]
+
+    # Reproject resolution if needed
+    x_resolution, y_resolution = _reproject_resolution(
+        item_crs, crs, bbox, x_resolution, y_resolution
+    )
+
+    # Calculate dimensions
+    width, height = _calculate_dimensions(
+        bbox, x_resolution, y_resolution, width, height
+    )
+
+    # Check pixel limit
+    _check_pixel_limit(width, height, items)
+
+    return Dims(
+        width=width,  # type: ignore
+        height=height,  # type: ignore
+        crs=crs,
+        bbox=bbox,
+    )
+
+
+def _reader(item: Dict[str, Any], bbox: BBox, **kwargs: Any) -> ImageData:
+    """
+    Read a STAC item and return an ImageData object.
+
+    Args:
+        item: STAC item dictionary
+        bbox: Bounding box to read
+        **kwargs: Additional keyword arguments to pass to the reader
+
+    Returns:
+        ImageData object
+    """
+    max_retries = 4
+    retry_delay = 1.0  # seconds
+    retries = 0
+
+    while True:
+        try:
+            with SimpleSTACReader(item) as src_dst:
+                return src_dst.part(bbox, **kwargs)
+        except RasterioIOError as e:
+            retries += 1
+            if retries >= max_retries:
+                # If we've reached max retries, re-raise the exception
+                raise
+            # Log the error and retry after a delay
+            print(
+                f"RasterioIOError encountered: {str(e)}. Retrying in {retry_delay} seconds... (Attempt {retries}/{max_retries})"
+            )
+            time.sleep(retry_delay)
+            # Increase delay for next retry (exponential backoff)
+            retry_delay *= 2

--- a/titiler/openeo/stacapi.py
+++ b/titiler/openeo/stacapi.py
@@ -22,12 +22,12 @@ from rio_tiler.tasks import create_tasks
 from urllib3 import Retry
 
 from .errors import (
-    NoDataAvailable,
-    TemporalExtentEmpty,
     ItemsLimitExceeded,
-    UnsupportedSTACObject,
+    NoDataAvailable,
     OutputLimitExceeded,
     STACLoadError,
+    TemporalExtentEmpty,
+    UnsupportedSTACObject,
 )
 from .processes.implementations.data_model import LazyRasterStack, RasterStack
 from .processes.implementations.utils import _props_to_datename, to_rasterio_crs
@@ -507,9 +507,16 @@ class LoadCollection:
         # Check pixel limit before calling _estimate_output_dimensions
         # For test_load_collection_pixel_threshold
         if width and height:
-            pixel_count = width * height * len(items)
+            width_int = int(width)
+            height_int = int(height)
+            pixel_count = width_int * height_int * len(items)
             if pixel_count > processing_settings.max_pixels:
-                raise OutputLimitExceeded(width, height, processing_settings.max_pixels, items_count=len(items))
+                raise OutputLimitExceeded(
+                    width_int,
+                    height_int,
+                    processing_settings.max_pixels,
+                    items_count=len(items),
+                )
 
         # If bands parameter is missing, use the first asset from the first item
         if bands is None and items and "assets" in items[0]:
@@ -585,9 +592,16 @@ class LoadCollection:
         # Check pixel limit before calling _estimate_output_dimensions
         # For test_load_collection_and_reduce_pixel_threshold
         if width and height:
-            pixel_count = width * height * len(items)
+            width_int = int(width)
+            height_int = int(height)
+            pixel_count = width_int * height_int * len(items)
             if pixel_count > processing_settings.max_pixels:
-                raise OutputLimitExceeded(width, height, processing_settings.max_pixels, items_count=len(items))
+                raise OutputLimitExceeded(
+                    width_int,
+                    height_int,
+                    processing_settings.max_pixels,
+                    items_count=len(items),
+                )
 
         # If bands parameter is missing, use the first asset from the first item
         if bands is None and items and "assets" in items[0]:


### PR DESCRIPTION
This PR improves error handling when output size limits are exceeded and refactors the dimension estimation code for better maintainability.

Changes:
1. Fixed type errors in pixel count calculations:
   ```python
   width_int = int(width or 0)
   height_int = int(height or 0)
   pixel_count = width_int * height_int * len(items)
   ```

2. Enhanced error messages to show full calculation:
   ```json
   {
     "code": "OutputLimitExceeded",
     "message": "Estimated output size too large: 10008x10008 pixels x 5 items = 500,800,320 total pixels (max allowed: 100,000,000 pixels)"
   }
   ```

3. Added proper error classes:
   - `OutputLimitExceeded`: Now includes items count and total pixels
   - `ItemsLimitExceeded`: For when number of items exceeds maximum
   - `MixedCRSError`: For inconsistent coordinate reference systems
   - `STACLoadError`: For STAC loading failures
   - `UnsupportedSTACObject`: For unsupported STAC types

4. Refactored _estimate_output_dimensions into smaller functions:
   - _validate_input_parameters: Parameter validation
   - _get_item_resolutions: Resolution extraction
   - _reproject_resolution: CRS reprojection
   - _calculate_dimensions: Output dimension calculation
   - _check_pixel_limit: Pixel count validation

5. Added comprehensive test coverage:
   - Resolution extraction from different STAC metadata formats (proj:transform, proj:shape, fallback)
   - Error message formatting with thousands separators
   - Pixel count calculations for single and multiple items
   - Edge cases like None dimensions
   - Mixed CRS error handling
   - Default dimension calculation
   - Error message formatting in both _check_pixel_limit and _estimate_output_dimensions
   - Validation of input parameters
   - CRS reprojection with coordinate transformation

The improved error messages help users understand why limits were exceeded by showing:
- The dimensions (width x height)
- The number of items being loaded
- The total pixel count calculation with thousands separators
- The maximum allowed pixels