### PR TITLE
fix: add version extraction from tags in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,14 @@ jobs:
       - name: checkout code
         uses: actions/checkout@v6
 
+      - name: Extract version from tag
+        id: version
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          TAG_NAME="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG_NAME#titiler-openeo-}"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -73,9 +81,9 @@ jobs:
           tags: |
             type=sha
             type=ref,event=branch
-            type=ref,event=tag
             type=ref,event=pr
             type=raw,value=dev,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=${{ steps.version.outputs.version }},enable=${{ startsWith(github.ref, 'refs/tags/') }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
 
       - name: set up docker buildx


### PR DESCRIPTION
## Description

Extract the version from tags in the CI workflow to streamline versioning for Docker images.

## Testing

- [ ] I have run the existing test suite and all tests pass
- [ ] I have tested this change manually

## Documentation

- [ ] I have updated the documentation accordingly
- [ ] My changes do not require documentation updates

## Checklist

- [ ] My PR title follows [conventional commit format](https://www.conventionalcommits.org/) (e.g., `feat: add new feature`, `fix: resolve issue`)
- [ ] My changes generate no new warnings
- [ ] I updated the Helm chart version if applicable

## Related Issues

<!-- Link to any related issues using "Fixes #123" or "Closes #123" -->

Fixes #

