### PR TITLE
feat: propagate top-level named parameters into reducer callbacks

### DIFF
--- a/docs/src/parameter-management.md
+++ b/docs/src/parameter-management.md
@@ -336,6 +336,72 @@ Complex parameters with validation and user context:
 }
 ```
 
+## Parameter Scope in Callbacks
+
+Top-level process parameters are available **everywhere** in the process graph, including inside callback processes such as `apply`, `apply_dimension`, and `reduce_dimension`.
+
+### How it works
+
+When a process like `reduce_dimension` accepts a `reducer` callback, it forwards the outer `named_parameters` into the callback's execution context. The callback-specific parameters (`data`, `context`, etc.) are merged on top, so they always take precedence.
+
+This means a `{"from_parameter": "my_param"}` reference inside a reducer or apply callback resolves the same way it would at the top level — from query parameters, then from `default` values.
+
+### Example: parameter used inside a reducer
+
+```json
+{
+  "process_graph": {
+    "load1": {
+      "process_id": "load_collection",
+      "arguments": { "id": "S2" }
+    },
+    "reduce1": {
+      "process_id": "reduce_dimension",
+      "arguments": {
+        "data": { "from_node": "load1" },
+        "dimension": "bands",
+        "reducer": {
+          "process_graph": {
+            "eq1": {
+              "process_id": "eq",
+              "arguments": {
+                "x": { "from_parameter": "data" },
+                "y": { "from_parameter": "indicator" }
+              },
+              "result": true
+            }
+          }
+        }
+      },
+      "result": true
+    }
+  },
+  "parameters": [
+    {
+      "name": "indicator",
+      "description": "Band index to select",
+      "schema": { "type": "integer" },
+      "default": 0
+    }
+  ]
+}
+```
+
+Here `indicator` is defined at the top level with `default: 0`. The `eq1` node inside the reducer's process graph can reference it directly via `{"from_parameter": "indicator"}`. Callers can override it:
+
+```bash
+POST /result?indicator=2
+```
+
+### Priority inside a callback
+
+| Source | Priority |
+|---|---|
+| Callback-specific parameters (`data`, `context`) | Highest — always win |
+| Outer `named_parameters` (query params + defaults) | Base scope |
+
+This means there is no risk of a top-level parameter accidentally overriding `data` or `context` inside a callback.
+
 ## Troubleshooting
 
 ### Common Issues

--- a/tests/test_dimension_reduction.py
+++ b/tests/test_dimension_reduction.py
@@ -16,7 +16,7 @@ from titiler.openeo.processes.implementations.reduce import (
 
 
 # Mock reducers for testing
-def mock_temporal_reducer(data):
+def mock_temporal_reducer(data, **kwargs):
     """Mock temporal reducer that returns mean across time."""
     arrays = []
     for key in data.keys():
@@ -34,7 +34,7 @@ def mock_temporal_reducer(data):
     return np.ma.mean(stacked, axis=0)
 
 
-def mock_spectral_reducer(data):
+def mock_spectral_reducer(data, **kwargs):
     """Mock spectral reducer that returns mean across bands.
 
     This reducer works with the stacked format from _reduce_spectral_dimension_stack:
@@ -68,7 +68,7 @@ class StatefulCachingReducer:
         self.call_count = 0
         self.cached_result = None
 
-    def __call__(self, data):
+    def __call__(self, data, **kwargs):
         """Reduce by computing mean, but use cached result if available."""
         self.call_count += 1
 
@@ -89,12 +89,12 @@ class StatefulCachingReducer:
         return result
 
 
-def mock_invalid_reducer_returns_dict(data):
+def mock_invalid_reducer_returns_dict(data, **kwargs):
     """Invalid reducer that returns a dict instead of array."""
     return {"invalid": "result"}
 
 
-def mock_invalid_reducer_returns_string(data):
+def mock_invalid_reducer_returns_string(data, **kwargs):
     """Invalid reducer that returns an object that can't be converted to array."""
 
     # Return an object that will definitely fail numpy.asarray conversion
@@ -649,3 +649,75 @@ class TestReduceDimensionIntegration:
 
         assert exc_info.value.dimension == "xyz"
         assert "does not exist" in str(exc_info.value)
+
+
+class TestNamedParametersPropagation:
+    """Tests that top-level named_parameters are propagated into reducer callbacks."""
+
+    def _make_stack(self, n=2, bands=2, size=4):
+        images = {}
+        for i in range(n):
+            array = np.ma.ones((bands, size, size), dtype=float) * (i + 1)
+            images[datetime(2021, 1, i + 1)] = ImageData(
+                array,
+                assets=[f"asset_{i}"],
+                crs="EPSG:4326",
+                bounds=(-180, -90, 180, 90),
+            )
+        return RasterStack.from_images(images)
+
+    def test_temporal_reducer_receives_named_parameters(self):
+        """Reducer called by reduce_dimension(temporal) receives outer named_parameters."""
+        received = {}
+
+        def capturing_reducer(data, **kwargs):
+            received.update(kwargs.get("named_parameters", {}))
+            arrays = [data[k].array for k in data.keys()]
+            return np.ma.mean(np.ma.stack(arrays, axis=0), axis=0)
+
+        data = self._make_stack()
+        reduce_dimension(
+            data,
+            capturing_reducer,
+            "temporal",
+            named_parameters={"indicator": 3, "threshold": 0.5},
+        )
+
+        assert received["indicator"] == 3
+        assert received["threshold"] == 0.5
+
+    def test_spectral_reducer_receives_named_parameters(self):
+        """Reducer called by reduce_dimension(spectral) receives outer named_parameters."""
+        received = {}
+
+        def capturing_reducer(data, **kwargs):
+            received.update(kwargs.get("named_parameters", {}))
+            return np.ma.mean(np.ma.asarray(data), axis=0)
+
+        data = self._make_stack()
+        reduce_dimension(
+            data,
+            capturing_reducer,
+            "bands",
+            named_parameters={"indicator": 7},
+        )
+
+        assert received["indicator"] == 7
+
+    def test_no_named_parameters_still_works(self):
+        """Passing no named_parameters doesn't break existing reducers."""
+        data = self._make_stack()
+        result = reduce_dimension(data, mock_temporal_reducer, "temporal")
+        assert len(result) == 1
+
+    def test_named_parameters_not_passed_when_empty(self):
+        """When named_parameters is None, reducers that don't accept it still work."""
+
+        def strict_reducer(data):  # no **kwargs — rejects unknown args
+            arrays = [data[k].array for k in data.keys()]
+            return np.ma.mean(np.ma.stack(arrays, axis=0), axis=0)
+
+        data = self._make_stack()
+        # Should not raise, because named_parameters=None → kwarg not forwarded
+        result = reduce_dimension(data, strict_reducer, "temporal")
+        assert len(result) == 1

--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -456,6 +456,79 @@ def test_apply_dimension_unsupported_dimension(sample_raster_stack):
     assert "xyz" in str(excinfo.value)
 
 
+def test_apply_propagates_named_parameters(sample_raster_stack):
+    """Test that apply() forwards outer named_parameters to the callback."""
+    received = {}
+
+    def capturing_process(x, **kwargs):
+        received.update(kwargs.get("named_parameters", {}))
+        return x
+
+    apply(
+        sample_raster_stack,
+        capturing_process,
+        named_parameters={"indicator": 3, "threshold": 0.5},
+    )
+
+    assert received["indicator"] == 3
+    assert received["threshold"] == 0.5
+
+
+def test_apply_named_parameters_do_not_override_context(sample_raster_stack):
+    """context kwarg always wins over a same-key entry in named_parameters."""
+    received = {}
+
+    def capturing_process(x, **kwargs):
+        received["context"] = kwargs.get("named_parameters", {}).get("context")
+        return x
+
+    apply(
+        sample_raster_stack,
+        capturing_process,
+        context={"my_ctx": True},
+        named_parameters={"context": {"my_ctx": False}},
+    )
+
+    assert received["context"] == {"my_ctx": True}
+
+
+def test_apply_dimension_propagates_named_parameters(sample_raster_stack):
+    """Test that apply_dimension() forwards outer named_parameters into callback."""
+    received = {}
+
+    def capturing_process(data, **kwargs):
+        received.update(kwargs.get("named_parameters", {}))
+        arrays = [img.array for img in data.values()]
+        return np.array(arrays)
+
+    apply_dimension(
+        sample_raster_stack,
+        capturing_process,
+        "temporal",
+        named_parameters={"indicator": 5},
+    )
+
+    assert received["indicator"] == 5
+
+
+def test_apply_dimension_named_parameters_spectral(sample_raster_stack):
+    """Test named_parameters propagation for spectral apply_dimension."""
+    received = {}
+
+    def capturing_process(data, **kwargs):
+        received.update(kwargs.get("named_parameters", {}))
+        return data
+
+    apply_dimension(
+        sample_raster_stack,
+        capturing_process,
+        "bands",
+        named_parameters={"scale": 2.0},
+    )
+
+    assert received["scale"] == 2.0
+
+
 def test_if_basic():
     """Test basic if function behavior."""
     # Test true condition

--- a/titiler/openeo/processes/implementations/apply.py
+++ b/titiler/openeo/processes/implementations/apply.py
@@ -25,10 +25,11 @@ def apply(
     data: RasterStack,
     process: Callable,
     context: Optional[Dict] = None,
+    named_parameters: Optional[dict] = None,
 ) -> RasterStack:
     """Apply process on RasterStack."""
     positional_parameters = {"x": 0}
-    named_parameters = {"context": context}
+    named_parameters = {**(named_parameters or {}), "context": context}
 
     def _process_img(img: ImageData):
         return ImageData(
@@ -53,6 +54,7 @@ def apply_dimension(
     dimension: str,
     target_dimension: Optional[str] = None,
     context: Optional[Dict[str, Any]] = None,
+    named_parameters: Optional[dict] = None,
 ) -> RasterStack:
     """Apply a process to all values along a dimension of a data cube.
 
@@ -76,7 +78,7 @@ def apply_dimension(
 
     # Parameters to pass to the process
     positional_parameters = {"data": 0}
-    named_parameters = {"context": context}
+    named_parameters = {**(named_parameters or {}), "context": context}
 
     # Handle temporal dimension
     if dim_lower in ["t", "temporal", "time"]:

--- a/titiler/openeo/processes/implementations/reduce.py
+++ b/titiler/openeo/processes/implementations/reduce.py
@@ -277,6 +277,7 @@ def apply_pixel_selection(
 def _reduce_temporal_dimension(
     data: RasterStack,
     reducer: Callable,
+    named_parameters: Optional[dict] = None,
 ) -> RasterStack:
     """Reduce the temporal dimension of a RasterStack.
 
@@ -303,7 +304,8 @@ def _reduce_temporal_dimension(
 
     # Note: The reducer will determine how much data it actually needs
     # Some reducers might be able to work with partial data
-    reduced_array = reducer(data=data)
+    extra_kwargs = {"named_parameters": named_parameters} if named_parameters else {}
+    reduced_array = reducer(data=data, **extra_kwargs)
 
     # Validate the reducer output - must NOT be a RasterStack or dict
     if isinstance(reduced_array, dict):
@@ -419,6 +421,7 @@ def _determine_output_band_count(final_data: numpy.ndarray) -> int:
 def _reduce_spectral_dimension_stack(
     data: RasterStack,
     reducer: Callable,
+    named_parameters: Optional[dict] = None,
 ) -> RasterStack:
     """Reduce the spectral dimension of a RasterStack.
 
@@ -493,7 +496,8 @@ def _reduce_spectral_dimension_stack(
     # Input shape: (bands, time, height, width)
     # Expected output shape: (time, height, width) for full reduction
     #                    or: (reduced_bands, time, height, width) for partial reduction
-    reduced_data = reducer(data=transposed_data)
+    extra_kwargs = {"named_parameters": named_parameters} if named_parameters else {}
+    reduced_data = reducer(data=transposed_data, **extra_kwargs)
 
     # Validate the reducer output - must NOT be a RasterStack or dict
     if isinstance(reduced_data, dict):
@@ -899,6 +903,7 @@ def reduce_dimension(
     reducer: Callable,
     dimension: str,
     context: Optional[Dict[str, Any]] = None,
+    named_parameters: Optional[dict] = None,
 ) -> Union[RasterStack, ImageData]:
     """Applies a reducer to a data cube dimension by collapsing all the values along the specified dimension.
 
@@ -924,12 +929,16 @@ def reduce_dimension(
         if len(data) <= 1:
             return data
 
-        return _reduce_temporal_dimension(data, reducer)
+        return _reduce_temporal_dimension(
+            data, reducer, named_parameters=named_parameters
+        )
 
     # Handle spectral dimension
     elif dim_lower in ["bands", "spectral"]:
         # Use unified stack reduction for both single and multi-image cases
-        return _reduce_spectral_dimension_stack(data, reducer)
+        return _reduce_spectral_dimension_stack(
+            data, reducer, named_parameters=named_parameters
+        )
 
     # Unsupported dimension
     else:


### PR DESCRIPTION


Named parameters are now accepted in the `apply` and `apply_dimension` functions, allowing them to be forwarded to reducer callbacks. This change enhances the flexibility of the reducer functions by enabling them to utilize these parameters. Tests confirm that named parameters propagate correctly during apply and reduce operations.



## Testing



- [x] I have run the existing test suite and all tests pass

- [x] I have tested this change manually



## Documentation



- [x] I have updated the documentation accordingly

- [x] My changes do not require documentation updates



## Checklist



- [x] My PR title follows [conventional commit format](https://www.conventionalcommits.org/) (e.g., `feat: add new feature`, `fix: resolve issue`)

- [x] My changes generate no new warnings

- [ ] I updated the Helm chart version if applicable



## Related Issues



Fixes #

