### PR TITLE
fix: permission for user store with explicit uid.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN apt-get update && \
 COPY --from=builder /opt/venv /opt/venv
 
 # Create non-root user
-RUN useradd -m -s /bin/bash titiler && \
+RUN useradd -u 65532 -m -s /bin/bash titiler && \
     mkdir -p /data /config
 COPY log_config.yaml /config/log_config.yaml
 RUN chown -R titiler:titiler /data /config

--- a/deployment/k8s/charts/Chart.yaml
+++ b/deployment/k8s/charts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 0.9.0
 description: OpenEO by TiTiler
 name: titiler-openeo
-version: 0.13.3
+version: 0.13.4
 icon: https://raw.githubusercontent.com/developmentseed/titiler/main/docs/logos/TiTiler_logo_small.png
 maintainers:
   - name: DevelopmentSeed

--- a/deployment/k8s/charts/templates/deployment.yaml
+++ b/deployment/k8s/charts/templates/deployment.yaml
@@ -28,7 +28,10 @@ spec:
             - |
               if [ -f "/config/init_store.json" ]; then
                 echo "Initializing JSON store from init_store.json..."
-                mkdir -p "$(dirname {{ .Values.database.json.path }})" && cp /config/init_store.json {{ .Values.database.json.path }}
+                mkdir -p "$(dirname {{ .Values.database.json.path }})"
+                cp /config/init_store.json {{ .Values.database.json.path }}
+                chown 65532:65532 {{ .Values.database.json.path }}
+                chmod 664 {{ .Values.database.json.path }}
                 echo "JSON store initialization complete."
               else
                 echo "No init_store.json found in configmap, skipping initialization."


### PR DESCRIPTION
When using NFS-based persistent volumes, the init container creates `store.json` with root ownership, causing permission denied errors when the main application (running as user `titiler`) attempts to write to it. Can't be fixed later because NFS storage ignores `fsGroup` in `podSecurityContext`.

This PR proposes to:

- Set explicit UID `65532` for `titiler` user in Dockerfile
- Add `chown 65532:65532` and `chmod 664` in init container after creating `store.json`