### PR TITLE
feat: add logical OR operation

### DIFF
--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -25,7 +25,7 @@ from titiler.openeo.processes.implementations.image import (
     to_array,
 )
 from titiler.openeo.processes.implementations.indices import ndvi, ndwi
-from titiler.openeo.processes.implementations.logic import if_
+from titiler.openeo.processes.implementations.logic import and_, if_, or_
 from titiler.openeo.processes.implementations.reduce import reduce_dimension
 
 
@@ -530,6 +530,41 @@ def test_if_with_image_data(sample_image_data):
 
     result = if_(False, data1, data2)
     assert result is data2
+
+
+def test_or_scalar():
+    """Test logical OR with scalar boolean values."""
+    assert or_(True, True) is True
+    assert or_(True, False) is True
+    assert or_(False, True) is True
+    assert or_(False, False) is False
+
+    # Non-boolean values are coerced (null/None treated as false)
+    assert or_(1, 0) is True
+    assert or_(0, None) is False
+
+
+def test_or_with_arrays():
+    """Test logical OR with numpy arrays (element-wise)."""
+    result = or_(np.array([True, False, True]), np.array([False, False, True]))
+    np.testing.assert_array_equal(result, np.array([True, False, True]))
+
+    # Mixed array / scalar operand
+    result = or_(np.array([True, False]), False)
+    np.testing.assert_array_equal(result, np.array([True, False]))
+
+
+def test_and_scalar():
+    """Test logical AND with scalar boolean values."""
+    assert and_(True, True) is True
+    assert and_(True, False) is False
+    assert and_(False, False) is False
+
+
+def test_and_with_arrays():
+    """Test logical AND with numpy arrays (element-wise)."""
+    result = and_(np.array([True, False]), np.array([True, True]))
+    np.testing.assert_array_equal(result, np.array([True, False]))
 
 
 def test_apply_dimension_water_mask_preserves_dimensions(sample_raster_stack):

--- a/titiler/openeo/processes/data/or.json
+++ b/titiler/openeo/processes/data/or.json
@@ -1,0 +1,93 @@
+{
+  "id": "or",
+  "summary": "Logical OR",
+  "description": "Checks if **at least one** of the values is true. Evaluates parameter `x` before `y` and stops once the outcome is unambiguous. If a component is `null`, the result will be `null` if the outcome is ambiguous.\n\n**Truth table:**\n\n```\na \\ b || null  | false | true\n----- || ----- | ----- | ----\nnull  || null  | null  | true\nfalse || null  | false | true\ntrue  || true  | true  | true\n```",
+  "categories": [
+    "logic"
+  ],
+  "parameters": [
+    {
+      "name": "x",
+      "description": "A boolean value.",
+      "schema": {
+        "type": [
+          "boolean",
+          "null"
+        ]
+      }
+    },
+    {
+      "name": "y",
+      "description": "A boolean value.",
+      "schema": {
+        "type": [
+          "boolean",
+          "null"
+        ]
+      }
+    }
+  ],
+  "returns": {
+    "description": "Boolean result of the logical OR.",
+    "schema": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    }
+  },
+  "examples": [
+    {
+      "arguments": {
+        "x": false,
+        "y": false
+      },
+      "returns": false
+    },
+    {
+      "arguments": {
+        "x": true,
+        "y": false
+      },
+      "returns": true
+    },
+    {
+      "arguments": {
+        "x": true,
+        "y": true
+      },
+      "returns": true
+    },
+    {
+      "arguments": {
+        "x": true,
+        "y": null
+      },
+      "returns": true
+    },
+    {
+      "arguments": {
+        "x": false,
+        "y": null
+      },
+      "returns": null
+    }
+  ],
+  "process_graph": {
+    "any": {
+      "process_id": "any",
+      "arguments": {
+        "data": [
+          {
+            "from_parameter": "x"
+          },
+          {
+            "from_parameter": "y"
+          }
+        ],
+        "ignore_nodata": false
+      },
+      "result": true
+    }
+  }
+}

--- a/titiler/openeo/processes/implementations/logic.py
+++ b/titiler/openeo/processes/implementations/logic.py
@@ -4,7 +4,7 @@ from typing import Any, Optional
 
 import numpy
 
-__all__ = ["if_", "and_", "lt", "lte", "gt", "gte", "eq", "neq"]
+__all__ = ["if_", "and_", "or_", "lt", "lte", "gt", "gte", "eq", "neq"]
 
 
 def if_(
@@ -91,6 +91,40 @@ def and_(x: Any, y: Any) -> Any:
 
 
 and_.__name__ = "and"
+
+
+def or_(x: Any, y: Any) -> Any:
+    """Logical OR operation.
+
+    Args:
+        x: First boolean value or array
+        y: Second boolean value or array
+
+    Returns:
+        True if at least one of x and y is true, False otherwise
+
+    Examples:
+        >>> or_(True, True)
+        True
+        >>> or_(True, False)
+        True
+        >>> or_(False, True)
+        True
+        >>> or_(False, False)
+        False
+        >>> import numpy as np
+        >>> or_(np.array([True, False]), np.array([False, False]))
+        array([ True, False])
+    """
+    # Handle numpy arrays - use element-wise logical OR
+    if isinstance(x, numpy.ndarray) or isinstance(y, numpy.ndarray):
+        return numpy.logical_or(x, y)
+
+    # Handle scalar boolean values
+    return bool(x) or bool(y)
+
+
+or_.__name__ = "or"
 
 
 def lt(x: Any, y: Any) -> bool:


### PR DESCRIPTION
## Description

Add a logical OR operation that supports both boolean values and numpy arrays. This operation evaluates two inputs and returns true if at least one of them is true.

## Testing

Tested the new logical OR function with various boolean inputs and numpy arrays to ensure correct behavior.

- [x] I have run the existing test suite and all tests pass
- [x] I have tested this change manually

## Documentation

- [ ] I have updated the documentation accordingly
- [x] My changes do not require documentation updates

## Checklist

- [x] My PR title follows [conventional commit format](https://www.conventionalcommits.org/) (e.g., `feat: add new feature`, `fix: resolve issue`)
- [x] My changes generate no new warnings
- [ ] I updated the Helm chart version if applicable

## Related Issues

Fixes #

