### PR TITLE
refactor: remove /readyz response cache

### DIFF
--- a/deployment/k8s/charts/templates/deployment.yaml
+++ b/deployment/k8s/charts/templates/deployment.yaml
@@ -144,12 +144,14 @@ spec:
               path: /healthz
               port: http
             initialDelaySeconds: 30
+            periodSeconds: 10
             timeoutSeconds: 10
           readinessProbe:
             httpGet:
               path: /readyz
               port: http
             initialDelaySeconds: 30
+            periodSeconds: 60
             timeoutSeconds: 30
           {{- with .Values.resources }}
           resources:

--- a/docs/src/kubernetes.md
+++ b/docs/src/kubernetes.md
@@ -76,12 +76,11 @@ Helm chart wires them to the pod's probes by default.
   OIDC well-known endpoint when OIDC auth is enabled. Returns `200` only when
   every check passes; otherwise `503` with a structured body listing which
   check failed. Used as `readinessProbe.httpGet.path` so an unhealthy pod is
-  removed from the Service's endpoints until it recovers. Results are cached
-  for 5 s by default; append `?fresh=1` to bypass the cache for manual
-  debugging.
+  removed from the Service's endpoints until it recovers.
 
-Per-check timeout and cache TTL can be tuned via
-`TITILER_OPENEO_HEALTH_CHECK_TIMEOUT` and `TITILER_OPENEO_HEALTH_CACHE_TTL`.
+To avoid hammering backends, the chart's `readinessProbe` uses
+`periodSeconds: 60`. The per-check timeout can be tuned with
+`TITILER_OPENEO_HEALTH_CHECK_TIMEOUT` (default `2.0`).
 
 ## Troubleshooting
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -26,7 +26,7 @@ def test_readyz_ok(app_no_auth, monkeypatch):
 
     monkeypatch.setattr(stacApiBackend, "ping", lambda self, *a, **kw: None)
 
-    response = app_no_auth.get("/readyz?fresh=1")
+    response = app_no_auth.get("/readyz")
     assert response.status_code == 200
     body = response.json()
     assert body["status"] == "ok"
@@ -50,7 +50,7 @@ def test_readyz_reports_failed_check(app_no_auth, monkeypatch):
 
     monkeypatch.setattr(stacApiBackend, "ping", boom)
 
-    response = app_no_auth.get("/readyz?fresh=1")
+    response = app_no_auth.get("/readyz")
     assert response.status_code == 503
     body = response.json()
     assert body["status"] == "degraded"
@@ -79,30 +79,6 @@ def test_run_check_success():
     assert "latency_ms" in result
 
 
-def test_readyz_cached(app_no_auth, monkeypatch):
-    """Repeated /readyz calls without ?fresh hit the cached result."""
-    from titiler.openeo.stacapi import stacApiBackend
-
-    counter = {"n": 0}
-
-    def counting_ping(self) -> None:
-        counter["n"] += 1
-
-    monkeypatch.setattr(stacApiBackend, "ping", counting_ping)
-
-    # First call populates the cache; second call must reuse it.
-    r1 = app_no_auth.get("/readyz")
-    r2 = app_no_auth.get("/readyz")
-    assert r1.status_code == 200
-    assert r2.status_code == 200
-    assert counter["n"] == 1
-
-    # ?fresh=1 bypasses the cache.
-    r3 = app_no_auth.get("/readyz?fresh=1")
-    assert r3.status_code == 200
-    assert counter["n"] == 2
-
-
 def test_readyz_includes_tile_store_when_configured(app_no_auth, monkeypatch):
     """When a tile store is configured, the tile_store check is included."""
     from titiler.openeo import main as main_module
@@ -121,7 +97,7 @@ def test_readyz_includes_tile_store_when_configured(app_no_auth, monkeypatch):
     from starlette.testclient import TestClient
 
     client = TestClient(main_module.create_app())
-    response = client.get("/readyz?fresh=1")
+    response = client.get("/readyz")
     assert response.status_code == 200
     body = response.json()
     assert body["checks"]["tile_store"]["status"] == "ok"

--- a/titiler/openeo/health.py
+++ b/titiler/openeo/health.py
@@ -12,10 +12,8 @@ Implements two distinct probes following Kubernetes semantics:
   when every check passes; otherwise 503 with a structured body listing
   which check failed. Suitable for a ``readinessProbe``.
 
-The ``/readyz`` result is cached for a short TTL (default 5 s, configurable
-via ``TITILER_OPENEO_HEALTH_CACHE_TTL``) so that a high-frequency probe
-does not hammer the STAC API. The cache can be bypassed for manual
-debugging with ``?fresh=1``.
+To avoid hammering backends, configure the Kubernetes probe with a
+suitable ``periodSeconds`` (the bundled Helm chart uses 30 s).
 """
 
 from __future__ import annotations
@@ -23,10 +21,9 @@ from __future__ import annotations
 import concurrent.futures
 import logging
 import time
-from threading import Lock
 from typing import Any, Callable, Dict, List, Optional
 
-from fastapi import APIRouter, FastAPI, Query
+from fastapi import APIRouter, FastAPI
 from fastapi.responses import JSONResponse
 
 from . import __version__ as titiler_version
@@ -39,35 +36,6 @@ logger = logging.getLogger(__name__)
 _executor = concurrent.futures.ThreadPoolExecutor(
     max_workers=4, thread_name_prefix="readyz-check"
 )
-
-
-class _ReadinessCache:
-    """Thread-safe cache for the /readyz response body and status code."""
-
-    def __init__(self, ttl: float) -> None:
-        self._ttl = ttl
-        self._expires_at: float = 0.0
-        self._payload: Optional[Dict[str, Any]] = None
-        self._status: int = 200
-        self._lock = Lock()
-
-    def get(self) -> Optional[tuple]:
-        """Return (status, payload) if cached value is still fresh."""
-        if self._ttl <= 0:
-            return None
-        with self._lock:
-            if self._payload is not None and time.monotonic() < self._expires_at:
-                return self._status, self._payload
-        return None
-
-    def set(self, status: int, payload: Dict[str, Any]) -> None:
-        """Store a result with the configured TTL."""
-        if self._ttl <= 0:
-            return
-        with self._lock:
-            self._status = status
-            self._payload = payload
-            self._expires_at = time.monotonic() + self._ttl
 
 
 def _run_check(name: str, fn: Callable[[], Any], timeout: float) -> Dict[str, Any]:
@@ -139,7 +107,6 @@ def register_health_endpoints(
     they don't clutter the generated docs.
     """
     settings = settings or HealthSettings()
-    cache = _ReadinessCache(ttl=settings.cache_ttl)
 
     router = APIRouter(tags=["health"], include_in_schema=False)
 
@@ -149,19 +116,8 @@ def register_health_endpoints(
         return {"status": "ok"}
 
     @router.get("/readyz")
-    def readyz(
-        fresh: int = Query(
-            0,
-            description="Set to 1 to bypass the cached result.",
-        ),
-    ) -> JSONResponse:
+    def readyz() -> JSONResponse:
         """Readiness probe. 200 when every configured dependency is healthy."""
-        if not fresh:
-            cached = cache.get()
-            if cached is not None:
-                cached_status, cached_payload = cached
-                return JSONResponse(status_code=cached_status, content=cached_payload)
-
         checks = _build_checks(
             service_store=service_store,
             tile_store=tile_store,
@@ -183,7 +139,6 @@ def register_health_endpoints(
             "checks": results,
         }
         status_code = 200 if all_ok else 503
-        cache.set(status_code, payload)
         return JSONResponse(status_code=status_code, content=payload)
 
     app.include_router(router)

--- a/titiler/openeo/settings.py
+++ b/titiler/openeo/settings.py
@@ -225,9 +225,6 @@ class HealthSettings(BaseSettings):
     # Per-check timeout in seconds for the /readyz probe
     check_timeout: Annotated[float, Field(gt=0.0)] = 2.0
 
-    # TTL of the cached /readyz result in seconds (0 disables caching)
-    cache_ttl: Annotated[float, Field(ge=0.0)] = 5.0
-
     model_config = SettingsConfigDict(
         env_prefix="TITILER_OPENEO_HEALTH_",
         env_file=".env",


### PR DESCRIPTION
Addresses review feedback on #269 from @vincentsarago.

## Changes

- Remove the `_ReadinessCache` from `/readyz` and the `cache_ttl` setting; backend pressure is now controlled exclusively by Kubernetes probe `periodSeconds`.
- Drop the `?fresh=1` query param (no longer needed).
- Helm chart: bump `readinessProbe.periodSeconds` to `60` and set `livenessProbe.periodSeconds` to `10`.
- Update docs and tests accordingly.
