### PR TITLE
fix: update context parameter type to Optional[Any] as per spec

### DIFF
--- a/tests/test_core_coverage.py
+++ b/tests/test_core_coverage.py
@@ -13,8 +13,9 @@ The tests are organized into logical groups covering:
 Each test is documented to explain what it validates and why it's important.
 """
 
+import inspect
 from datetime import datetime
-from typing import Any, List, Optional, Union
+from typing import List, Optional, Union
 
 import numpy as np
 import pytest
@@ -26,8 +27,18 @@ from openeo_pg_parser_networkx.pg_schema import (
 
 from titiler.openeo.auth import User
 from titiler.openeo.errors import ProcessParameterMissing
-from titiler.openeo.processes.implementations.core import process
+from titiler.openeo.processes.implementations.apply import apply, apply_dimension
+from titiler.openeo.processes.implementations.arrays import merge_cubes
+from titiler.openeo.processes.implementations.core import (
+    _validate_with_pydantic,
+    process,
+)
 from titiler.openeo.processes.implementations.data_model import RasterStack
+from titiler.openeo.processes.implementations.reduce import (
+    aggregate_temporal,
+    reduce_dimension,
+)
+from titiler.openeo.processes.implementations.spatial import aggregate_spatial
 
 
 class TestResolvePositionalArgs:
@@ -687,24 +698,34 @@ class TestTypeValidation:
         result = complex_param(x=[1.0, 2.0, 3.0])
         assert result == "[1.0, 2.0, 3.0]"
 
-    def test_validation_context_accepts_any_type(self):
-        """Test that an Optional[Any] context parameter accepts any data type.
+    @pytest.mark.parametrize(
+        "func",
+        [
+            apply,
+            apply_dimension,
+            aggregate_temporal,
+            reduce_dimension,
+            aggregate_spatial,
+            merge_cubes,
+        ],
+    )
+    @pytest.mark.parametrize("context_value", [[0.1, 0.2, 0.03], {"a": 1}, 42, None])
+    def test_context_param_accepts_any_type(self, func, context_value):
+        """Test that real process implementations accept any ``context`` value.
 
-        Validates: The OpenEO ``context`` argument is specified as "Any data
-        type", so a list (or any other value) must pass validation.
+        Validates: The ``context`` annotation of each process implementation
+        is wide enough that ``_validate_with_pydantic`` (the function in the
+        original traceback) accepts a list, dict, scalar, or None.
 
-        Why important: Process graphs may pass a list, scalar, or dict as
-        ``context``. Restricting it to dict raised a spurious TypeError.
+        Why important: This reads the *actual* signature of the shipped
+        implementations, so reverting ``context`` to ``Optional[Dict]`` in
+        apply.py/reduce.py/spatial.py/arrays.py fails this test. The earlier
+        version only tested a locally-defined function and would not catch
+        such a regression.
         """
-
-        @process
-        def accepts_context(context: Optional[Any] = None) -> Any:
-            return context
-
-        assert accepts_context(context=[0.1, 0.2, 0.03]) == [0.1, 0.2, 0.03]
-        assert accepts_context(context={"a": 1}) == {"a": 1}
-        assert accepts_context(context=42) == 42
-        assert accepts_context(context=None) is None
+        annotation = inspect.signature(func).parameters["context"].annotation
+        # Must not raise — TypeError here is exactly the original bug.
+        _validate_with_pydantic("context", context_value, annotation, func.__name__)
 
 
 class TestProcessDecoratorEdgeCases:

--- a/tests/test_core_coverage.py
+++ b/tests/test_core_coverage.py
@@ -14,7 +14,7 @@ Each test is documented to explain what it validates and why it's important.
 """
 
 from datetime import datetime
-from typing import List, Optional, Union
+from typing import Any, List, Optional, Union
 
 import numpy as np
 import pytest
@@ -686,6 +686,25 @@ class TestTypeValidation:
         # This should work and log debug message if TypeAdapter fails
         result = complex_param(x=[1.0, 2.0, 3.0])
         assert result == "[1.0, 2.0, 3.0]"
+
+    def test_validation_context_accepts_any_type(self):
+        """Test that an Optional[Any] context parameter accepts any data type.
+
+        Validates: The OpenEO ``context`` argument is specified as "Any data
+        type", so a list (or any other value) must pass validation.
+
+        Why important: Process graphs may pass a list, scalar, or dict as
+        ``context``. Restricting it to dict raised a spurious TypeError.
+        """
+
+        @process
+        def accepts_context(context: Optional[Any] = None) -> Any:
+            return context
+
+        assert accepts_context(context=[0.1, 0.2, 0.03]) == [0.1, 0.2, 0.03]
+        assert accepts_context(context={"a": 1}) == {"a": 1}
+        assert accepts_context(context=42) == 42
+        assert accepts_context(context=None) is None
 
 
 class TestProcessDecoratorEdgeCases:

--- a/titiler/openeo/processes/implementations/apply.py
+++ b/titiler/openeo/processes/implementations/apply.py
@@ -24,7 +24,7 @@ class DimensionNotAvailable(Exception):
 def apply(
     data: RasterStack,
     process: Callable,
-    context: Optional[Dict] = None,
+    context: Optional[Any] = None,
 ) -> RasterStack:
     """Apply process on RasterStack."""
     positional_parameters = {"x": 0}
@@ -52,7 +52,7 @@ def apply_dimension(
     process: Callable,
     dimension: str,
     target_dimension: Optional[str] = None,
-    context: Optional[Dict[str, Any]] = None,
+    context: Optional[Any] = None,
 ) -> RasterStack:
     """Apply a process to all values along a dimension of a data cube.
 
@@ -330,7 +330,7 @@ def _apply_spectral_dimension_stack(
 
 def xyz_to_bbox(
     data: Dict[str, Any],
-    context: Optional[Dict] = None,
+    context: Optional[Any] = None,
 ) -> BoundingBox:
     """Apply process on ArrayLike."""
 
@@ -361,7 +361,7 @@ def xyz_to_tileinfo(
     y: int,
     z: int,
     stage: str = "test",
-    context: Optional[Dict] = None,
+    context: Optional[Any] = None,
 ) -> Dict:
     """Convert XYZ coordinates to tile information."""
 

--- a/titiler/openeo/processes/implementations/arrays.py
+++ b/titiler/openeo/processes/implementations/arrays.py
@@ -232,7 +232,7 @@ def _merge_images_bands(
     img1: ImageData,
     img2: ImageData,
     overlap_resolver: Optional[Callable],
-    context: Optional[Dict[str, Any]] = None,
+    context: Optional[Any] = None,
 ) -> ImageData:
     """Merge two ImageData objects along the band dimension.
 
@@ -327,7 +327,7 @@ def merge_cubes(
     cube1: RasterStack,
     cube2: RasterStack,
     overlap_resolver: Optional[Callable] = None,
-    context: Optional[Dict[str, Any]] = None,
+    context: Optional[Any] = None,
 ) -> RasterStack:
     """Merge two compatible data cubes.
 

--- a/titiler/openeo/processes/implementations/reduce.py
+++ b/titiler/openeo/processes/implementations/reduce.py
@@ -809,7 +809,7 @@ def aggregate_temporal(
     reducer: Callable,
     labels: Optional[List[Union[float, str]]] = None,
     dimension: Optional[Literal["t", "temporal", "time"]] = None,
-    context: Optional[Dict[str, Any]] = None,
+    context: Optional[Any] = None,
 ) -> RasterStack:
     """Computes a temporal aggregation based on an array of temporal intervals.
 
@@ -898,7 +898,7 @@ def reduce_dimension(
     data: RasterStack,
     reducer: Callable,
     dimension: str,
-    context: Optional[Dict[str, Any]] = None,
+    context: Optional[Any] = None,
 ) -> Union[RasterStack, ImageData]:
     """Applies a reducer to a data cube dimension by collapsing all the values along the specified dimension.
 

--- a/titiler/openeo/processes/implementations/spatial.py
+++ b/titiler/openeo/processes/implementations/spatial.py
@@ -202,7 +202,7 @@ def aggregate_spatial(
     geometries: Union[Dict, Any],
     reducer: Callable,
     target_dimension: Optional[str] = None,
-    context: Optional[Dict[str, Any]] = None,
+    context: Optional[Any] = None,
 ) -> Dict[str, Any]:
     """Aggregates statistics for one or more geometries over the spatial dimensions.
 


### PR DESCRIPTION
## Description

Update the context parameter type to `Optional[Any]` across multiple functions for improved flexibility in accepting various data types.

## Testing

Tested the changes by adding a new test case to validate that the context parameter accepts any data type, ensuring compatibility with lists, scalars, and dictionaries.

- [x] I have run the existing test suite and all tests pass
- [x] I have tested this change manually

## Documentation

- [ ] I have updated the documentation accordingly
- [x] My changes do not require documentation updates

## Checklist

- [x] My PR title follows [conventional commit format](https://www.conventionalcommits.org/) (e.g., `feat: add new feature`, `fix: resolve issue`)
- [x] My changes generate no new warnings
- [ ] I updated the Helm chart version if applicable

## Related Issues

<!-- Link to any related issues using "Fixes #123" or "Closes #123" -->

Fixes #

