### PR TITLE
fix: add semver Docker tags on release (0.x.y, 0.x, 0, latest)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -91,14 +91,27 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Parse semver from tag
+        id: semver
+        run: |
+          TAG="${{ needs.release-please.outputs.tag_name }}"
+          VERSION="${TAG#v}"
+          MAJOR="${VERSION%%.*}"
+          MINOR="${VERSION%.*}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "major=${MAJOR}" >> "$GITHUB_OUTPUT"
+          echo "minor=${MINOR}" >> "$GITHUB_OUTPUT"
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
+            type=raw,value=${{ steps.semver.outputs.version }}
             type=raw,value=${{ needs.release-please.outputs.tag_name }}
-            type=raw,value={{date 'YYYYMMDD-HHmmss' tz='UTC'}}
+            type=raw,value=${{ steps.semver.outputs.minor }}
+            type=raw,value=${{ steps.semver.outputs.major }}
             type=raw,value=latest
 
       - name: Build and push


### PR DESCRIPTION
## Problem

Release Please creates the git tag and GitHub Release via `GITHUB_TOKEN`. GitHub suppresses downstream workflow triggers for events generated by `GITHUB_TOKEN`, so `ci.yml`'s `push.tags` path never fires for automated releases — its semver tag logic is dead code.

`release-please.yml` already has a `publish-docker` job that **does** fire (chained via `needs:`, not via an event trigger), but its tag list only produced:
- `v0.9.2` (raw `tag_name`)
- `20241215-121500` (timestamp — non-standard noise)
- `latest`

Missing: `0.9.2`, `0.9`, `0`.

## Fix

Add a `Parse semver from tag` step before `Extract metadata` in the `publish-docker` job that derives `version`, `minor`, and `major` from `tag_name` (e.g. `v0.9.2` → `0.9.2`, `0.9`, `0`).

Replace the tag list with:
```
0.9.2     ← patch (no v-prefix, conventional for image tags)
v0.9.2    ← with v-prefix (matches the git tag)
0.9       ← minor floating tag
0         ← major floating tag
latest    ← always-latest pointer
```

## No new secrets required

Uses only `secrets.GITHUB_TOKEN` with `packages: write` (already declared). No PAT needed — the Docker publish is chained within the same workflow via `needs:`, not via a downstream event trigger.

## How to verify

After merging a Release Please PR:
```bash
docker manifest inspect ghcr.io/sentinel-hub/titiler-openeo:X.Y.Z
docker manifest inspect ghcr.io/sentinel-hub/titiler-openeo:X.Y
docker manifest inspect ghcr.io/sentinel-hub/titiler-openeo:X
docker manifest inspect ghcr.io/sentinel-hub/titiler-openeo:latest
```
All four should return identical `RepoDigests`.