### PR TITLE
ci: ignore release-please PRs in title validation

### DIFF
--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -43,8 +43,12 @@ jobs:
           # Disable validation of merge commits
           validateSingleCommit: false
           # Allow additional subjects like "Merge branch..."
+          # `autorelease: pending` is set by release-please on its release PRs,
+          # whose titles (e.g. `chore(main): release 0.15.0`) use the release
+          # branch name as scope and therefore fail scope validation.
           ignoreLabels: |
             skip-changelog
+            autorelease: pending
           # Custom error message
           subjectPattern: ^(?![A-Z]).+$
           subjectPatternError: |


### PR DESCRIPTION
## Problem

The [Validate PR Title](.github/workflows/validate-pr-title.yml) workflow uses `amannn/action-semantic-pull-request` with a fixed `scopes:` list (`api`, `auth`, `processes`, `store`, `docker`, `helm`, `docs`, `deps`, `ci`).

release-please always emits release PR titles of the form:

```
chore(<release-branch>): release <version>
```

…where the scope is the **release branch name**, not a code scope. For this repo that means titles like `chore(main): release 0.15.0`, which fails the scope check and blocks merging the release PR — see the failure on #258:

> Unknown scope "main" found in pull request title "chore(main): release 0.15.0". Scope must match one of: api, auth, processes, store, docker, helm, docs, deps, ci.

## Fix

Add `autorelease: pending` (a label release-please always applies to its release PRs) to `ignoreLabels` so release-please PRs bypass the validator. All other PRs continue to be checked exactly as before.

## Verification

After merging, re-run the failed `Validate PR Title` job on #258 and #238; both should be skipped (`autorelease: pending` label present).
