### PR TITLE
feat: add validation for saving multi-slice RasterStack to single-frame formats

### DIFF
--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -155,6 +155,25 @@ def test_save_result_single_image():
     assert len(result.data) > 0  # Should contain PNG bytes
 
 
+def test_save_result_multi_slice_single_frame_format_raises():
+    """A multi-slice RasterStack cannot be saved to a single-frame format.
+
+    This is the failure mode behind merge_cubes of two cubes with non-matching
+    time labels: the overlap_resolver is never applied and both slices are
+    carried through, leaving a 2-key stack that PNG/JPEG cannot represent.
+    """
+    array = numpy.array([[1, 2], [3, 4]], dtype=numpy.uint8)[None, ...]
+    data = RasterStack.from_images(
+        {
+            datetime(2021, 6, 1): ImageData(array),
+            datetime(2021, 8, 1): ImageData(array),
+        }
+    )
+
+    with pytest.raises(ValueError, match="2 temporal slices"):
+        save_result(data, "png")
+
+
 def test_save_result_feature_collection():
     """Test save_result with FeatureCollection."""
     data = {

--- a/titiler/openeo/processes/implementations/io.py
+++ b/titiler/openeo/processes/implementations/io.py
@@ -343,5 +343,19 @@ def save_result(
             combined_img = _handle_raster_geotiff(data)
             return _save_single_result(combined_img, format, options)
 
+        # A multi-slice RasterStack cannot be written to a single-frame format
+        # (PNG/JPEG and friends). This usually means an upstream operation kept a
+        # temporal dimension that the caller expected to be collapsed — e.g.
+        # merge_cubes received two cubes with non-matching time labels, so the
+        # overlap_resolver was never applied and both slices were carried through.
+        raise ValueError(
+            f"Cannot save a RasterStack with {len(data)} temporal slices "
+            f"(keys: {list(data.keys())}) to single-frame format "
+            f"'{format}'. Use 'tiff'/'gtiff' to write all slices as a "
+            "multi-band GeoTIFF, or collapse the temporal dimension first "
+            "(e.g. reduce_dimension over 't', or align the time labels so "
+            "merge_cubes can apply the overlap_resolver)."
+        )
+
     # Otherwise, save as a single result
     return _save_single_result(data, format, options)


### PR DESCRIPTION
## Description

Add validation to prevent saving a multi-slice RasterStack to single-frame formats like PNG or JPEG. This change raises a ValueError when such an operation is attempted, guiding users to use appropriate formats or collapse the temporal dimension first.

## Testing

Tested the new validation by adding a unit test that confirms the expected error is raised when attempting to save a multi-slice RasterStack as a single-frame format.

- [ ] I have run the existing test suite and all tests pass
- [ ] I have tested this change manually

## Documentation

- [ ] I have updated the documentation accordingly
- [ ] My changes do not require documentation updates

## Checklist

- [ ] My PR title follows [conventional commit format](https://www.conventionalcommits.org/) (e.g., `feat: add new feature`, `fix: resolve issue`)
- [ ] My changes generate no new warnings
- [ ] I updated the Helm chart version if applicable

## Related Issues

Fixes #

