### PR TITLE
fix: revert Docker build changes from PR #153

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,8 @@ jobs:
   publish-docker:
     needs: [tests]
     runs-on: ubuntu-latest
-    # only publish on main or tags (not on PRs, including Dependabot)
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+    # only publish on main, tags, and PRs
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/' || github.event_name == 'pull_request' )
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Revert the Docker build modifications introduced in PR #153 to restore the previous functionality. This change aims to address issues that arose from the recent updates.

## Description

Revert the Docker build modifications introduced in PR #153 to restore the previous functionality. This change aims to address issues that arose from the recent updates.

## Testing

- [ ] I have run the existing test suite and all tests pass
- [ ] I have tested this change manually

## Documentation

- [ ] I have updated the documentation accordingly
- [ ] My changes do not require documentation updates

## Checklist

- [ ] My PR title follows [conventional commit format](https://www.conventionalcommits.org/) (e.g., `feat: add new feature`, `fix: resolve issue`)
- [ ] My changes generate no new warnings
- [ ] I updated the Helm chart version if applicable

## Related Issues

Fixes #

