### PR TITLE
fix: pydantic validation error.

### DIFF
--- a/titiler/openeo/auth.py
+++ b/titiler/openeo/auth.py
@@ -12,7 +12,7 @@ from attrs import define, field
 from fastapi import Header
 from fastapi.exceptions import HTTPException
 from fastapi.security.utils import get_authorization_scheme_param
-from pydantic import BaseModel, Field, ValidationError, field_validator
+from pydantic import BaseModel, Field, field_validator
 from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_403_FORBIDDEN
 from typing_extensions import Self
 
@@ -287,7 +287,7 @@ class AuthToken(BaseModel):
     def check_token(cls, v):
         """Validate Token."""
         if v == "":
-            raise ValidationError("Empty token string.")
+            raise ValueError("Empty token string.")
         return v
 
     @classmethod


### PR DESCRIPTION
From https://docs.pydantic.dev/2.6/errors/errors/: 

> Validation code should not raise ValidationError itself, but rather raise a ValueError or AssertionError (or subclass thereof) which will be caught and used to populate ValidationError.

FIxing this for the `check_token` field validator in `titiler/openeo/auth.py`. My guess: it is still Pydantic v1 syntax to raise `ValidationError`, but it is incompatible with Pydantic v2.

