### PR TITLE
Bump version to 0.6.0 and update changelog for release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] (2025-12-04)
+
 ### Changed
 
 * move `get_load_collection_nodes` and `resolves_process_graph_parameters` method within the `EndpointsFactory` class
@@ -99,7 +101,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial release of openEO by TiTiler
 
-[unreleased]: https://github.com/sentinel-hub/titiler-openeo/compare/v0.5.0...HEAD
+[unreleased]: https://github.com/sentinel-hub/titiler-openeo/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/sentinel-hub/titiler-openeo/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/sentinel-hub/titiler-openeo/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/sentinel-hub/titiler-openeo/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/sentinel-hub/titiler-openeo/compare/v0.2.1...v0.3.0

--- a/deployment/k8s/charts/Chart.yaml
+++ b/deployment/k8s/charts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 0.5.0
+appVersion: 0.6.0
 description: OpenEO by TiTiler
 name: titiler-openeo
-version: 0.12.0
+version: 0.12.1
 icon: https://raw.githubusercontent.com/developmentseed/titiler/main/docs/logos/TiTiler_logo_small.png
 maintainers:
   - name: DevelopmentSeed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,7 @@ explicit_package_bases = true
 max-complexity = 14
 
 [tool.bumpversion]
-current_version = "0.5.0"
+current_version = "0.6.0"
 search = "{current_version}"
 replace = "{new_version}"
 regex = false

--- a/titiler/openeo/__init__.py
+++ b/titiler/openeo/__init__.py
@@ -1,3 +1,3 @@
 """titiler.openeo"""
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"


### PR DESCRIPTION
Update the version number to 0.6.0 across relevant files and reflect this change in the changelog. Adjust the application version in the Helm chart accordingly.