### PR TITLE
feat: virtual bands plugin mechanism

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,19 @@ export $(cat .env | xargs)
 uvicorn titiler.openeo.main:app --host 0.0.0.0 --port 8081
 ```
 
+> **Stale `*.egg-info` shadows entry points.** The project builds with
+> `hatchling`. A leftover `titiler_openeo.egg-info/` directory at the repo root
+> (from an old `setuptools`/`pip install -e .`) is picked up by
+> `importlib.metadata` *before* the hatchling install and lacks the
+> `entry_points.txt`, so plugin entry points (e.g.
+> `titiler.openeo.virtual_bands`) silently resolve to nothing. If a registered
+> plugin reports as "unknown", remove the stale directory and re-sync:
+>
+> ```bash
+> rm -rf titiler_openeo.egg-info
+> uv sync --reinstall-package titiler-openeo
+> ```
+
 ## Pre-commit hooks
 
 This repo is set to use `pre-commit` to run *isort*, *flake8*, *pydocstring*, *black*, and *mypy* when committing new code.

--- a/deployment/k8s/charts/files/virtual_bands.json
+++ b/deployment/k8s/charts/files/virtual_bands.json
@@ -1,0 +1,12 @@
+{
+  "sentinel-2-l2a": [
+    {
+      "plugin": "normalized_difference",
+      "options": {"name": "NDVI", "a": "B08_10m", "b": "B04_10m"}
+    },
+    {
+      "plugin": "constant_from_property",
+      "options": {"name": "viewZenithMean", "property": "view:incidence_angle"}
+    }
+  ]
+}

--- a/deployment/k8s/charts/templates/configmap.yaml
+++ b/deployment/k8s/charts/templates/configmap.yaml
@@ -16,6 +16,10 @@ data:
   default_services.json: |-
     {{ .Files.Get .Values.database.defaultServices | nindent 4 }}
   {{- end }}
+  {{- if .Values.stac.virtualBandsConfig }}
+  virtual_bands.json: |-
+    {{ .Files.Get .Values.stac.virtualBandsConfig | nindent 4 }}
+  {{- end }}
   {{- if and (eq .Values.auth.method "basic") .Values.auth.basic.enabled }}
   basic-auth-users: {{ toJson .Values.auth.basic.users | quote }}
   {{- end }}

--- a/deployment/k8s/charts/templates/deployment.yaml
+++ b/deployment/k8s/charts/templates/deployment.yaml
@@ -73,6 +73,10 @@ spec:
             # STAC configuration
             - name: TITILER_OPENEO_STAC_API_URL
               value: {{ .Values.stac.apiUrl | quote }}
+            {{- if .Values.stac.virtualBandsConfig }}
+            - name: TITILER_OPENEO_VIRTUAL_BANDS_CONFIG
+              value: "/config/virtual_bands.json"
+            {{- end }}
             # Authentication configuration
             - name: TITILER_OPENEO_AUTH_METHOD
               value: {{ .Values.auth.method | quote }}

--- a/deployment/k8s/charts/tests/virtual_bands_test.yaml
+++ b/deployment/k8s/charts/tests/virtual_bands_test.yaml
@@ -1,0 +1,40 @@
+suite: test virtual bands wiring
+templates:
+  - deployment.yaml
+  - configmap.yaml
+tests:
+  - it: should not set the virtual bands env var by default
+    template: deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TITILER_OPENEO_VIRTUAL_BANDS_CONFIG
+            value: "/config/virtual_bands.json"
+
+  - it: should set the virtual bands env var when configured
+    template: deployment.yaml
+    set:
+      stac.virtualBandsConfig: files/virtual_bands.json
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TITILER_OPENEO_VIRTUAL_BANDS_CONFIG
+            value: "/config/virtual_bands.json"
+
+  - it: should not add the configmap key by default
+    template: configmap.yaml
+    asserts:
+      - exists:
+          path: data["virtual_bands.json"]
+        not: true
+
+  - it: should embed the config in the configmap when configured
+    template: configmap.yaml
+    set:
+      stac.virtualBandsConfig: files/virtual_bands.json
+    asserts:
+      - matchRegex:
+          path: data["virtual_bands.json"]
+          pattern: normalized_difference

--- a/deployment/k8s/charts/values.yaml
+++ b/deployment/k8s/charts/values.yaml
@@ -86,6 +86,13 @@ auth:
 # STAC configuration
 stac:
   apiUrl: "https://stac.eoapi.dev"  # STAC API endpoint URL
+  # Virtual bands plugin configuration. Path (relative to the chart) to a JSON
+  # file binding virtual band plugins to collections. The referenced plugins
+  # must be registered as `titiler.openeo.virtual_bands` entry points in the
+  # running image (the built-in examples ship with titiler-openeo; custom
+  # plugins require a custom image). Leave empty to disable. Example:
+  # files/virtual_bands.json
+  virtualBandsConfig: ""
 
 env:
   CPL_TMPDIR: /tmp

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
       - Parameter Management: "parameter-management.md"
       - Service Authorization: "authorization.md"
       - Tile Assignment: "tile-assignment.md"
+      - Virtual Bands: "virtual-bands.md"
   - Administrator Guide:
     - Overview: "admin-guide.md"
     - OpenID Connect: "openid-connect.md"

--- a/docs/src/virtual-bands.md
+++ b/docs/src/virtual-bands.md
@@ -1,0 +1,137 @@
+# Virtual Bands
+
+Some collections need bands that do **not** exist as raster assets in the source
+STAC catalog. A common example: Sentinel-2 view/sun angle bands
+(`viewZenithMean`, `sunZenithAngles`, ...) used by SentinelHub-style eval scripts.
+In catalogs such as the CDSE Sentinel-2 catalog these are not raster files — they
+exist only as per-scene scalar properties (`view:incidence_angle`, `view:azimuth`,
+`view:sun_azimuth`). Reconstructing them is therefore **collection-specific**.
+
+The **virtual bands** mechanism lets you declare such bands through a plugin that is
+bound to a collection in configuration. A virtual band is:
+
+- **advertised** in the collection's `cube:dimensions` band dimension, so openEO
+  clients accept it as a valid band name; and
+- **computed lazily** at read time from STAC item metadata and/or the pixel values
+  of real bands, only when (and if) a data slice is actually materialized.
+
+## Configuration
+
+Set `TITILER_OPENEO_VIRTUAL_BANDS_CONFIG` to the path of a JSON file mapping
+collection ids to a list of plugin bindings:
+
+```json
+{
+  "sentinel-2-l2a": [
+    {
+      "plugin": "normalized_difference",
+      "options": {"name": "NDVI", "a": "B08_10m", "b": "B04_10m"}
+    },
+    {
+      "plugin": "constant_from_property",
+      "options": {"name": "viewZenithMean", "property": "view:incidence_angle"}
+    }
+  ]
+}
+```
+
+Each entry references a `plugin` by its **entry-point name** (see below) and passes
+`options` as keyword arguments to the plugin.
+
+### Kubernetes / Helm
+
+The bundled Helm chart wires this for you. Point `stac.virtualBandsConfig` at a
+JSON file in the chart (a sample lives at `files/virtual_bands.json`):
+
+```yaml
+stac:
+  apiUrl: "https://stac.dataspace.copernicus.eu/v1"
+  virtualBandsConfig: "files/virtual_bands.json"
+```
+
+The chart embeds the file in the ConfigMap (mounted at `/config`) and sets
+`TITILER_OPENEO_VIRTUAL_BANDS_CONFIG=/config/virtual_bands.json`. When the value
+is empty (the default), nothing is mounted and the feature is disabled.
+
+!!! note
+    The referenced plugins must be registered as `titiler.openeo.virtual_bands`
+    entry points **in the running image**. The built-in examples ship with
+    titiler-openeo; custom plugins require building an image that installs your
+    plugin package.
+
+## Built-in example plugins
+
+| Entry-point name         | Class                        | Computes from        |
+|--------------------------|------------------------------|----------------------|
+| `normalized_difference`  | `NormalizedDifferencePlugin` | two real bands `(a-b)/(a+b)` |
+| `constant_from_property` | `ConstantFromPropertyPlugin` | a scalar STAC item property, broadcast over the grid |
+
+`constant_from_property` shows how to wire values that are **not** raster assets:
+the value is read from `item.properties[...]` and broadcast to the output grid. It
+is the generic pattern for reconstructing per-scene angle bands.
+
+!!! note
+    A purely property-derived band has no real band of its own, so request it
+    **alongside at least one real band** (e.g. `["SCL", "viewZenithMean"]`). The
+    real band anchors the output grid (shape, CRS, bounds); without it the loader
+    raises an error.
+
+## Writing a plugin
+
+Plugins subclass `VirtualBandPlugin` and are discovered through the
+`titiler.openeo.virtual_bands` entry-point group.
+
+```python
+from typing import List
+import numpy, pystac
+from rio_tiler.models import ImageData
+from titiler.openeo.virtualbands import BandMetadata, VirtualBandPlugin, band_array
+
+
+class MyIndexPlugin(VirtualBandPlugin):
+    def __init__(self, name: str, a: str, b: str, **options):
+        super().__init__(name=name, a=a, b=b, **options)
+        self.name, self.a, self.b = name, a, b
+
+    def provided_bands(self) -> List[BandMetadata]:
+        return [BandMetadata(name=self.name, description="my index")]
+
+    def required_bands(self) -> List[str]:
+        # Real bands the loader must read so they are available in `compute`.
+        return [self.a, self.b]
+
+    def compute(self, name: str, items: List[pystac.Item], image: ImageData):
+        a = band_array(image, self.a)   # look bands up by name
+        b = band_array(image, self.b)
+        return (a - b) / (a + b)
+```
+
+Register it via entry points in your package's `pyproject.toml`:
+
+```toml
+[project.entry-points."titiler.openeo.virtual_bands"]
+my_index = "my_package.plugins:MyIndexPlugin"
+```
+
+### The plugin interface
+
+- `provided_bands() -> list[BandMetadata]` — band(s) added to the collection.
+- `required_bands() -> list[str]` — real asset bands the loader must read so they
+  are present in `compute`'s `image`. Empty for purely metadata-derived bands.
+- `compute(name, items, image) -> ndarray` — return a `(H, W)` (or `(1, H, W)`)
+  array aligned to `image`. `items` are the STAC items for the slice (use
+  `item.properties` for metadata-derived values); `image.band_names` are the real
+  band names, so `band_array(image, name)` looks them up.
+
+## How it works
+
+- **Metadata**: the registry augments each collection's `cube:dimensions` band
+  dimension with the provided band names (`stacApiBackend._augment_with_virtual_bands`).
+- **Reading**: `load_collection` splits the requested bands into real, virtual, and
+  *support* bands (real bands needed only to compute requested virtual bands). It
+  reads `real + support`, then — inside the lazy per-slice task — computes each
+  requested virtual band and reorders the output to exactly the requested band
+  order, dropping support-only bands.
+- **Laziness**: `compute` runs only when a slice is materialized, and only for
+  bands the user actually requested. Collections with no bound plugins follow the
+  original code path unchanged.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,10 @@ duckdb = ["duckdb"]
 postgres = ["sqlalchemy>=2.0.0", "psycopg2-binary"]
 oidc = ["cryptography", "httpx"]
 
+[project.entry-points."titiler.openeo.virtual_bands"]
+normalized_difference = "titiler.openeo.virtualbands.examples:NormalizedDifferencePlugin"
+constant_from_property = "titiler.openeo.virtualbands.examples:ConstantFromPropertyPlugin"
+
 [project.urls]
 Homepage = "https://sentinel-hub.github.io/titiler-openeo/"
 Documentation = "https://sentinel-hub.github.io/titiler-openeo/"

--- a/tests/test_virtual_bands.py
+++ b/tests/test_virtual_bands.py
@@ -1,0 +1,357 @@
+"""Tests for the virtual bands plugin mechanism."""
+
+from typing import List
+
+import numpy
+import pytest
+from openeo_pg_parser_networkx.pg_schema import BoundingBox
+from pystac import Item
+from rio_tiler.models import ImageData
+
+from titiler.openeo.reader import SimpleSTACReader
+from titiler.openeo.stacapi import LoadCollection, stacApiBackend
+from titiler.openeo.virtualbands import (
+    BandMetadata,
+    VirtualBandPlugin,
+    VirtualBandRegistry,
+)
+
+
+def _item(assets, properties=None):
+    """Build a minimal projected STAC item with the given asset names."""
+    props = {
+        "datetime": "2021-01-01T00:00:00Z",
+        "proj:crs": "EPSG:4326",
+        "proj:transform": [0.0002, 0.0, 0.0, 0.0, -0.0002, 0.0],
+    }
+    props.update(properties or {})
+    return Item.from_dict(
+        {
+            "type": "Feature",
+            "id": "test-item",
+            "stac_version": "1.0.0",
+            "stac_extensions": [
+                "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+            ],
+            "bbox": [0, 0, 1, 1],
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+            },
+            "properties": props,
+            "assets": {
+                name: {
+                    "href": f"https://example.com/{name}.tif",
+                    "type": "image/tiff; application=geotiff",
+                }
+                for name in assets
+            },
+            "links": [],
+        }
+    )
+
+
+class _MockReader(SimpleSTACReader):
+    def part(self, bbox, **kwargs):
+        return ImageData(
+            numpy.zeros(
+                (1, kwargs.get("height", 4), kwargs.get("width", 4)), dtype="uint8"
+            ),
+            crs=kwargs.get("dst_crs", "EPSG:4326"),
+        )
+
+
+def _mosaic_mock(value_map, calls=None):
+    """Return a mosaic_reader replacement filling each asset with a known value."""
+
+    def _m(items, reader, bbox, **kwargs):
+        assets = kwargs["assets"]
+        if calls is not None:
+            calls.append(list(assets))
+        h = kwargs.get("height") or 4
+        w = kwargs.get("width") or 4
+        arr = numpy.ma.stack(
+            [numpy.full((h, w), value_map[a], dtype="float32") for a in assets]
+        )
+        return ImageData(arr, crs=kwargs.get("dst_crs", "EPSG:4326")), None
+
+    return _m
+
+
+# --------------------------------------------------------------------------- #
+# Registry
+# --------------------------------------------------------------------------- #
+
+
+def test_registry_from_config_resolves_entry_point():
+    reg = VirtualBandRegistry.from_config(
+        {
+            "col": [
+                {
+                    "plugin": "normalized_difference",
+                    "options": {"name": "NDVI", "a": "B08", "b": "B04"},
+                }
+            ]
+        }
+    )
+    assert reg.has_plugins("col")
+    assert reg.virtual_band_names("col") == ["NDVI"]
+    assert not reg.has_plugins("other")
+
+
+def test_registry_unknown_plugin_raises():
+    with pytest.raises(ValueError, match="Unknown virtual band plugin"):
+        VirtualBandRegistry.from_config({"col": [{"plugin": "does-not-exist"}]})
+
+
+def test_registry_empty():
+    reg = VirtualBandRegistry.empty()
+    assert not reg.has_plugins("col")
+    assert reg.virtual_band_names("col") == []
+
+
+def test_registry_split_preserves_order_and_collects_support():
+    reg = VirtualBandRegistry.from_config(
+        {
+            "col": [
+                {
+                    "plugin": "normalized_difference",
+                    "options": {"name": "NDVI", "a": "B08", "b": "B04"},
+                }
+            ]
+        }
+    )
+    split = reg.split("col", ["SCL", "NDVI", "B02"])
+    assert split.real == ["SCL", "B02"]
+    assert split.virtual == ["NDVI"]
+    assert split.support == ["B08", "B04"]
+
+
+def test_registry_split_no_support_when_band_already_requested():
+    reg = VirtualBandRegistry.from_config(
+        {
+            "col": [
+                {
+                    "plugin": "normalized_difference",
+                    "options": {"name": "NDVI", "a": "B08", "b": "B04"},
+                }
+            ]
+        }
+    )
+    split = reg.split("col", ["B08", "NDVI", "B04"])
+    assert split.support == []
+
+
+# --------------------------------------------------------------------------- #
+# Metadata augmentation
+# --------------------------------------------------------------------------- #
+
+
+def _backend_with_ndvi():
+    reg = VirtualBandRegistry.from_config(
+        {
+            "col": [
+                {
+                    "plugin": "normalized_difference",
+                    "options": {"name": "NDVI", "a": "B08", "b": "B04"},
+                }
+            ]
+        }
+    )
+    return stacApiBackend(url="https://example.com", virtual_bands=reg)
+
+
+def test_augment_appends_to_existing_band_dimension():
+    backend = _backend_with_ndvi()
+    col = {"id": "col", "cube:dimensions": {"b": {"type": "bands", "values": ["SCL"]}}}
+    backend._augment_with_virtual_bands(col)
+    assert col["cube:dimensions"]["b"]["values"] == ["SCL", "NDVI"]
+
+
+def test_augment_creates_band_dimension_when_missing():
+    backend = _backend_with_ndvi()
+    col = {"id": "col", "cube:dimensions": {}}
+    backend._augment_with_virtual_bands(col)
+    assert col["cube:dimensions"]["spectral"] == {"type": "bands", "values": ["NDVI"]}
+
+
+def test_augment_noop_without_plugins():
+    backend = stacApiBackend(url="https://example.com")
+    col = {"id": "col", "cube:dimensions": {"b": {"type": "bands", "values": ["SCL"]}}}
+    backend._augment_with_virtual_bands(col)
+    assert col["cube:dimensions"]["b"]["values"] == ["SCL"]
+
+
+# --------------------------------------------------------------------------- #
+# Read path: band-math (NDVI) and ordering
+# --------------------------------------------------------------------------- #
+
+
+def test_load_collection_computes_ndvi_and_preserves_order(monkeypatch):
+    reg = VirtualBandRegistry.from_config(
+        {
+            "col": [
+                {
+                    "plugin": "normalized_difference",
+                    "options": {"name": "NDVI", "a": "B08", "b": "B04"},
+                }
+            ]
+        }
+    )
+    item = _item(["SCL", "B08", "B04"])
+    monkeypatch.setattr("titiler.openeo.reader.SimpleSTACReader", _MockReader)
+    monkeypatch.setattr(LoadCollection, "_get_items", lambda *a, **k: [item])
+    monkeypatch.setattr(
+        "titiler.openeo.stacapi.mosaic_reader",
+        _mosaic_mock({"SCL": 1.0, "B08": 0.6, "B04": 0.2}),
+    )
+
+    loader = LoadCollection(stac_api=stacApiBackend(url="https://x", virtual_bands=reg))
+    result = loader.load_collection(
+        id="col",
+        spatial_extent=BoundingBox(west=0, south=0, east=1, north=1, crs="EPSG:4326"),
+        bands=["SCL", "NDVI"],
+        width=4,
+        height=4,
+    )
+
+    assert result.band_names == ["SCL", "NDVI"]
+    img = next(iter(result.values()))
+    assert img.band_names == ["SCL", "NDVI"]
+    assert img.array.shape[0] == 2
+    # SCL passthrough, NDVI = (0.6 - 0.2) / (0.6 + 0.2) = 0.5; support bands dropped
+    numpy.testing.assert_allclose(img.array[0], 1.0)
+    numpy.testing.assert_allclose(img.array[1], 0.5, rtol=1e-5)
+
+
+def test_load_collection_property_virtual_band(monkeypatch):
+    reg = VirtualBandRegistry.from_config(
+        {
+            "col": [
+                {
+                    "plugin": "constant_from_property",
+                    "options": {
+                        "name": "viewZenithMean",
+                        "property": "view:incidence_angle",
+                    },
+                }
+            ]
+        }
+    )
+    item = _item(["SCL"], properties={"view:incidence_angle": 7.5})
+    monkeypatch.setattr("titiler.openeo.reader.SimpleSTACReader", _MockReader)
+    monkeypatch.setattr(LoadCollection, "_get_items", lambda *a, **k: [item])
+    monkeypatch.setattr(
+        "titiler.openeo.stacapi.mosaic_reader", _mosaic_mock({"SCL": 1.0})
+    )
+
+    loader = LoadCollection(stac_api=stacApiBackend(url="https://x", virtual_bands=reg))
+    result = loader.load_collection(
+        id="col",
+        spatial_extent=BoundingBox(west=0, south=0, east=1, north=1, crs="EPSG:4326"),
+        bands=["SCL", "viewZenithMean"],
+        width=4,
+        height=4,
+    )
+    img = next(iter(result.values()))
+    assert img.band_names == ["SCL", "viewZenithMean"]
+    numpy.testing.assert_allclose(img.array[1], 7.5)
+
+
+def test_load_collection_no_plugins_is_unchanged(monkeypatch):
+    """Regression: a collection with no plugins reads exactly the requested bands."""
+    calls: List[List[str]] = []
+    item = _item(["B04", "B08"])
+    monkeypatch.setattr("titiler.openeo.reader.SimpleSTACReader", _MockReader)
+    monkeypatch.setattr(LoadCollection, "_get_items", lambda *a, **k: [item])
+    monkeypatch.setattr(
+        "titiler.openeo.stacapi.mosaic_reader",
+        _mosaic_mock({"B04": 0.2, "B08": 0.6}, calls=calls),
+    )
+
+    loader = LoadCollection(stac_api=stacApiBackend(url="https://x"))
+    result = loader.load_collection(
+        id="col",
+        spatial_extent=BoundingBox(west=0, south=0, east=1, north=1, crs="EPSG:4326"),
+        bands=["B04", "B08"],
+        width=4,
+        height=4,
+    )
+    next(iter(result.values()))
+    assert calls == [["B04", "B08"]]  # no support bands, exact order
+    assert result.band_names == ["B04", "B08"]
+
+
+# --------------------------------------------------------------------------- #
+# Laziness
+# --------------------------------------------------------------------------- #
+
+
+class _CountingPlugin(VirtualBandPlugin):
+    def __init__(self):
+        super().__init__()
+        self.calls = 0
+
+    def provided_bands(self) -> List[BandMetadata]:
+        return [BandMetadata(name="VBAND")]
+
+    def required_bands(self) -> List[str]:
+        return ["B04"]
+
+    def compute(self, name, items, image):
+        self.calls += 1
+        return numpy.ma.zeros(image.array.shape[-2:], dtype="float32")
+
+
+def test_virtual_band_not_computed_until_slice_materialized(monkeypatch):
+    plugin = _CountingPlugin()
+    reg = VirtualBandRegistry({"col": [plugin]})
+    item = _item(["B04"])
+    monkeypatch.setattr("titiler.openeo.reader.SimpleSTACReader", _MockReader)
+    monkeypatch.setattr(LoadCollection, "_get_items", lambda *a, **k: [item])
+    monkeypatch.setattr(
+        "titiler.openeo.stacapi.mosaic_reader", _mosaic_mock({"B04": 0.2})
+    )
+
+    loader = LoadCollection(stac_api=stacApiBackend(url="https://x", virtual_bands=reg))
+    result = loader.load_collection(
+        id="col",
+        spatial_extent=BoundingBox(west=0, south=0, east=1, north=1, crs="EPSG:4326"),
+        bands=["VBAND"],
+        width=4,
+        height=4,
+    )
+    # Nothing computed at graph-build time.
+    assert plugin.calls == 0
+    # Computed once the slice is realized.
+    next(iter(result.values()))
+    assert plugin.calls == 1
+
+
+def test_purely_virtual_without_grid_anchor_raises(monkeypatch):
+    """A purely property-derived band with no real band to anchor the grid errors."""
+    reg = VirtualBandRegistry.from_config(
+        {
+            "col": [
+                {
+                    "plugin": "constant_from_property",
+                    "options": {"name": "ANGLE", "property": "view:incidence_angle"},
+                }
+            ]
+        }
+    )
+    item = _item(["SCL"], properties={"view:incidence_angle": 7.5})
+    monkeypatch.setattr("titiler.openeo.reader.SimpleSTACReader", _MockReader)
+    monkeypatch.setattr(LoadCollection, "_get_items", lambda *a, **k: [item])
+
+    loader = LoadCollection(stac_api=stacApiBackend(url="https://x", virtual_bands=reg))
+    with pytest.raises(ValueError, match="anchor the output grid"):
+        loader.load_collection(
+            id="col",
+            spatial_extent=BoundingBox(
+                west=0, south=0, east=1, north=1, crs="EPSG:4326"
+            ),
+            bands=["ANGLE"],
+            width=4,
+            height=4,
+        )

--- a/tests/test_virtual_bands.py
+++ b/tests/test_virtual_bands.py
@@ -110,6 +110,41 @@ def test_registry_empty():
     assert reg.virtual_band_names("col") == []
 
 
+def test_registry_malformed_entry_raises():
+    with pytest.raises(ValueError, match="must be an object with a 'plugin' key"):
+        VirtualBandRegistry.from_config({"col": ["not-a-dict"]})
+
+
+def test_registry_entries_must_be_a_list():
+    with pytest.raises(ValueError, match="must be a list of plugin entries"):
+        VirtualBandRegistry.from_config({"col": {"plugin": "normalized_difference"}})
+
+
+def test_registry_options_must_be_object():
+    with pytest.raises(ValueError, match="'options' for plugin"):
+        VirtualBandRegistry.from_config(
+            {"col": [{"plugin": "normalized_difference", "options": ["a", "b"]}]}
+        )
+
+
+def test_registry_rejects_duplicate_band_names():
+    with pytest.raises(ValueError, match="Duplicate virtual band name 'NDVI'"):
+        VirtualBandRegistry.from_config(
+            {
+                "col": [
+                    {
+                        "plugin": "normalized_difference",
+                        "options": {"name": "NDVI", "a": "B08", "b": "B04"},
+                    },
+                    {
+                        "plugin": "normalized_difference",
+                        "options": {"name": "NDVI", "a": "B05", "b": "B04"},
+                    },
+                ]
+            }
+        )
+
+
 def test_registry_split_preserves_order_and_collects_support():
     reg = VirtualBandRegistry.from_config(
         {
@@ -326,6 +361,39 @@ def test_virtual_band_not_computed_until_slice_materialized(monkeypatch):
     # Computed once the slice is realized.
     next(iter(result.values()))
     assert plugin.calls == 1
+
+
+class _BadShapePlugin(VirtualBandPlugin):
+    def provided_bands(self) -> List[BandMetadata]:
+        return [BandMetadata(name="BAD")]
+
+    def required_bands(self) -> List[str]:
+        return ["B04"]
+
+    def compute(self, name, items, image):
+        # Wrong shape: extra leading dimension.
+        return numpy.ma.zeros((2, *image.array.shape[-2:]), dtype="float32")
+
+
+def test_virtual_band_bad_shape_raises(monkeypatch):
+    reg = VirtualBandRegistry({"col": [_BadShapePlugin()]})
+    item = _item(["B04"])
+    monkeypatch.setattr("titiler.openeo.reader.SimpleSTACReader", _MockReader)
+    monkeypatch.setattr(LoadCollection, "_get_items", lambda *a, **k: [item])
+    monkeypatch.setattr(
+        "titiler.openeo.stacapi.mosaic_reader", _mosaic_mock({"B04": 0.2})
+    )
+
+    loader = LoadCollection(stac_api=stacApiBackend(url="https://x", virtual_bands=reg))
+    result = loader.load_collection(
+        id="col",
+        spatial_extent=BoundingBox(west=0, south=0, east=1, north=1, crs="EPSG:4326"),
+        bands=["B04", "BAD"],
+        width=4,
+        height=4,
+    )
+    with pytest.raises(ValueError, match="returned an array of shape"):
+        next(iter(result.values()))
 
 
 def test_purely_virtual_without_grid_anchor_raises(monkeypatch):

--- a/titiler/openeo/main.py
+++ b/titiler/openeo/main.py
@@ -32,8 +32,14 @@ def _load_virtual_bands_registry(config_path: str | None) -> VirtualBandRegistry
 
     import json
 
-    with open(config_path) as f:
-        config = json.load(f)
+    try:
+        with open(config_path) as f:
+            config = json.load(f)
+    except (OSError, json.JSONDecodeError) as err:
+        raise ValueError(
+            f"Failed to load virtual bands config from "
+            f"TITILER_OPENEO_VIRTUAL_BANDS_CONFIG='{config_path}': {err}"
+        ) from err
     return VirtualBandRegistry.from_config(config)
 
 

--- a/titiler/openeo/main.py
+++ b/titiler/openeo/main.py
@@ -20,8 +20,22 @@ from .processes import PROCESS_SPECIFICATIONS, process_registry
 from .services import get_store, get_tile_store, get_udp_store
 from .settings import ApiSettings, AuthSettings, BackendSettings
 from .stacapi import LoadCollection, LoadStac, stacApiBackend
+from .virtualbands import VirtualBandRegistry
 
 STAC_VERSION = "1.0.0"
+
+
+def _load_virtual_bands_registry(config_path: str | None) -> VirtualBandRegistry:
+    """Build the virtual band registry from a JSON config file (if configured)."""
+    if not config_path:
+        return VirtualBandRegistry.empty()
+
+    import json
+
+    with open(config_path) as f:
+        config = json.load(f)
+    return VirtualBandRegistry.from_config(config)
+
 
 api_settings = ApiSettings()
 auth_settings = AuthSettings()
@@ -35,9 +49,11 @@ except Exception as err:
         "Please set TITILER_OPENEO_STAC_API_URL and TITILER_OPENEO_STORE_URL"
     ) from err
 
+virtual_bands = _load_virtual_bands_registry(backend_settings.virtual_bands_config)
 stac_client = stacApiBackend(
     str(backend_settings.stac_api_url),
     exclude_collections=backend_settings.exclude_collections,
+    virtual_bands=virtual_bands,
 )  # type: ignore
 service_store = get_store(str(backend_settings.store_url))
 udp_store = get_udp_store(str(backend_settings.store_url))

--- a/titiler/openeo/settings.py
+++ b/titiler/openeo/settings.py
@@ -169,6 +169,9 @@ class BackendSettings(BaseSettings):
     default_services_file: Optional[str] = (
         None  # Path to default services configuration file
     )
+    virtual_bands_config: Optional[str] = (
+        None  # Path to JSON config binding virtual band plugins to collections
+    )
     exclude_collections: list[str] = Field(
         default_factory=list,
         description="List of collection IDs to exclude from the API (e.g. non-compliant STAC collections).",

--- a/titiler/openeo/stacapi.py
+++ b/titiler/openeo/stacapi.py
@@ -192,12 +192,14 @@ class stacApiBackend:
             # Preserve item_assets declaration order (and stay JSON-serializable);
             # an unordered set here led to non-deterministic band order (#280).
             bands_name: List[str] = []
+            seen_bands: set = set()
             for key, asset in collection.ext.item_assets.items():
                 if (
                     "data" in asset.properties.get("roles", [])
-                    and key not in bands_name
+                    and key not in seen_bands
                 ):
                     bands_name.append(key)
+                    seen_bands.add(key)
             if bands_name:
                 dims["spectral"] = dc.Dimension.from_dict(
                     {
@@ -339,8 +341,15 @@ def _assemble_virtual_bands(
             if plugin is None:  # pragma: no cover - guarded by virtual_names
                 raise ValueError(f"No plugin provides virtual band '{name}'")
             arr = plugin.compute(name, items, img)
-            if arr.ndim == 2:
+            expected_hw = img.array.shape[-2:]
+            if arr.ndim == 2 and arr.shape == expected_hw:
                 arr = arr[numpy.newaxis, ...]
+            elif not (arr.ndim == 3 and arr.shape == (1, *expected_hw)):
+                raise ValueError(
+                    f"Virtual band '{name}' plugin "
+                    f"{type(plugin).__name__} returned an array of shape "
+                    f"{arr.shape}; expected {expected_hw} or (1, *{expected_hw})"
+                )
             out_arrays.append(arr)
         else:
             i = real_index[name]

--- a/titiler/openeo/stacapi.py
+++ b/titiler/openeo/stacapi.py
@@ -3,6 +3,7 @@
 from threading import Lock
 from typing import Any, Dict, List, Optional, Sequence, Union
 
+import numpy
 import pyproj
 import pystac
 from attrs import define, field
@@ -22,6 +23,7 @@ from pystac_client.stac_api_io import StacApiIO
 from rasterio.warp import transform_bounds
 from rio_tiler.constants import MAX_THREADS
 from rio_tiler.errors import TileOutsideBounds
+from rio_tiler.models import ImageData
 from rio_tiler.mosaic.methods import PixelSelectionMethod
 from rio_tiler.mosaic.reader import mosaic_reader
 from rio_tiler.tasks import create_tasks
@@ -39,6 +41,7 @@ from .processes.implementations.data_model import RasterStack
 from .processes.implementations.utils import _props_to_datetime, to_rasterio_crs
 from .reader import _estimate_output_dimensions, _reader
 from .settings import CacheSettings, ProcessingSettings, PySTACSettings
+from .virtualbands import VirtualBandRegistry
 
 pystac_settings = PySTACSettings()
 cache_config = CacheSettings()
@@ -58,6 +61,7 @@ class stacApiBackend:
 
     url: str = field()
     exclude_collections: list = field(factory=list)
+    virtual_bands: VirtualBandRegistry = field(factory=VirtualBandRegistry.empty)
     _client_cache: Client = field(default=None, init=False)
 
     @property
@@ -98,6 +102,7 @@ class stacApiBackend:
 
             col_dict = collection.to_dict()
             self._fix_collection(col_dict)
+            self._augment_with_virtual_bands(col_dict)
             collections.append(col_dict)
 
         return collections
@@ -184,11 +189,16 @@ class stacApiBackend:
         # bands
         if "item_assets" in collection.extra_fields:
             ia.ItemAssetsExtension.add_to(collection)
-            bands_name = set()
+            # Preserve item_assets declaration order (and stay JSON-serializable);
+            # an unordered set here led to non-deterministic band order (#280).
+            bands_name: List[str] = []
             for key, asset in collection.ext.item_assets.items():
-                if "data" in asset.properties.get("roles", []):
-                    bands_name.add(key)
-            if len(bands_name) > 0:
+                if (
+                    "data" in asset.properties.get("roles", [])
+                    and key not in bands_name
+                ):
+                    bands_name.append(key)
+            if bands_name:
                 dims["spectral"] = dc.Dimension.from_dict(
                     {
                         "type": "bands",
@@ -197,6 +207,35 @@ class stacApiBackend:
                 )
 
         return dims
+
+    def _augment_with_virtual_bands(self, collection: Dict) -> None:
+        """Add registered virtual band names to the collection band dimension.
+
+        Pure metadata operation: ensures a ``cube:dimensions`` band dimension
+        exists and appends the virtual band names (deterministic order) so openEO
+        clients accept them. Does not read data or invoke plugin ``compute``.
+        """
+        collection_id = collection.get("id")
+        if not collection_id or not self.virtual_bands.has_plugins(collection_id):
+            return
+
+        names = self.virtual_bands.virtual_band_names(collection_id)
+        if not names:
+            return
+
+        cube_dims = collection.setdefault("cube:dimensions", {})
+        band_dim = next(
+            (d for d in cube_dims.values() if d.get("type") == "bands"), None
+        )
+        if band_dim is None:
+            band_dim = {"type": "bands", "values": []}
+            cube_dims["spectral"] = band_dim
+
+        values = list(band_dim.get("values") or [])
+        for name in names:
+            if name not in values:
+                values.append(name)
+        band_dim["values"] = values
 
     def getvariables(self, collection: Collection) -> Dict[str, dc.Variable]:
         """Get variables from collection"""
@@ -233,6 +272,7 @@ class stacApiBackend:
 
         col_dict = collection.to_dict()
         self._fix_collection(col_dict)
+        self._augment_with_virtual_bands(col_dict)
 
         return col_dict
 
@@ -271,6 +311,48 @@ class stacApiBackend:
             max_items=max_items,
         )
         return list(items.items())
+
+
+def _assemble_virtual_bands(
+    img: ImageData,
+    requested_bands: List[str],
+    read_bands: List[str],
+    virtual_names: set,
+    registry: VirtualBandRegistry,
+    collection_id: str,
+    items: List[Item],
+) -> ImageData:
+    """Compute requested virtual bands and reorder to the requested band order.
+
+    Runs inside the lazy per-date task, so it only executes when a slice is
+    materialized. ``img`` holds the real bands in ``read_bands`` order; the
+    returned ImageData holds exactly ``requested_bands`` in that order.
+    """
+    # Expose the real band names so plugins can look bands up by name.
+    img.band_names = read_bands
+    real_index = {name: i for i, name in enumerate(read_bands)}
+
+    out_arrays = []
+    for name in requested_bands:
+        if name in virtual_names:
+            plugin = registry.plugin_for_band(collection_id, name)
+            if plugin is None:  # pragma: no cover - guarded by virtual_names
+                raise ValueError(f"No plugin provides virtual band '{name}'")
+            arr = plugin.compute(name, items, img)
+            if arr.ndim == 2:
+                arr = arr[numpy.newaxis, ...]
+            out_arrays.append(arr)
+        else:
+            i = real_index[name]
+            out_arrays.append(img.array[i : i + 1])
+
+    final = numpy.ma.concatenate(out_arrays, axis=0)
+    return ImageData(
+        final,
+        bounds=img.bounds,
+        crs=img.crs,
+        band_names=requested_bands,
+    )
 
 
 @define
@@ -709,6 +791,34 @@ class LoadCollection:
 
         return cql2_filter
 
+    def _resolve_virtual_bands(
+        self, collection_id: str, bands: Optional[List[str]]
+    ) -> tuple[set, Optional[List[str]]]:
+        """Split requested bands into virtual names and the real bands to read.
+
+        Pure metadata work (no reads, no plugin compute). Returns the set of
+        requested virtual band names and the list of real bands to actually read
+        (requested real bands plus support bands needed to compute the virtual
+        ones). When no virtual bands are requested, returns ``(set(), bands)``.
+        """
+        registry = self.stac_api.virtual_bands
+        if not bands or not registry.has_plugins(collection_id):
+            return set(), bands
+
+        split = registry.split(collection_id, bands)
+        if not split.virtual:
+            return set(), bands
+
+        read_bands = split.real + split.support
+        if not read_bands:
+            raise ValueError(
+                f"Virtual bands {split.virtual} for collection '{collection_id}' "
+                "require at least one real band to anchor the output grid; "
+                "request a real band alongside them or have the plugin "
+                "declare one via required_bands()."
+            )
+        return set(split.virtual), read_bands
+
     def load_collection(
         self,
         id: str,
@@ -769,9 +879,14 @@ class LoadCollection:
         if bands is None and items and items[0].assets:
             bands = list(items[0].assets.keys())[:1]  # Take the first asset as default
 
-        # Estimate dimensions based on items and spatial extent
+        # Split requested bands into real vs virtual (collection-bound plugins).
+        # This is pure metadata work: no reads and no plugin compute happen here.
+        registry = self.stac_api.virtual_bands
+        virtual_names, read_bands = self._resolve_virtual_bands(id, bands)
+
+        # Estimate dimensions based on the real bands that will actually be read
         dimensions = _estimate_output_dimensions(
-            items, spatial_extent, bands, width, height, target_crs=target_crs
+            items, spatial_extent, read_bands, width, height, target_crs=target_crs
         )
 
         # Extract values from the result
@@ -805,7 +920,7 @@ class LoadCollection:
             bbox: List[float],
             bounds_crs: Any,
             output_crs: Any,
-            bands: Optional[list[str]],
+            read_bands: Optional[list[str]],
             width: int,
             height: int,
             tile_buffer: Optional[float],
@@ -817,7 +932,7 @@ class LoadCollection:
                 mosaic_kwargs = {
                     "threads": 0,
                     "bounds_crs": bounds_crs,
-                    "assets": bands,
+                    "assets": read_bands,
                     "dst_crs": output_crs,
                     "width": int(width) if width else width,
                     "height": int(height) if height else height,
@@ -833,6 +948,21 @@ class LoadCollection:
                     bbox,
                     **mosaic_kwargs,
                 )
+
+                # Lazily compute virtual bands (if any) and reorder the bands to
+                # the originally requested order. Only requested virtual bands are
+                # computed, and only now that this slice is materialized.
+                if virtual_names:
+                    img = _assemble_virtual_bands(
+                        img,
+                        bands,
+                        read_bands,
+                        virtual_names,
+                        registry,
+                        id,
+                        date_items,
+                    )
+
                 return img
 
             return task
@@ -845,7 +975,7 @@ class LoadCollection:
                 bbox,
                 bounds_crs,
                 output_crs,
-                bands,
+                read_bands,
                 width,
                 height,
                 tile_buffer,

--- a/titiler/openeo/virtualbands/__init__.py
+++ b/titiler/openeo/virtualbands/__init__.py
@@ -1,0 +1,19 @@
+"""Virtual bands plugin mechanism for titiler-openeo.
+
+Virtual bands are computed at read time from STAC item metadata and/or real band
+pixel values, and bound to collections through configuration. See
+:mod:`titiler.openeo.virtualbands.registry` for the binding mechanism and
+:mod:`titiler.openeo.virtualbands.base` for the plugin interface.
+"""
+
+from .base import BandMetadata, VirtualBandPlugin, band_array
+from .registry import ENTRY_POINT_GROUP, SplitBands, VirtualBandRegistry
+
+__all__ = [
+    "BandMetadata",
+    "VirtualBandPlugin",
+    "band_array",
+    "VirtualBandRegistry",
+    "SplitBands",
+    "ENTRY_POINT_GROUP",
+]

--- a/titiler/openeo/virtualbands/base.py
+++ b/titiler/openeo/virtualbands/base.py
@@ -1,0 +1,99 @@
+"""Base classes for titiler-openeo virtual bands plugins.
+
+A *virtual band* is a band that does not exist as a raster asset in the source
+STAC catalog but can be computed at read time from STAC item metadata and/or from
+the pixel values of real bands. Plugins are bound to collections through
+configuration (see :mod:`titiler.openeo.virtualbands.registry`).
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import List, Optional
+
+import numpy
+import pystac
+from rio_tiler.models import ImageData
+
+__all__ = ["BandMetadata", "VirtualBandPlugin", "band_array"]
+
+
+@dataclass
+class BandMetadata:
+    """Metadata describing a virtual band.
+
+    Used to advertise the band in the collection's ``cube:dimensions`` band
+    dimension (and, optionally, in ``summaries.eo:bands``) so openEO clients
+    accept it as a valid band name.
+    """
+
+    name: str
+    description: str = ""
+    dtype: str = "float32"
+    common_name: Optional[str] = None
+    unit: Optional[str] = None
+
+
+class VirtualBandPlugin(ABC):
+    """Base class for a collection-bound virtual band plugin.
+
+    Subclasses are instantiated with the ``options`` dictionary from the
+    configuration entry, passed as keyword arguments. They declare the band(s)
+    they provide, the real asset bands they need to compute them, and a
+    ``compute`` method invoked lazily at read time.
+    """
+
+    def __init__(self, **options):
+        """Store plugin options from the configuration entry."""
+        self.options = options
+
+    @abstractmethod
+    def provided_bands(self) -> List[BandMetadata]:
+        """Return metadata for the band(s) this plugin adds to the collection."""
+        ...
+
+    def required_bands(self) -> List[str]:
+        """Real asset band names needed to compute the provided band(s).
+
+        Returns an empty list for purely metadata-derived bands. The loader
+        reads these bands even when the user did not request them in the output.
+        """
+        return []
+
+    @abstractmethod
+    def compute(
+        self,
+        name: str,
+        items: List[pystac.Item],
+        image: ImageData,
+    ) -> numpy.ndarray:
+        """Compute a single virtual band.
+
+        Args:
+            name: The provided band name being requested.
+            items: The source STAC items for the slice being materialized
+                (e.g. all items mosaicked for one datetime). Use these for
+                metadata-derived bands (scalar properties, etc.).
+            image: ImageData of the already-read real bands for this slice. Its
+                ``band_names`` are the real band names, so :func:`band_array` can
+                look bands up by name. Use ``image.bounds``/``image.crs`` and the
+                array shape to align the output to the grid.
+
+        Returns:
+            A 2D ``(H, W)`` or 3D ``(1, H, W)`` array aligned to ``image``.
+        """
+        ...
+
+
+def band_array(image: ImageData, name: str) -> numpy.ndarray:
+    """Return the ``(H, W)`` array for band ``name`` from ``image``.
+
+    Relies on ``image.band_names`` being set to the real band names (the loader
+    does this before invoking :meth:`VirtualBandPlugin.compute`).
+    """
+    try:
+        idx = list(image.band_names).index(name)
+    except ValueError as err:
+        raise ValueError(
+            f"Required band '{name}' not found in image bands {list(image.band_names)}"
+        ) from err
+    return image.array[idx]

--- a/titiler/openeo/virtualbands/examples.py
+++ b/titiler/openeo/virtualbands/examples.py
@@ -1,0 +1,132 @@
+"""Reference virtual band plugins shipped with titiler-openeo."""
+
+from typing import List
+
+import numpy
+import pystac
+from rio_tiler.models import ImageData
+
+from .base import BandMetadata, VirtualBandPlugin, band_array
+
+__all__ = ["NormalizedDifferencePlugin", "ConstantFromPropertyPlugin"]
+
+
+class NormalizedDifferencePlugin(VirtualBandPlugin):
+    """Compute a normalized difference index from two real bands.
+
+    Example configuration entry::
+
+        {"plugin": "normalized_difference",
+         "options": {"name": "NDVI", "a": "B08_10m", "b": "B04_10m"}}
+
+    Produces a band ``name`` equal to ``(a - b) / (a + b)``. This is a trivial
+    reference implementation that exercises the band-math path of the virtual
+    band mechanism.
+    """
+
+    def __init__(self, name: str, a: str, b: str, **options):
+        """Initialize with the output band name and the two source bands."""
+        super().__init__(name=name, a=a, b=b, **options)
+        self.name = name
+        self.a = a
+        self.b = b
+
+    def provided_bands(self) -> List[BandMetadata]:
+        """Advertise the single normalized-difference band."""
+        return [
+            BandMetadata(
+                name=self.name,
+                description=f"Normalized difference ({self.a} - {self.b}) / "
+                f"({self.a} + {self.b})",
+                dtype="float32",
+            )
+        ]
+
+    def required_bands(self) -> List[str]:
+        """The two real bands needed for the computation."""
+        return [self.a, self.b]
+
+    def compute(
+        self,
+        name: str,
+        items: List[pystac.Item],
+        image: ImageData,
+    ) -> numpy.ndarray:
+        """Return ``(a - b) / (a + b)`` aligned to ``image``."""
+        a = band_array(image, self.a).astype("float32")
+        b = band_array(image, self.b).astype("float32")
+        denom = a + b
+        # Avoid division warnings/`inf`; masked where denominator is zero.
+        result = numpy.ma.masked_array(
+            numpy.where(denom != 0, (a - b), 0),
+            mask=numpy.ma.getmaskarray(a) | numpy.ma.getmaskarray(b) | (denom == 0),
+        )
+        result = result / numpy.ma.masked_equal(denom, 0)
+        return result.astype("float32")
+
+
+class ConstantFromPropertyPlugin(VirtualBandPlugin):
+    """Broadcast a per-scene STAC item property value as a constant band.
+
+    This demonstrates wiring values that are *not* raster assets: the value comes
+    from ``item.properties`` rather than from pixel data. It is the generic
+    pattern behind reconstructing Sentinel-2 angle bands (e.g. a scene's mean
+    view/sun angle) as a constant raster.
+
+    Example configuration entry::
+
+        {"plugin": "constant_from_property",
+         "options": {"name": "viewZenithMean", "property": "view:incidence_angle"}}
+
+    The band has no ``required_bands``; it still needs a real band to be requested
+    alongside it so the output grid (shape/CRS/bounds) is defined.
+    """
+
+    def __init__(self, name: str, property: str, default=None, **options):
+        """Initialize with the output band name and source item property key."""
+        super().__init__(name=name, property=property, default=default, **options)
+        self.name = name
+        self.property = property
+        self.default = default
+
+    def provided_bands(self) -> List[BandMetadata]:
+        """Advertise the single property-derived band."""
+        return [
+            BandMetadata(
+                name=self.name,
+                description=f"Constant raster from STAC item property "
+                f"'{self.property}'",
+                dtype="float32",
+            )
+        ]
+
+    def required_bands(self) -> List[str]:
+        """No real bands are needed; the value comes from item metadata."""
+        return []
+
+    def compute(
+        self,
+        name: str,
+        items: List[pystac.Item],
+        image: ImageData,
+    ) -> numpy.ndarray:
+        """Broadcast the property value across ``image``'s grid as a constant."""
+        value = None
+        for item in items:
+            candidate = item.properties.get(self.property)
+            if candidate is not None:
+                value = candidate
+                break
+        if value is None:
+            value = self.default
+        if value is None:
+            raise ValueError(
+                f"Property '{self.property}' not found on items for virtual band "
+                f"'{self.name}' and no default provided"
+            )
+
+        height, width = image.array.shape[-2:]
+        return numpy.ma.masked_array(
+            numpy.full((height, width), float(value), dtype="float32"),
+            mask=False,
+        )

--- a/titiler/openeo/virtualbands/registry.py
+++ b/titiler/openeo/virtualbands/registry.py
@@ -1,0 +1,148 @@
+"""Registry binding virtual band plugins to collections.
+
+Plugins are discovered through Python entry points in the
+``titiler.openeo.virtual_bands`` group and bound to collections via a
+configuration mapping::
+
+    {
+      "<collection_id>": [
+        {"plugin": "<entry_point_name>", "options": {...}},
+        ...
+      ]
+    }
+"""
+
+from importlib.metadata import entry_points
+from typing import Dict, List, NamedTuple, Optional
+
+from .base import BandMetadata, VirtualBandPlugin
+
+__all__ = ["VirtualBandRegistry", "SplitBands", "ENTRY_POINT_GROUP"]
+
+ENTRY_POINT_GROUP = "titiler.openeo.virtual_bands"
+
+
+class SplitBands(NamedTuple):
+    """Result of splitting requested bands against a collection's plugins."""
+
+    real: List[str]
+    """Requested bands that are real assets (in requested order)."""
+
+    virtual: List[str]
+    """Requested bands that are virtual (in requested order)."""
+
+    support: List[str]
+    """Real bands required to compute the requested virtual bands but not
+    themselves requested for output (deduplicated, deterministic order)."""
+
+
+def _load_plugin_classes() -> Dict[str, type]:
+    """Load virtual band plugin classes registered via entry points."""
+    classes: Dict[str, type] = {}
+    for ep in entry_points(group=ENTRY_POINT_GROUP):
+        classes[ep.name] = ep.load()
+    return classes
+
+
+class VirtualBandRegistry:
+    """Maps collection ids to the virtual band plugins bound to them."""
+
+    def __init__(self, plugins: Optional[Dict[str, List[VirtualBandPlugin]]] = None):
+        """Initialize with a mapping of collection id -> plugin instances."""
+        self._plugins: Dict[str, List[VirtualBandPlugin]] = plugins or {}
+
+    @classmethod
+    def empty(cls) -> "VirtualBandRegistry":
+        """Return a registry with no plugins."""
+        return cls({})
+
+    @classmethod
+    def from_config(cls, config: Optional[Dict]) -> "VirtualBandRegistry":
+        """Build a registry from a configuration mapping.
+
+        Args:
+            config: Mapping of collection id to a list of
+                ``{"plugin": name, "options": {...}}`` entries. ``None`` or an
+                empty mapping yields an empty registry.
+
+        Raises:
+            ValueError: If a referenced plugin name is not registered as an
+                entry point.
+        """
+        if not config:
+            return cls.empty()
+
+        available = _load_plugin_classes()
+        plugins: Dict[str, List[VirtualBandPlugin]] = {}
+        for collection_id, entries in config.items():
+            instances: List[VirtualBandPlugin] = []
+            for entry in entries:
+                name = entry["plugin"]
+                if name not in available:
+                    raise ValueError(
+                        f"Unknown virtual band plugin '{name}' for collection "
+                        f"'{collection_id}'. Registered plugins: "
+                        f"{sorted(available)}"
+                    )
+                options = entry.get("options", {})
+                instances.append(available[name](**options))
+            plugins[collection_id] = instances
+        return cls(plugins)
+
+    def has_plugins(self, collection_id: str) -> bool:
+        """Whether any plugin is bound to the collection."""
+        return bool(self._plugins.get(collection_id))
+
+    def plugins_for(self, collection_id: str) -> List[VirtualBandPlugin]:
+        """Return the plugins bound to the collection."""
+        return self._plugins.get(collection_id, [])
+
+    def provided_band_metadata(self, collection_id: str) -> List[BandMetadata]:
+        """Return BandMetadata for every virtual band of the collection."""
+        meta: List[BandMetadata] = []
+        for plugin in self.plugins_for(collection_id):
+            meta.extend(plugin.provided_bands())
+        return meta
+
+    def virtual_band_names(self, collection_id: str) -> List[str]:
+        """Return virtual band names for the collection (deterministic order)."""
+        return [b.name for b in self.provided_band_metadata(collection_id)]
+
+    def plugin_for_band(
+        self, collection_id: str, name: str
+    ) -> Optional[VirtualBandPlugin]:
+        """Return the plugin that provides band ``name``, if any."""
+        for plugin in self.plugins_for(collection_id):
+            if any(b.name == name for b in plugin.provided_bands()):
+                return plugin
+        return None
+
+    def split(self, collection_id: str, requested_bands: List[str]) -> SplitBands:
+        """Partition ``requested_bands`` into real, virtual, and support bands.
+
+        Order of ``real`` and ``virtual`` follows ``requested_bands``. ``support``
+        lists real bands required by the requested virtual bands that are not
+        themselves in ``requested_bands``.
+        """
+        virtual_names = set(self.virtual_band_names(collection_id))
+
+        real: List[str] = []
+        virtual: List[str] = []
+        for band in requested_bands:
+            if band in virtual_names:
+                virtual.append(band)
+            else:
+                real.append(band)
+
+        support: List[str] = []
+        seen = set(real)
+        for name in virtual:
+            plugin = self.plugin_for_band(collection_id, name)
+            if plugin is None:
+                continue
+            for req in plugin.required_bands():
+                if req not in seen:
+                    support.append(req)
+                    seen.add(req)
+
+        return SplitBands(real=real, virtual=virtual, support=support)

--- a/titiler/openeo/virtualbands/registry.py
+++ b/titiler/openeo/virtualbands/registry.py
@@ -66,8 +66,9 @@ class VirtualBandRegistry:
                 empty mapping yields an empty registry.
 
         Raises:
-            ValueError: If a referenced plugin name is not registered as an
-                entry point.
+            ValueError: If the config is malformed, references an unregistered
+                plugin, or binds two plugins that provide the same band name to
+                one collection.
         """
         if not config:
             return cls.empty()
@@ -75,8 +76,20 @@ class VirtualBandRegistry:
         available = _load_plugin_classes()
         plugins: Dict[str, List[VirtualBandPlugin]] = {}
         for collection_id, entries in config.items():
+            if not isinstance(entries, list):
+                raise ValueError(
+                    f"Virtual bands config for collection '{collection_id}' must "
+                    f"be a list of plugin entries, got {type(entries).__name__}"
+                )
+
             instances: List[VirtualBandPlugin] = []
             for entry in entries:
+                if not isinstance(entry, dict) or "plugin" not in entry:
+                    raise ValueError(
+                        f"Invalid virtual band entry for collection "
+                        f"'{collection_id}': each entry must be an object with a "
+                        f"'plugin' key, got {entry!r}"
+                    )
                 name = entry["plugin"]
                 if name not in available:
                     raise ValueError(
@@ -85,9 +98,32 @@ class VirtualBandRegistry:
                         f"{sorted(available)}"
                     )
                 options = entry.get("options", {})
+                if not isinstance(options, dict):
+                    raise ValueError(
+                        f"'options' for plugin '{name}' (collection "
+                        f"'{collection_id}') must be an object, got "
+                        f"{type(options).__name__}"
+                    )
                 instances.append(available[name](**options))
+
+            cls._check_unique_band_names(collection_id, instances)
             plugins[collection_id] = instances
         return cls(plugins)
+
+    @staticmethod
+    def _check_unique_band_names(
+        collection_id: str, plugins: List[VirtualBandPlugin]
+    ) -> None:
+        """Ensure no two plugins advertise the same band name for a collection."""
+        seen: set = set()
+        for plugin in plugins:
+            for band in plugin.provided_bands():
+                if band.name in seen:
+                    raise ValueError(
+                        f"Duplicate virtual band name '{band.name}' for "
+                        f"collection '{collection_id}'; band names must be unique"
+                    )
+                seen.add(band.name)
 
     def has_plugins(self, collection_id: str) -> bool:
         """Whether any plugin is bound to the collection."""


### PR DESCRIPTION
## Summary

Introduces a **plugin mechanism for "virtual bands"** — bands that don't exist as raster assets in the source STAC catalog but can be computed at read time from STAC item metadata and/or real band pixel values, bound to collections via configuration.

### Motivation

A user running the SNAP LAI notebook against the CDSE-deployed titiler-openeo hit `ValueError: Invalid band name/index 'viewZenithMean'`. The openEO client validates requested bands against the collection's `cube:dimensions.spectral.values`, which we derive purely from `item_assets` with a `data` role. The Sentinel-2 angle bands (`viewZenithMean`, `sunZenithAngles`, ...) used by SentinelHub-style eval scripts don't exist as raster assets in the CDSE catalog — they exist only as per-scene scalar properties (`view:incidence_angle`, `view:azimuth`, `view:sun_azimuth`). Such reconstruction is inherently **collection-specific**, hence a plugin mechanism rather than hardcoding.

## What's included

- **`titiler.openeo.virtualbands` package**
  - `VirtualBandPlugin` ABC, `BandMetadata`, `band_array` helper
  - `VirtualBandRegistry` — discovers plugins via the `titiler.openeo.virtual_bands` entry-point group and binds them to collections through config
  - Example plugins: `normalized_difference` (band math) and `constant_from_property` (broadcasts a STAC item property as a constant raster — the generic pattern for angle reconstruction)
- **Metadata**: `stacApiBackend._augment_with_virtual_bands` injects virtual band names into `cube:dimensions` so clients accept them. Also fixes the non-deterministic band order from an unordered set (#280).
- **Read path**: `LoadCollection` splits requested bands into real/virtual/support, reads `real + support`, then — **inside the lazy per-slice task** — computes virtual bands and reorders to the requested order, dropping support-only bands.
- **Laziness**: `compute` runs only when a slice is materialized and only for requested virtual bands. Collections with no plugins follow the unchanged code path.
- **Config**: `TITILER_OPENEO_VIRTUAL_BANDS_CONFIG` (JSON), wired in `main.py`.
- **Kubernetes/Helm**: `stac.virtualBandsConfig` value → ConfigMap embedding + env var, sample `files/virtual_bands.json`, and helm-unittest coverage.
- **Docs**: new `virtual-bands.md` page added to the nav.

### Config example

\`\`\`json
{
  "sentinel-2-l2a": [
    {"plugin": "normalized_difference", "options": {"name": "NDVI", "a": "B08_10m", "b": "B04_10m"}},
    {"plugin": "constant_from_property", "options": {"name": "viewZenithMean", "property": "view:incidence_angle"}}
  ]
}
\`\`\`

## Testing

- `uv run pytest` — full suite green (635 passed); new `tests/test_virtual_bands.py` covers registry, metadata augmentation, read/order, no-plugin regression, and laziness.
- `helm unittest .` — 15 passed; `helm lint` clean.
- pre-commit (ruff/isort/mypy/markdownlint) clean.

## Notes / follow-ups

- The actual Sentinel-2 angle-band plugin (and higher-fidelity reconstruction from granule-metadata 5 km angle grids) is intentionally left as a follow-up; this PR lands the framework + examples.
- Custom (non-bundled) plugins require building an image that installs the plugin package exposing the entry point — the chart wires config, not code.
- Removed a stale git-ignored \`titiler_openeo.egg-info/\` that was shadowing the hatchling dist-info and hiding entry points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)