### PR TITLE
fix: correct default image tag format in deployment.yaml

### DIFF
--- a/deployment/k8s/charts/README.md
+++ b/deployment/k8s/charts/README.md
@@ -66,7 +66,7 @@ helm install titiler-openeo . -f values-cdse.yaml -n your-namespace
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `image.repository` | Container image repository | `ghcr.io/sentinel-hub/titiler-openeo` |
-| `image.tag` | Container image tag (defaults to `titiler-openeo-v{{ .Chart.AppVersion }}` when unset) | `titiler-openeo-v0.12.0` |
+| `image.tag` | Container image tag (defaults to `titiler-openeo-{{ .Chart.AppVersion }}` when unset) | `titiler-openeo-0.12.0` |
 | `image.pullPolicy` | Container image pull policy | `IfNotPresent` |
 | `replicaCount` | Number of replicas | `1` |
 

--- a/deployment/k8s/charts/templates/deployment.yaml
+++ b/deployment/k8s/charts/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "titiler-openeo-v%s" .Chart.AppVersion) }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "titiler-openeo-%s" .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - {{ .Values.image.command | quote }}

--- a/deployment/k8s/charts/tests/deployment_test.yaml
+++ b/deployment/k8s/charts/tests/deployment_test.yaml
@@ -8,7 +8,7 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: ^ghcr\.io/sentinel-hub/titiler-openeo:titiler-openeo-v[0-9]+\.[0-9]+\.[0-9]+$
+          pattern: ^ghcr\.io/sentinel-hub/titiler-openeo:titiler-openeo-[0-9]+\.[0-9]+\.[0-9]+$
 
   - it: should use custom tag when image.tag is set
     set:


### PR DESCRIPTION
## Description

Correct the default image tag format in the deployment configuration to ensure proper versioning.

## Testing

Tested the changes by verifying the deployment configuration for correct image tag formatting.

- [ ] I have run the existing test suite and all tests pass
- [ ] I have tested this change manually

## Documentation

- [ ] I have updated the documentation accordingly
- [ ] My changes do not require documentation updates

## Checklist

- [ ] My PR title follows [conventional commit format](https://www.conventionalcommits.org/) (e.g., `feat: add new feature`, `fix: resolve issue`)
- [ ] My changes generate no new warnings
- [ ] I updated the Helm chart version if applicable

## Related Issues

Fixes #

