### PR TITLE
Update version to 0.2.1 and document release process

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes
 
+## [0.2.1] (Unreleased)
+
+### Changed
+
+* Fix load_collection to properly merge items from same date to maintain strict temporal dimension [#93](https://github.com/sentinel-hub/titiler-openeo/pull/93)
+* Improve error handling for output size limits with clearer error messages and proper pixel count calculation [#94](https://github.com/sentinel-hub/titiler-openeo/pull/94)
+
 ## [0.2.0] (2025-05-19)
 
 ### Added
@@ -35,3 +42,4 @@ Initial release of openEO by TiTiler
 
 [0.1.0]: https://github.com/sentinel-hub/titiler-openeo/releases/tag/0.1.0
 [0.2.0]: https://github.com/sentinel-hub/titiler-openeo/compare/v0.1.0...v0.2.0
+[0.2.1]: https://github.com/sentinel-hub/titiler-openeo/compare/v0.2.0...HEAD

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changes
 
-## [0.2.1] (Unreleased)
+## [0.2.1] (2025-05-21)
 
 ### Changed
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,63 @@
+# Release Process
+
+This document outlines the steps to create a new release of titiler-openeo.
+
+## Steps
+
+1. Create a new branch for the release:
+   ```bash
+   git checkout -b release/vX.Y.Z
+   ```
+
+2. Update version numbers in the following files:
+   ```
+   deployment/k8s/charts/Chart.yaml:
+   - Update appVersion to new version (e.g., 0.2.1)
+   - Increment version by 0.0.1 (e.g., 0.9.0 -> 0.9.1)
+
+   pyproject.toml:
+   - Update current_version under [tool.bumpversion]
+
+   titiler/openeo/__init__.py:
+   - Update __version__
+   ```
+
+3. Update CHANGES.md:
+   - Change the "(Unreleased)" text to the current date
+   - Ensure all changes are properly documented under the new version
+   - Keep the format consistent with previous entries
+
+4. Create a Pull Request:
+   - Push your branch to GitHub
+   - Create a PR titled "Release vX.Y.Z"
+   - Include a summary of the changes in the PR description
+   - Wait for approval and merge
+
+5. After the PR is merged, create a git tag and push:
+   ```bash
+   git checkout main
+   git pull
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+
+6. Create a GitHub release:
+   - Go to https://github.com/sentinel-hub/titiler-openeo/releases
+   - Click "Draft a new release"
+   - Choose the tag you just created
+   - Title the release "vX.Y.Z"
+   - Copy the changelog entries for this version into the description
+   - Publish the release
+
+## Version Numbering
+
+We follow semantic versioning (MAJOR.MINOR.PATCH):
+- MAJOR version for incompatible API changes
+- MINOR version for new functionality in a backward compatible manner
+- PATCH version for backward compatible bug fixes
+
+## Helm Chart Versioning
+
+The Helm chart version (in Chart.yaml) follows its own versioning scheme:
+- Increment the chart version by 0.0.1 for each release
+- Update appVersion to match the new titiler-openeo version

--- a/deployment/k8s/charts/Chart.yaml
+++ b/deployment/k8s/charts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 0.2.0
+appVersion: 0.2.1
 description: OpenEO by TiTiler
 name: titiler-openeo
-version: 0.9.0
+version: 0.9.1
 icon: https://raw.githubusercontent.com/developmentseed/titiler/main/docs/logos/TiTiler_logo_small.png
 maintainers:
   - name: DevelopmentSeed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ explicit_package_bases = true
 max-complexity = 14
 
 [tool.bumpversion]
-current_version = "0.2.0"
+current_version = "0.2.1"
 search = "{current_version}"
 replace = "{new_version}"
 regex = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ explicit_package_bases = true
 max-complexity = 14
 
 [tool.bumpversion]
-current_version = "0.2.2"
+current_version = "0.2.1"
 search = "{current_version}"
 replace = "{new_version}"
 regex = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ explicit_package_bases = true
 max-complexity = 14
 
 [tool.bumpversion]
-current_version = "0.2.1"
+current_version = "0.2.2"
 search = "{current_version}"
 replace = "{new_version}"
 regex = false

--- a/titiler/openeo/__init__.py
+++ b/titiler/openeo/__init__.py
@@ -1,3 +1,3 @@
 """titiler.openeo"""
 
-__version__ = "0.2.2"
+__version__ = "0.2.1"

--- a/titiler/openeo/__init__.py
+++ b/titiler/openeo/__init__.py
@@ -1,3 +1,3 @@
 """titiler.openeo"""
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"

--- a/titiler/openeo/__init__.py
+++ b/titiler/openeo/__init__.py
@@ -1,3 +1,3 @@
 """titiler.openeo"""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"


### PR DESCRIPTION
Bump the version to 0.2.1, update the changelog with recent fixes, and document the release process in a new file.