### PR TITLE
Refactor STAC reader and enhance output dimension handling

### DIFF
--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -8,6 +8,7 @@ import rasterio
 from titiler.openeo.errors import OutputLimitExceeded
 from titiler.openeo.models import SpatialExtent
 from titiler.openeo.reader import (
+    SimpleSTACReader,
     _calculate_dimensions,
     _check_pixel_limit,
     _estimate_output_dimensions,
@@ -131,9 +132,6 @@ def sample_stac_item():
             },
         },
     }
-
-
-from titiler.openeo.reader import SimpleSTACReader
 
 
 def test_get_assets_resolutions(sample_stac_item):

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, Optional
 
-import attr
+import copy
 import pytest
 import rasterio
 from openeo_pg_parser_networkx.pg_schema import BoundingBox
@@ -14,7 +14,7 @@ from titiler.openeo.reader import (
     _calculate_dimensions,
     _check_pixel_limit,
     _estimate_output_dimensions,
-    _get_item_resolutions,
+    _get_assets_resolutions,
     _reproject_resolution,
 )
 
@@ -23,117 +23,96 @@ from titiler.openeo.reader import (
 def sample_stac_item():
     """Create a sample STAC item."""
     return {
+        "type": "Feature",
+        "stac_version": "1.0.0",
+        "stac_extensions": [
+            "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
+            "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        ],
         "id": "test-item",
         "bbox": [0, 0, 10, 10],
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]]],
+        },
+        "properties": {
+            "datetime": "2025-01-01T00:00:00Z",
+            "proj:epsg": 4326,
+            "proj:shape": [100, 100],
+            "proj:transform": [0.1, 0, 0, 0, -0.1, 10, 0, 0, 1],
+        },
         "assets": {
             "B01": {
                 "href": "https://example.com/B01.tif",
-                "proj:transform": [1, 0, 0, 0, -1, 0, 0, 0, 1],
-            }
+                "type": "image/tiff; application=geotiff",
+                "proj:epsg": 32631,
+                "proj:shape": [1000, 1000],
+                "proj:transform": [10, 0, 0, 0, -10, 0, 0, 0, 1],
+            },
+            "B02": {
+                "href": "https://example.com/B02.tif",
+                "type": "image/tiff; application=geotiff",
+                "proj:shape": [2000, 2000],
+            },
         },
     }
 
 
-@attr.s(auto_attribs=True)
-class MockSimpleSTACReader:
-    """Mock SimpleSTACReader."""
-
-    input: Dict[str, Any]
-    _bounds: Optional[list] = attr.ib(init=False)
-    _transform: Optional[Affine] = attr.ib(init=False)
-    _crs: Optional[rasterio.crs.CRS] = attr.ib(init=False)
-
-    def __attrs_post_init__(self) -> None:
-        """Initialize reader attributes."""
-        self._bounds = self.input["bbox"]
-        self._crs = rasterio.crs.CRS.from_epsg(4326)
-        self._transform = None
-
-        # Initialize transform from asset if available
-        if asset := self.input["assets"].get("B01"):
-            if "proj:transform" in asset:
-                t = asset["proj:transform"]
-                self._transform = Affine(t[0], t[1], t[2], t[3], t[4], t[5])
-            elif "proj:shape" in asset:
-                # Create transform from bounds and shape
-                west, south, east, north = self._bounds
-                width, height = asset["proj:shape"]
-                self._transform = from_bounds(west, south, east, north, width, height)
-
-    @property
-    def bounds(self):
-        """Return item bounds."""
-        return self._bounds
-
-    @property
-    def transform(self):
-        """Return transform."""
-        return self._transform
-
-    @property
-    def crs(self):
-        """Return CRS."""
-        return self._crs
-
-    def __enter__(self):
-        """Context manager enter method."""
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        """Context manager exit method."""
-        pass
+from titiler.openeo.reader import SimpleSTACReader
 
 
-@pytest.fixture
-def sample_spatial_extent():
-    """Create a sample spatial extent."""
-    return SpatialExtent(west=0, south=0, east=10, north=10, crs="EPSG:4326")
-
-
-def test_get_item_resolutions(sample_stac_item):
+def test_get_assets_resolutions(sample_stac_item):
     """Test resolution extraction from STAC item."""
-    # Test with proj:transform
-    with MockSimpleSTACReader(sample_stac_item) as src_dst:
-        x_res, y_res = _get_item_resolutions(sample_stac_item, src_dst)
-        assert len(x_res) > 0
-        assert len(y_res) > 0
-        assert x_res[0] == 1.0  # From proj:transform
-        assert y_res[0] == 1.0  # From proj:transform
+    # Test with all bands
+    with SimpleSTACReader(sample_stac_item) as src_dst:
+        resolutions = _get_assets_resolutions(sample_stac_item, src_dst)
 
-    # Test with proj:shape
-    item_with_shape = {
-        "id": "test-item",
-        "bbox": [0, 0, 10, 10],
-        "assets": {
-            "B01": {
-                "href": "https://example.com/B01.tif",
-                "proj:shape": [100, 100],
-            }
-        },
-    }
-    with MockSimpleSTACReader(item_with_shape) as src_dst:
-        x_res, y_res = _get_item_resolutions(item_with_shape, src_dst)
-        assert len(x_res) > 0
-        assert len(y_res) > 0
-        assert x_res[0] == 0.1  # 10/100
-        assert y_res[0] == 0.1  # 10/100
+        # Check B01 (with explicit CRS and transform)
+        assert "B01" in resolutions
+        x_res, y_res, crs = resolutions["B01"]
+        assert x_res == 10.0
+        assert y_res == 10.0
+        assert crs.to_epsg() == 32631
 
-    # Test fallback to default resolution
+        # Check B02 (with only transform)
+        assert "B02" in resolutions
+        x_res, y_res, crs = resolutions["B02"]
+        assert x_res == 0.1
+        assert y_res == 0.1
+        assert crs.to_epsg() == 4326  # Using default item CRS
+
+    # Test with specific bands
+    with SimpleSTACReader(sample_stac_item) as src_dst:
+        resolutions = _get_assets_resolutions(sample_stac_item, src_dst, bands=["B01"])
+        assert len(resolutions) == 1
+        assert "B01" in resolutions
+        assert "B02" not in resolutions
+
+    # Test with missing bands
+    with SimpleSTACReader(sample_stac_item) as src_dst:
+        resolutions = _get_assets_resolutions(sample_stac_item, src_dst, bands=["B03"])
+        assert len(resolutions) == 0
+
+    # Test with item without any projection info
     item_without_metadata = {
+        "type": "Feature",
+        "stac_version": "1.0.0",
         "id": "test-item",
         "bbox": [0, 0, 10, 10],
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]]],
+        },
+        "properties": {"datetime": "2025-01-01T00:00:00Z"},
         "assets": {
             "B01": {
                 "href": "https://example.com/B01.tif",
             }
         },
     }
-    with MockSimpleSTACReader(item_without_metadata) as src_dst:
-        x_res, y_res = _get_item_resolutions(item_without_metadata, src_dst)
-        assert len(x_res) > 0
-        assert len(y_res) > 0
-        assert x_res[0] == 1.0  # Default resolution
-        assert y_res[0] == 1.0  # Default resolution
+    with SimpleSTACReader(item_without_metadata) as src_dst:
+        resolutions = _get_assets_resolutions(item_without_metadata, src_dst)
+        assert "B01" not in resolutions
 
 
 def test_reproject_resolution():
@@ -206,19 +185,19 @@ def test_calculate_dimensions():
 def test_check_pixel_limit():
     """Test pixel count limit check."""
     # Test within limit
-    _check_pixel_limit(100, 100, [{"id": "item1"}, {"id": "item2"}])
+    _check_pixel_limit(100, 100, 2, 2)
 
     # Test exceeding limit with multiple items
     with pytest.raises(OutputLimitExceeded) as exc_info:
-        _check_pixel_limit(10000, 10000, [{"id": "item1"}, {"id": "item2"}])
+        _check_pixel_limit(10000, 10000, 2, 3)  # 600 million pixels
     error_msg = str(exc_info.value)
-    assert "10000x10000 pixels x 2 items" in error_msg
-    assert "200,000,000 total pixels" in error_msg  # Test thousands separator
+    assert "10000x10000 pixels x 2 items x 3 bands" in error_msg
+    assert "600,000,000 total pixels" in error_msg  # Test thousands separator
     assert "max allowed: 100,000,000 pixels" in error_msg
 
     # Test exceeding limit with single item
     with pytest.raises(OutputLimitExceeded) as exc_info:
-        _check_pixel_limit(15000, 15000, [{"id": "item1"}])  # 225 million pixels
+        _check_pixel_limit(15000, 15000, 1, 1)  # 225 million pixels
     error_msg = str(exc_info.value)
     assert "15000x15000 pixels" in error_msg
     assert "225,000,000 total pixels" in error_msg
@@ -226,99 +205,94 @@ def test_check_pixel_limit():
 
     # Test with None dimensions (should convert to 0)
     width_int, height_int = None, None
-    items = [{"id": "item1"}, {"id": "item2"}]
     _check_pixel_limit(
-        width_int, height_int, items
+        width_int, height_int, 2, 1
     )  # Should not raise error for 0 pixels
 
 
-def test_estimate_output_dimensions(
-    sample_stac_item, sample_spatial_extent, monkeypatch
-):
+def test_estimate_output_dimensions(sample_stac_item):
     """Test complete output dimension estimation."""
-    monkeypatch.setattr("titiler.openeo.reader.SimpleSTACReader", MockSimpleSTACReader)
-
-    # Test with full extent
-    result = _estimate_output_dimensions(
-        [sample_stac_item],
-        sample_spatial_extent,
-        ["B01"],
-    )
-    assert "width" in result
-    assert "height" in result
-    assert "crs" in result
-    assert "bbox" in result
-    assert result["width"] == 10
-    assert result["height"] == 10
+    # Test with full extent using UTM asset
+    full_extent = SpatialExtent(west=0, south=0, east=5, north=5, crs="EPSG:4326")
+    with pytest.raises(OutputLimitExceeded) as exc_info:
+        _estimate_output_dimensions(
+            [sample_stac_item],
+            full_extent,
+            ["B01"],
+        )
 
     # Test with cropped extent
-    cropped_extent = BoundingBox(west=0, south=0, east=5, north=5, crs="EPSG:4326")
+    cropped_extent = SpatialExtent(
+        west=4.9, south=4.9, east=5, north=5, crs="EPSG:4326"
+    )
     result_cropped = _estimate_output_dimensions(
         [sample_stac_item],
         cropped_extent,
         ["B01"],
     )
-    # Dimensions should be half when extent is halved
-    assert result_cropped["width"] == result["width"] // 2
-    assert result_cropped["height"] == result["height"] // 2
+
+    assert "width" in result_cropped
+    assert "height" in result_cropped
+    assert "crs" in result_cropped
+    assert "bbox" in result_cropped
+    assert result_cropped["crs"].to_epsg() == 4326  # Target CRS is from spatial_extent
+    # Dimensions should be based on the B01 asset's transform after reprojection
+    assert result_cropped["width"] > 0
+    assert result_cropped["height"] > 0
 
     # Test with specified width
     result = _estimate_output_dimensions(
         [sample_stac_item],
-        sample_spatial_extent,
+        full_extent,
         ["B01"],
-        width=100,
+        width=1024,
     )
-    assert result["width"] == 100
+    assert result["width"] == 1024
     assert result["height"] > 0  # Should be proportional
 
     # Test with specified height
     result = _estimate_output_dimensions(
         [sample_stac_item],
-        sample_spatial_extent,
+        full_extent,
         ["B01"],
-        height=100,
+        height=1024,
     )
-    assert result["height"] == 100
+    assert result["height"] == 1024
     assert result["width"] > 0  # Should be proportional
-
-    # Test output size limit with single item
-    with pytest.raises(OutputLimitExceeded) as exc_info:
-        _estimate_output_dimensions(
-            [sample_stac_item],
-            sample_spatial_extent,
-            ["B01"],
-            width=15000,
-            height=15000,
-        )
-    error_msg = str(exc_info.value)
-    assert "15000x15000 pixels" in error_msg
-    assert "225,000,000 total pixels" in error_msg
-    assert "max allowed: 100,000,000 pixels" in error_msg
 
     # Test output size limit with multiple items
     with pytest.raises(OutputLimitExceeded) as exc_info:
+        item2 = copy.deepcopy(sample_stac_item)
+        item2["id"] = "test-item-2"
+        item2["properties"]["datetime"] = "2025-01-02T00:00:00Z"
         _estimate_output_dimensions(
-            [sample_stac_item, sample_stac_item.copy()],
-            sample_spatial_extent,
+            [sample_stac_item, item2],
+            full_extent,
             ["B01"],
             width=10000,
             height=10000,
         )
     error_msg = str(exc_info.value)
-    assert "10000x10000 pixels x 2 items" in error_msg
+    assert "10000x10000 pixels x 2 items x 1 bands" in error_msg
     assert "200,000,000 total pixels" in error_msg
     assert "max allowed: 100,000,000 pixels" in error_msg
 
     # Test with default dimensions
+    real_extent = SpatialExtent(
+        crs="EPSG:32631",
+        west= 0,
+        south=0,
+        east=10000,
+        north=10000,
+    )
     result = _estimate_output_dimensions(
         [sample_stac_item],
-        sample_spatial_extent,
+        real_extent,
         ["B01"],
         width=None,
         height=None,
     )
     assert isinstance(result["width"], int)
     assert isinstance(result["height"], int)
-    assert result["width"] > 0
-    assert result["height"] > 0
+    assert result["width"] == 1000  # Based on B01 asset resolution
+    assert result["height"] == 1000  # Based on B01 asset resolution

--- a/tests/test_stacapi.py
+++ b/tests/test_stacapi.py
@@ -20,6 +20,7 @@ def test_processing_settings():
     settings = ProcessingSettings(max_pixels=50_000_000)
     assert settings.max_pixels == 50_000_000
 
+
 # Mock SimpleSTACReader to return fixed dimensions and transform
 class MockReader(SimpleSTACReader):
     def part(self, bbox, **kwargs):
@@ -27,10 +28,14 @@ class MockReader(SimpleSTACReader):
         import numpy
 
         return ImageData(
-            numpy.zeros((1, kwargs.get("height", 1000), kwargs.get("width", 1000)), dtype="uint8"),
+            numpy.zeros(
+                (1, kwargs.get("height", 1000), kwargs.get("width", 1000)),
+                dtype="uint8",
+            ),
             assets=kwargs.get("assets", ["B01"]),
             crs=kwargs.get("dst_crs", "EPSG:4326"),
-            )
+        )
+
 
 def test_load_collection_pixel_threshold(monkeypatch):
     """Test pixel threshold in load_collection."""

--- a/titiler/openeo/errors.py
+++ b/titiler/openeo/errors.py
@@ -253,12 +253,14 @@ class OutputLimitExceeded(OpenEOException):
         height: int,
         max_pixels: int,
         items_count: Optional[int] = None,
+        bands_count: Optional[int] = None,
     ):
         """Initialize error with output size limit exceeded."""
-        total_pixels = width * height * (items_count or 1)
+        total_pixels = width * height * (items_count or 1) * (bands_count or 1)
         message = (
             f"Estimated output size too large: {width}x{height} pixels"
             + (f" x {items_count} items" if items_count else "")
+            + (f" x {bands_count} bands" if bands_count else "")
             + f" = {total_pixels:,} total pixels (max allowed: {max_pixels:,} pixels)"
         )
         super().__init__(


### PR DESCRIPTION
Refactor the STAC reader and error handling to support asset-level resolutions and pixel limits. Introduce a complex STAC items fixture and improve output dimension tests for mixed resolutions and coordinate reference systems. Separate target CRS and bounding box logic for better output dimension estimation.