### PR TITLE
fix: include-component-in-tag to false

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,4 +1,5 @@
 {
+  "include-component-in-tag": false,
   "packages": {
     ".": {
       "release-type": "python",


### PR DESCRIPTION
## Description

Add the `include-component-in-tag` configuration option to the `release-please` setup, allowing for more control over tagging behavior.

## Testing

- [ ] I have run the existing test suite and all tests pass
- [ ] I have tested this change manually

## Documentation

- [ ] I have updated the documentation accordingly
- [ ] My changes do not require documentation updates

## Checklist

- [ ] My PR title follows [conventional commit format](https://www.conventionalcommits.org/) (e.g., `feat: add new feature`, `fix: resolve issue`)
- [ ] My changes generate no new warnings
- [ ] I updated the Helm chart version if applicable

## Related Issues

Fixes #

