### PR TITLE
Add force-release functionality for tile assignment and update documentation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## [0.2.1] (2025-05-21)
 
+### Added
+
+* Added force-release functionality for tile assignment to release tiles regardless of state
+
 ### Changed
 
 * Fix load_collection to properly merge items from same date to maintain strict temporal dimension [#93](https://github.com/sentinel-hub/titiler-openeo/pull/93)

--- a/tests/test_tile_assignment_process.py
+++ b/tests/test_tile_assignment_process.py
@@ -10,7 +10,6 @@ from titiler.openeo.services.base import (
     TileNotAssignedError,
 )
 
-
 class MockTileStore(TileAssignmentStore):
     """Mock tile store for testing."""
 
@@ -78,17 +77,30 @@ class MockTileStore(TileAssignmentStore):
 
         raise TileNotAssignedError("No tile assigned")
 
+    def force_release_tile(self, service_id, x, y, z):
+        """Mock force release tile."""
+        # Find tile by coordinates
+        for key, tile in self.assignments.items():
+            if (
+                key.startswith(f"{service_id}:")
+                and tile["x"] == x
+                and tile["y"] == y
+                and tile["z"] == z
+            ):
+                released_tile = {**tile, "stage": "released"}
+                del self.assignments[key]
+                return released_tile
+        raise TileNotAssignedError("No tile found with these coordinates")
+
     def get_user_tile(self, service_id, user_id):
         """Mock get user tile."""
         key = f"{service_id}:{user_id}"
         return self.assignments.get(key)
 
-
 @pytest.fixture
 def store():
     """Create a mock tile store."""
     return MockTileStore()
-
 
 def test_claim_tile(store):
     """Test claiming a tile through the process."""
@@ -107,7 +119,6 @@ def test_claim_tile(store):
     assert result["y"] == 0
     assert result["z"] == 12
     assert result["stage"] == "claimed"
-
 
 def test_release_tile(store):
     """Test releasing a tile through the process."""
@@ -134,7 +145,6 @@ def test_release_tile(store):
     )
 
     assert result["stage"] == "released"
-
 
 def test_submit_tile(store):
     """Test submitting a tile through the process."""
@@ -165,7 +175,6 @@ def test_submit_tile(store):
     assert result["z"] == claimed["z"]
     assert result["stage"] == "submitted"
 
-
 def test_invalid_stage(store):
     """Test invalid stage parameter."""
     with pytest.raises(ValueError, match="Invalid stage"):
@@ -178,7 +187,6 @@ def test_invalid_stage(store):
             service_id="test_service",
             user_id="test_user",
         )
-
 
 def test_no_tiles_available(store):
     """Test when no tiles are available."""
@@ -193,7 +201,6 @@ def test_no_tiles_available(store):
             user_id="test_user",
         )
 
-
 def test_release_not_assigned(store):
     """Test releasing a tile that isn't assigned."""
     with pytest.raises(TileNotAssignedError):
@@ -206,7 +213,6 @@ def test_release_not_assigned(store):
             service_id="test_service",
             user_id="test_user",
         )
-
 
 def test_submit_not_assigned(store):
     """Test submitting a tile that isn't assigned."""
@@ -221,9 +227,8 @@ def test_submit_not_assigned(store):
             user_id="test_user",
         )
 
-
 def test_unauthorized_release(store):
-    """Test releasing another user's tile with control_user=True."""
+    """Test releasing another user's tile."""
     # First user claims a tile
     tile_assignment(
         zoom=12,
@@ -245,12 +250,10 @@ def test_unauthorized_release(store):
             store=store,
             service_id="test_service",
             user_id="user2",
-            control_user=True,
         )
 
-
 def test_unauthorized_submit(store):
-    """Test submitting another user's tile with control_user=True."""
+    """Test submitting another user's tile."""
     # First user claims a tile
     tile_assignment(
         zoom=12,
@@ -272,13 +275,11 @@ def test_unauthorized_submit(store):
             store=store,
             service_id="test_service",
             user_id="user2",
-            control_user=True,
         )
 
-
-def test_control_user_disabled(store):
-    """Test operations on another user's tile with control_user=False."""
-    # First user claims a tile
+def test_force_release_submitted_tile(store):
+    """Test force-releasing a submitted tile."""
+    # First claim and submit a tile
     claimed = tile_assignment(
         zoom=12,
         x_range=(0, 1),
@@ -286,37 +287,8 @@ def test_control_user_disabled(store):
         stage="claim",
         store=store,
         service_id="test_service",
-        user_id="user1",
+        user_id="test_user",
     )
-
-    # Second user can release it with control_user=False
-    released = tile_assignment(
-        zoom=12,
-        x_range=(0, 1),
-        y_range=(0, 1),
-        stage="release",
-        store=store,
-        service_id="test_service",
-        user_id="user2",
-        control_user=False,
-    )
-
-    assert released["x"] == claimed["x"]
-    assert released["y"] == claimed["y"]
-    assert released["stage"] == "released"
-
-    # First user claims a new tile
-    claimed = tile_assignment(
-        zoom=12,
-        x_range=(0, 1),
-        y_range=(0, 1),
-        stage="claim",
-        store=store,
-        service_id="test_service",
-        user_id="user1",
-    )
-
-    # Second user can submit it with control_user=False
     submitted = tile_assignment(
         zoom=12,
         x_range=(0, 1),
@@ -324,44 +296,36 @@ def test_control_user_disabled(store):
         stage="submit",
         store=store,
         service_id="test_service",
-        user_id="user2",
-        control_user=False,
-    )
-
-    assert submitted["x"] == claimed["x"]
-    assert submitted["y"] == claimed["y"]
-    assert submitted["stage"] == "submitted"
-
-
-def test_release_submitted_tile(store):
-    """Test releasing a submitted tile."""
-    # First claim and submit a tile
-    tile_assignment(
-        zoom=12,
-        x_range=(0, 1),
-        y_range=(0, 1),
-        stage="claim",
-        store=store,
-        service_id="test_service",
         user_id="test_user",
     )
-    tile_assignment(
+
+    # Force release the tile - this should work even though it's submitted
+    result = tile_assignment(
         zoom=12,
         x_range=(0, 1),
         y_range=(0, 1),
-        stage="submit",
+        stage="force-release",
         store=store,
         service_id="test_service",
         user_id="test_user",
     )
 
-    # Try to release it
-    with pytest.raises(TileAlreadyLockedError):
+    assert result["x"] == claimed["x"]
+    assert result["y"] == claimed["y"]
+    assert result["z"] == claimed["z"]
+    assert result["stage"] == "released"
+
+    # Verify tile is gone
+    assert store.get_user_tile("test_service", "test_user") is None
+
+def test_force_release_nonexistent_tile(store):
+    """Test force-releasing a tile that doesn't exist."""
+    with pytest.raises(TileNotAssignedError):
         tile_assignment(
             zoom=12,
             x_range=(0, 1),
             y_range=(0, 1),
-            stage="release",
+            stage="force-release",
             store=store,
             service_id="test_service",
             user_id="test_user",

--- a/tests/test_tile_assignment_process.py
+++ b/tests/test_tile_assignment_process.py
@@ -10,6 +10,7 @@ from titiler.openeo.services.base import (
     TileNotAssignedError,
 )
 
+
 class MockTileStore(TileAssignmentStore):
     """Mock tile store for testing."""
 
@@ -97,10 +98,12 @@ class MockTileStore(TileAssignmentStore):
         key = f"{service_id}:{user_id}"
         return self.assignments.get(key)
 
+
 @pytest.fixture
 def store():
     """Create a mock tile store."""
     return MockTileStore()
+
 
 def test_claim_tile(store):
     """Test claiming a tile through the process."""
@@ -119,6 +122,7 @@ def test_claim_tile(store):
     assert result["y"] == 0
     assert result["z"] == 12
     assert result["stage"] == "claimed"
+
 
 def test_release_tile(store):
     """Test releasing a tile through the process."""
@@ -145,6 +149,7 @@ def test_release_tile(store):
     )
 
     assert result["stage"] == "released"
+
 
 def test_submit_tile(store):
     """Test submitting a tile through the process."""
@@ -175,6 +180,7 @@ def test_submit_tile(store):
     assert result["z"] == claimed["z"]
     assert result["stage"] == "submitted"
 
+
 def test_invalid_stage(store):
     """Test invalid stage parameter."""
     with pytest.raises(ValueError, match="Invalid stage"):
@@ -187,6 +193,7 @@ def test_invalid_stage(store):
             service_id="test_service",
             user_id="test_user",
         )
+
 
 def test_no_tiles_available(store):
     """Test when no tiles are available."""
@@ -201,6 +208,7 @@ def test_no_tiles_available(store):
             user_id="test_user",
         )
 
+
 def test_release_not_assigned(store):
     """Test releasing a tile that isn't assigned."""
     with pytest.raises(TileNotAssignedError):
@@ -214,6 +222,7 @@ def test_release_not_assigned(store):
             user_id="test_user",
         )
 
+
 def test_submit_not_assigned(store):
     """Test submitting a tile that isn't assigned."""
     with pytest.raises(TileNotAssignedError):
@@ -226,6 +235,7 @@ def test_submit_not_assigned(store):
             service_id="test_service",
             user_id="test_user",
         )
+
 
 def test_unauthorized_release(store):
     """Test releasing another user's tile."""
@@ -252,6 +262,7 @@ def test_unauthorized_release(store):
             user_id="user2",
         )
 
+
 def test_unauthorized_submit(store):
     """Test submitting another user's tile."""
     # First user claims a tile
@@ -277,6 +288,7 @@ def test_unauthorized_submit(store):
             user_id="user2",
         )
 
+
 def test_force_release_submitted_tile(store):
     """Test force-releasing a submitted tile."""
     # First claim and submit a tile
@@ -289,7 +301,7 @@ def test_force_release_submitted_tile(store):
         service_id="test_service",
         user_id="test_user",
     )
-    submitted = tile_assignment(
+    tile_assignment(
         zoom=12,
         x_range=(0, 1),
         y_range=(0, 1),
@@ -317,6 +329,7 @@ def test_force_release_submitted_tile(store):
 
     # Verify tile is gone
     assert store.get_user_tile("test_service", "test_user") is None
+
 
 def test_force_release_nonexistent_tile(store):
     """Test force-releasing a tile that doesn't exist."""

--- a/tests/test_tile_assignment_user.py
+++ b/tests/test_tile_assignment_user.py
@@ -49,6 +49,10 @@ class MockTileStore(TileAssignmentStore):
         self.last_user_id = user_id
         return {"x": 1000, "y": 2000, "z": 12, "stage": "submitted"}
 
+    def force_release_tile(self, service_id: str, x: int, y: int, z: int) -> Dict:
+        """Mock force-releasing a tile."""
+        return {"x": x, "y": y, "z": z, "stage": "released"}
+
 
 def test_tile_assignment_user_parameter():
     """Test that tile_assignment correctly handles the user parameter."""

--- a/tests/test_tile_store.py
+++ b/tests/test_tile_store.py
@@ -237,10 +237,7 @@ def test_force_release_tile(tile_store):
 
     # Force release should work even on submitted tiles
     released = tile_store.force_release_tile(
-        service_id="test_service",
-        x=submitted["x"],
-        y=submitted["y"],
-        z=submitted["z"]
+        service_id="test_service", x=submitted["x"], y=submitted["y"], z=submitted["z"]
     )
 
     # Verify release response
@@ -250,17 +247,16 @@ def test_force_release_tile(tile_store):
     assert released["stage"] == "released"
 
     # Verify tile is no longer assigned
-    assert tile_store.get_user_tile(service_id="test_service", user_id="test_user") is None
+    assert (
+        tile_store.get_user_tile(service_id="test_service", user_id="test_user") is None
+    )
+
 
 def test_force_release_nonexistent_tile(tile_store):
     """Test force-releasing a tile that doesn't exist."""
     with pytest.raises(TileNotAssignedError):
-        tile_store.force_release_tile(
-            service_id="test_service",
-            x=0,
-            y=0,
-            z=12
-        )
+        tile_store.force_release_tile(service_id="test_service", x=0, y=0, z=12)
+
 
 def test_complex_scenario(tile_store):
     """Test a complex scenario with multiple users and various operations."""

--- a/titiler/openeo/processes/data/tile_assignment.json
+++ b/titiler/openeo/processes/data/tile_assignment.json
@@ -43,7 +43,7 @@
             "description": "Stage of tile assignment",
             "schema": {
                 "type": "string",
-                "enum": ["claim", "release", "submit"]
+                "enum": ["claim", "release", "submit", "force-release"]
             }
         },
         {
@@ -66,15 +66,6 @@
             "schema": {
                 "type": "string"
             }
-        },
-        {
-            "name": "control_user",
-            "description": "Whether to enforce user-specific tile control",
-            "schema": {
-                "type": "boolean"
-            },
-            "optional": true,
-            "default": true
         }
     ],
     "returns": {
@@ -87,7 +78,7 @@
                 "z": {"type": "integer"},
                 "stage": {
                     "type": "string",
-                    "enum": ["claimed", "released", "submitted"]
+                    "enum": ["claimed", "released", "submitted", "force-released"]
                 },
                 "user_id": {"type": "string"}
             },

--- a/titiler/openeo/processes/implementations/tile_assignment.py
+++ b/titiler/openeo/processes/implementations/tile_assignment.py
@@ -54,10 +54,7 @@ def tile_assignment(
         else:  # force-release
             # Use the current tile's coordinates for force release
             return store.force_release_tile(
-                service_id,
-                current_tile["x"],
-                current_tile["y"],
-                current_tile["z"]
+                service_id, current_tile["x"], current_tile["y"], current_tile["z"]
             )
     else:
         raise ValueError(f"Invalid stage: {stage}")

--- a/titiler/openeo/processes/implementations/tile_assignment.py
+++ b/titiler/openeo/processes/implementations/tile_assignment.py
@@ -17,7 +17,6 @@ def tile_assignment(
     store: TileAssignmentStore,
     service_id: str,
     user_id: str,
-    control_user: bool = True,  # Optional parameter to enable user control
 ) -> Dict[str, Any]:
     """Assign XYZ tiles to users.
 
@@ -25,13 +24,10 @@ def tile_assignment(
         zoom: Fixed zoom level
         x_range: Range of X values [min, max]
         y_range: Range of Y values [min, max]
-        stage: Stage of assignment (claim/release/submit)
+        stage: Stage of assignment (claim/release/submit/force-release)
         store: Tile assignment store instance
         service_id: Current service ID
         user_id: Current user ID
-        control_user: Enable user verification for release/submit operations.
-                    When True, only the user who claimed a tile can release/submit it.
-                    Defaults to True.
 
     Returns:
         Dict containing x, y, z coordinates and stage
@@ -44,24 +40,24 @@ def tile_assignment(
     """
     if stage == "claim":
         return store.claim_tile(service_id, user_id, zoom, x_range, y_range)
-    elif stage in ["release", "submit"]:
-        if control_user:
-            # Get current tile assignment to check ownership
-            current_tile = store.get_user_tile(service_id, user_id)
-            if not current_tile:
-                raise TileNotAssignedError(f"No tile assigned to user {user_id}")
-
-            # Get tile's assigned user
-            tile_user = current_tile.get("user_id")
-            if tile_user != user_id:
-                raise TileNotAssignedError(
-                    f"Tile is assigned to user {tile_user}, not {user_id}"
-                )
+    elif stage in ["release", "submit", "force-release"]:
+        # Get current tile assignment
+        current_tile = store.get_user_tile(service_id, user_id)
+        if not current_tile:
+            raise TileNotAssignedError(f"No tile assigned to user {user_id}")
 
         # Perform the requested operation
         if stage == "release":
             return store.release_tile(service_id, user_id)
-        else:  # submit
+        elif stage == "submit":
             return store.submit_tile(service_id, user_id)
+        else:  # force-release
+            # Use the current tile's coordinates for force release
+            return store.force_release_tile(
+                service_id,
+                current_tile["x"],
+                current_tile["y"],
+                current_tile["z"]
+            )
     else:
         raise ValueError(f"Invalid stage: {stage}")

--- a/titiler/openeo/services/base.py
+++ b/titiler/openeo/services/base.py
@@ -104,6 +104,26 @@ class TileAssignmentStore(metaclass=abc.ABCMeta):
         ...
 
     @abc.abstractmethod
+    def force_release_tile(
+        self, service_id: str, x: int, y: int, z: int
+    ) -> Dict[str, Any]:
+        """Force release a tile regardless of its state.
+
+        Args:
+            service_id: The service identifier
+            x: The tile x coordinate
+            y: The tile y coordinate
+            z: The tile z coordinate
+
+        Returns:
+            Dict with x, y, z, and stage of released tile
+
+        Raises:
+            TileNotAssignedError: When tile does not exist
+        """
+        ...
+
+    @abc.abstractmethod
     def get_user_tile(self, service_id: str, user_id: str) -> Optional[Dict[str, Any]]:
         """Get a user's currently assigned tile.
 

--- a/titiler/openeo/services/sqlalchemy_tile.py
+++ b/titiler/openeo/services/sqlalchemy_tile.py
@@ -220,3 +220,40 @@ class SQLAlchemyTileStore(TileAssignmentStore):
                 "z": tile.z,
                 "stage": "submitted",
             }
+
+    def force_release_tile(
+        self,
+        service_id: str,
+        x: int,
+        y: int,
+        z: int,
+    ) -> Dict[str, Any]:
+        """Force release a tile regardless of its state."""
+        with Session(self._engine) as session:
+            tile = session.execute(
+                select(TileAssignment).where(
+                    TileAssignment.service_id == service_id,
+                    TileAssignment.x == x,
+                    TileAssignment.y == y,
+                    TileAssignment.z == z,
+                )
+            ).scalar_one_or_none()
+
+            if not tile:
+                raise TileNotAssignedError(
+                    f"No tile assignment found for {x},{y},{z} in service {service_id}"
+                )
+
+            # Store tile info before deletion
+            tile_info = {
+                "x": tile.x,
+                "y": tile.y,
+                "z": tile.z,
+                "stage": "released",
+            }
+
+            # Delete the tile assignment regardless of its state
+            session.delete(tile)
+            session.commit()
+
+            return tile_info


### PR DESCRIPTION
- Implemented force-release option in tile assignment process to allow users to release tiles regardless of their current state.
- Updated JSON schema and process implementation to include "force-release" stage.
- Enhanced documentation to reflect changes in tile assignment behavior.
- Added tests for force-releasing tiles in various scenarios.