### PR TITLE
ci: exclude nested CHANGELOG.md files from markdownlint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,4 +34,4 @@ repos:
       - id: markdownlint
         files: \.(md|mkd|markdown)$
         args: ["--fix"]
-        exclude: ^(CHANGES\.md|RELEASE\.md|CHANGELOG\.md)$
+        exclude: (^|/)(CHANGES|RELEASE|CHANGELOG)\.md$


### PR DESCRIPTION
release-please generates `deployment/k8s/charts/CHANGELOG.md` with sibling `## What's Changed` headings under each `## <version>` heading, which trips MD024 and breaks the release PR (#238).

Broaden the markdownlint `exclude` pattern so it matches `CHANGELOG.md` at any depth, not just at the repo root.