### PR TITLE
feat: add filter_temporal openEO process

### DIFF
--- a/tests/test_filter_temporal.py
+++ b/tests/test_filter_temporal.py
@@ -1,0 +1,197 @@
+"""Test filter_temporal process."""
+
+from datetime import datetime
+
+import numpy as np
+import pytest
+from rio_tiler.models import ImageData
+
+from titiler.openeo.processes.implementations.data_model import RasterStack
+from titiler.openeo.processes.implementations.filter import (
+    DimensionNotAvailable,
+    filter_temporal,
+)
+from titiler.openeo.processes.implementations.reduce import TemporalExtentEmpty
+
+
+def _make_raster_stack(dates_values):
+    """Helper: create a RasterStack from a list of (datetime, fill_value) tuples."""
+    images = {}
+    for dt, val in dates_values:
+        array = np.ma.ones((2, 4, 4)) * val
+        images[dt] = ImageData(
+            array,
+            assets=[f"asset_{dt.isoformat()}"],
+            crs="EPSG:4326",
+            bounds=(-180, -90, 180, 90),
+            band_descriptions=["red", "green"],
+        )
+    return RasterStack.from_images(images)
+
+
+class TestFilterTemporalBasic:
+    """Basic filter_temporal tests."""
+
+    def test_keeps_only_matching_timestamps(self):
+        """Only timestamps within [start, end) are kept."""
+        data = _make_raster_stack(
+            [
+                (datetime(2020, 1, 15), 1.0),
+                (datetime(2020, 6, 15), 2.0),
+                (datetime(2021, 3, 1), 3.0),
+            ]
+        )
+        result = filter_temporal(data, extent=["2020-01-01", "2021-01-01"])
+        assert isinstance(result, RasterStack)
+        assert sorted(result.keys()) == [
+            datetime(2020, 1, 15),
+            datetime(2020, 6, 15),
+        ]
+
+    def test_left_closed_right_open(self):
+        """Start is included, end is excluded."""
+        data = _make_raster_stack(
+            [
+                (datetime(2020, 1, 1), 1.0),
+                (datetime(2021, 1, 1), 2.0),
+            ]
+        )
+        result = filter_temporal(data, extent=["2020-01-01", "2021-01-01"])
+        assert list(result.keys()) == [datetime(2020, 1, 1)]
+
+    def test_open_start(self):
+        """A null lower boundary keeps everything before the end."""
+        data = _make_raster_stack(
+            [
+                (datetime(2019, 1, 1), 1.0),
+                (datetime(2020, 6, 15), 2.0),
+                (datetime(2021, 3, 1), 3.0),
+            ]
+        )
+        result = filter_temporal(data, extent=[None, "2021-01-01"])
+        assert sorted(result.keys()) == [
+            datetime(2019, 1, 1),
+            datetime(2020, 6, 15),
+        ]
+
+    def test_open_end(self):
+        """A null upper boundary keeps everything from the start onwards."""
+        data = _make_raster_stack(
+            [
+                (datetime(2019, 1, 1), 1.0),
+                (datetime(2020, 6, 15), 2.0),
+                (datetime(2021, 3, 1), 3.0),
+            ]
+        )
+        result = filter_temporal(data, extent=["2020-01-01", None])
+        assert sorted(result.keys()) == [
+            datetime(2020, 6, 15),
+            datetime(2021, 3, 1),
+        ]
+
+    def test_datetime_extent_with_timezone(self):
+        """RFC 3339 date-time strings with Z suffix are supported."""
+        data = _make_raster_stack(
+            [
+                (datetime(2020, 1, 15), 1.0),
+                (datetime(2020, 6, 15), 2.0),
+            ]
+        )
+        result = filter_temporal(
+            data,
+            extent=["2020-01-01T00:00:00Z", "2020-02-01T00:00:00Z"],
+        )
+        assert list(result.keys()) == [datetime(2020, 1, 15)]
+
+    def test_empty_result(self):
+        """An extent matching nothing yields an empty stack."""
+        data = _make_raster_stack([(datetime(2020, 6, 15), 1.0)])
+        result = filter_temporal(data, extent=["2010-01-01", "2011-01-01"])
+        assert len(result) == 0
+
+    def test_preserves_data_values(self):
+        """Filtered images preserve their pixel values and metadata."""
+        data = _make_raster_stack(
+            [
+                (datetime(2020, 6, 15), 7.0),
+                (datetime(2021, 6, 15), 9.0),
+            ]
+        )
+        result = filter_temporal(data, extent=["2020-01-01", "2021-01-01"])
+        img = result[datetime(2020, 6, 15)]
+        np.testing.assert_array_almost_equal(img.array.data, 7.0)
+        assert img.band_descriptions == ["red", "green"]
+
+
+class TestFilterTemporalDimension:
+    """Tests for the optional dimension parameter."""
+
+    @pytest.mark.parametrize("dimension", ["t", "temporal", "time", "T", "Temporal"])
+    def test_valid_dimension_names(self, dimension):
+        """Recognized temporal dimension names are accepted."""
+        data = _make_raster_stack([(datetime(2020, 6, 15), 1.0)])
+        result = filter_temporal(
+            data, extent=["2020-01-01", "2021-01-01"], dimension=dimension
+        )
+        assert len(result) == 1
+
+    def test_unknown_dimension_raises(self):
+        """An unknown dimension raises DimensionNotAvailable."""
+        data = _make_raster_stack([(datetime(2020, 6, 15), 1.0)])
+        with pytest.raises(DimensionNotAvailable):
+            filter_temporal(
+                data, extent=["2020-01-01", "2021-01-01"], dimension="bands"
+            )
+
+
+class TestFilterTemporalValidation:
+    """Validation/exception tests."""
+
+    def test_empty_extent_raises(self):
+        """end <= start raises TemporalExtentEmpty."""
+        data = _make_raster_stack([(datetime(2020, 6, 15), 1.0)])
+        with pytest.raises(TemporalExtentEmpty):
+            filter_temporal(data, extent=["2021-01-01", "2020-01-01"])
+
+    def test_both_boundaries_null_raises(self):
+        """Both boundaries null is invalid."""
+        data = _make_raster_stack([(datetime(2020, 6, 15), 1.0)])
+        with pytest.raises(ValueError):
+            filter_temporal(data, extent=[None, None])
+
+    def test_wrong_extent_length_raises(self):
+        """An extent that is not a two-element array is invalid."""
+        data = _make_raster_stack([(datetime(2020, 6, 15), 1.0)])
+        with pytest.raises(ValueError):
+            filter_temporal(data, extent=["2020-01-01"])
+
+    def test_empty_data_returned_as_is(self):
+        """Filtering an empty stack returns it unchanged."""
+        data = _make_raster_stack([(datetime(2020, 6, 15), 1.0)])
+        empty = data.filter_keys([])
+        result = filter_temporal(empty, extent=["2020-01-01", "2021-01-01"])
+        assert len(result) == 0
+
+
+class TestFilterKeys:
+    """Tests for the RasterStack.filter_keys helper."""
+
+    def test_subset_preserves_order_and_metadata(self):
+        """Subset keeps temporal order and spatial metadata."""
+        data = _make_raster_stack(
+            [
+                (datetime(2020, 1, 1), 1.0),
+                (datetime(2020, 2, 1), 2.0),
+                (datetime(2020, 3, 1), 3.0),
+            ]
+        )
+        subset = data.filter_keys([datetime(2020, 3, 1), datetime(2020, 1, 1)])
+        assert list(subset.keys()) == [datetime(2020, 1, 1), datetime(2020, 3, 1)]
+        assert subset.band_names == ["red", "green"]
+        assert subset.bounds == (-180, -90, 180, 90)
+
+    def test_unknown_keys_ignored(self):
+        """Keys not present in the stack are ignored."""
+        data = _make_raster_stack([(datetime(2020, 1, 1), 1.0)])
+        subset = data.filter_keys([datetime(1999, 1, 1)])
+        assert len(subset) == 0

--- a/tests/test_filter_temporal.py
+++ b/tests/test_filter_temporal.py
@@ -195,3 +195,60 @@ class TestFilterKeys:
         data = _make_raster_stack([(datetime(2020, 1, 1), 1.0)])
         subset = data.filter_keys([datetime(1999, 1, 1)])
         assert len(subset) == 0
+
+    def test_preserves_geometry_cutline_for_cached_items(self):
+        """Cached items keep their footprint geometry so cutline_mask is computed.
+
+        Regression test: replacing refs with ImageRef.from_image would drop the
+        asset geometry and make cutline_mask() return None. The subset must keep
+        the geometry-aware ref while avoiding task re-execution.
+        """
+        geometry = {
+            "type": "Polygon",
+            "coordinates": [[[-10, -10], [10, -10], [10, 10], [-10, 10], [-10, -10]]],
+        }
+        calls = {"n": 0}
+
+        def make_task():
+            def task():
+                calls["n"] += 1
+                arr = np.ma.ones((2, 8, 8))
+                return ImageData(
+                    arr,
+                    crs="EPSG:4326",
+                    bounds=(-180, -90, 180, 90),
+                    band_descriptions=["red", "green"],
+                )
+
+            return task
+
+        key = datetime(2020, 6, 15)
+        tasks = [(make_task(), {"datetime": key, "geometry": geometry})]
+        stack = RasterStack(
+            tasks=tasks,
+            timestamp_fn=lambda asset: asset["datetime"],
+            width=8,
+            height=8,
+            bounds=(-180, -90, 180, 90),
+            dst_crs="EPSG:4326",
+            band_names=["red", "green"],
+        )
+
+        # Realize so the data is cached, then subset.
+        _ = stack[key]
+        assert calls["n"] == 1
+
+        subset = stack.filter_keys([key])
+        ref = subset.get_image_ref(key)
+        assert ref is not None
+
+        # Geometry-based cutline mask is still available (not None) ...
+        cutline = ref.cutline_mask()
+        assert cutline is not None
+        assert cutline.shape == (8, 8)
+        # ... and computing it did NOT re-execute the underlying task.
+        assert calls["n"] == 1
+
+        # Realizing returns the cached image without re-running the task.
+        assert subset[key] is not None
+        assert calls["n"] == 1

--- a/titiler/openeo/processes/data/filter_temporal.json
+++ b/titiler/openeo/processes/data/filter_temporal.json
@@ -1,0 +1,107 @@
+{
+  "id": "filter_temporal",
+  "summary": "Temporal filter based on temporal intervals",
+  "description": "Limits the data cube to the specified interval of dates and/or times.\n\nMore precisely, the filter checks whether each of the temporal dimension labels is greater than or equal to the lower boundary (start date/time) and less than the value of the upper boundary (end date/time). This corresponds to a left-closed interval, which contains the lower boundary but not the upper boundary.",
+  "categories": [
+    "cubes",
+    "filter"
+  ],
+  "parameters": [
+    {
+      "name": "data",
+      "description": "A data cube.",
+      "schema": {
+        "type": "object",
+        "subtype": "datacube",
+        "dimensions": [
+          {
+            "type": "temporal"
+          }
+        ]
+      }
+    },
+    {
+      "name": "extent",
+      "description": "Left-closed temporal interval, i.e. an array with exactly two elements:\n\n1. The first element is the start of the temporal interval. The specified time instant is **included** in the interval.\n2. The second element is the end of the temporal interval. The specified time instant is **excluded** from the interval.\n\nThe second element must always be greater/later than the first element. Otherwise, a `TemporalExtentEmpty` exception is thrown.\n\nAlso supports unbounded intervals by setting one of the boundaries to `null`, but never both.",
+      "schema": {
+        "type": "array",
+        "subtype": "temporal-interval",
+        "minItems": 2,
+        "maxItems": 2,
+        "items": {
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "date-time",
+              "subtype": "date-time",
+              "description": "Date and time with a time zone."
+            },
+            {
+              "type": "string",
+              "format": "date",
+              "subtype": "date",
+              "description": "Date only, formatted as `YYYY-MM-DD`. The time zone is UTC. Missing time components are all 0."
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "examples": [
+          [
+            "2015-01-01T00:00:00Z",
+            "2016-01-01T00:00:00Z"
+          ],
+          [
+            "2015-01-01",
+            "2016-01-01"
+          ]
+        ]
+      }
+    },
+    {
+      "name": "dimension",
+      "description": "The name of the temporal dimension to filter on. If no specific dimension is specified, the filter applies to all temporal dimensions. Fails with a `DimensionNotAvailable` exception if the specified dimension does not exist.",
+      "schema": {
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "default": null,
+      "optional": true
+    }
+  ],
+  "returns": {
+    "description": "A data cube restricted to the specified temporal extent. The dimensions and dimension properties (name, type, labels, reference system and resolution) remain unchanged, except that the temporal dimensions (determined by `dimensions` parameter) may have less dimension labels.",
+    "schema": {
+      "type": "object",
+      "subtype": "datacube",
+      "dimensions": [
+        {
+          "type": "temporal"
+        }
+      ]
+    }
+  },
+  "exceptions": {
+    "DimensionNotAvailable": {
+      "message": "A dimension with the specified name does not exist."
+    },
+    "TemporalExtentEmpty": {
+      "message": "The temporal extent is empty. The second instant in time must always be greater/later than the first instant in time."
+    }
+  },
+  "links": [
+    {
+      "href": "https://openeo.org/documentation/1.0/datacubes.html#filter",
+      "rel": "about",
+      "title": "Filters explained in the openEO documentation"
+    },
+    {
+      "href": "https://www.rfc-editor.org/rfc/rfc3339.html",
+      "rel": "about",
+      "title": "RFC3339: Details about formatting temporal strings"
+    }
+  ]
+}

--- a/titiler/openeo/processes/implementations/__init__.py
+++ b/titiler/openeo/processes/implementations/__init__.py
@@ -4,6 +4,7 @@ from .apply import *  # noqa
 from .arrays import *  # noqa
 from .data_model import ImageRef, RasterStack  # noqa
 from .dem import *  # noqa
+from .filter import *  # noqa
 from .get_param_item import *  # noqa
 from .image import *  # noqa
 from .indices import *  # noqa

--- a/titiler/openeo/processes/implementations/data_model.py
+++ b/titiler/openeo/processes/implementations/data_model.py
@@ -658,6 +658,53 @@ class RasterStack(Dict[datetime, ImageData]):
                 continue
         raise KeyError("No successful tasks found in RasterStack")
 
+    def filter_keys(self, keys: List[datetime]) -> "RasterStack":
+        """Return a new RasterStack restricted to the given keys.
+
+        The subset preserves lazy loading: tasks for the selected timestamps are
+        reused (not executed) and any already-cached data is carried over. The
+        resulting stack keeps the same spatial metadata (size, bounds, CRS,
+        band names) as the source.
+
+        Args:
+            keys: The datetime keys to keep. Keys not present in this stack are
+                ignored. Temporal ordering of the source is preserved.
+
+        Returns:
+            RasterStack: A new stack containing only the matching timestamps.
+        """
+        selected = set(keys)
+        ordered_keys = [k for k in self._keys if k in selected]
+
+        new_tasks = [self._tasks[self._key_to_task_index[k]] for k in ordered_keys]
+
+        instance = RasterStack(
+            tasks=new_tasks,
+            timestamp_fn=self._timestamp_fn,
+            allowed_exceptions=self._allowed_exceptions,
+            max_workers=self._max_workers,
+            width=self._width,
+            height=self._height,
+            bounds=self._bounds,
+            dst_crs=self._dst_crs,
+            band_names=self._band_names,
+        )
+
+        # Carry over any already-computed data so we don't recompute it and
+        # so that stacks built via `from_images` (whose tasks are no-ops)
+        # remain usable.
+        with self._cache_lock:
+            preserved = {
+                k: self._data_cache[k] for k in ordered_keys if k in self._data_cache
+            }
+        if preserved:
+            instance._data_cache.update(preserved)
+            instance._image_refs.update(
+                {k: ImageRef.from_image(image=v) for k, v in preserved.items()}
+            )
+
+        return instance
+
     @classmethod
     def from_images(cls, images: Dict[datetime, ImageData], **kwargs) -> "RasterStack":
         """Create a RasterStack from pre-loaded ImageData instances.

--- a/titiler/openeo/processes/implementations/data_model.py
+++ b/titiler/openeo/processes/implementations/data_model.py
@@ -38,6 +38,20 @@ from rio_tiler.types import BBox
 T = TypeVar("T")
 
 
+def _cached_image_task(image: ImageData) -> Callable[[], ImageData]:
+    """Build a task function that returns an already-loaded ImageData.
+
+    Used to back a lazy ImageRef with cached data: ``realize()`` returns the
+    cached image without re-executing work, while the ImageRef keeps its
+    geometry so ``cutline_mask()`` is still computed from the footprint.
+    """
+
+    def _task() -> ImageData:
+        return image
+
+    return _task
+
+
 def compute_cutline_mask(
     geometry: Union[Dict[str, Any], List[Dict[str, Any]]],
     width: int,
@@ -706,7 +720,7 @@ class RasterStack(Dict[datetime, ImageData]):
             for k, img in preserved.items():
                 ref = instance._image_refs.get(k)
                 if ref is not None:
-                    ref._task_fn = (lambda _img=img: _img)
+                    ref._task_fn = _cached_image_task(img)
                 else:
                     instance._image_refs[k] = ImageRef.from_image(image=img)
 

--- a/titiler/openeo/processes/implementations/data_model.py
+++ b/titiler/openeo/processes/implementations/data_model.py
@@ -699,9 +699,16 @@ class RasterStack(Dict[datetime, ImageData]):
             }
         if preserved:
             instance._data_cache.update(preserved)
-            instance._image_refs.update(
-                {k: ImageRef.from_image(image=v) for k, v in preserved.items()}
-            )
+
+            # Keep geometry-based cutline masks (ImageRefs built from tasks/assets) but
+            # avoid re-executing work by overriding the task function to return the
+            # already-cached ImageData.
+            for k, img in preserved.items():
+                ref = instance._image_refs.get(k)
+                if ref is not None:
+                    ref._task_fn = (lambda _img=img: _img)
+                else:
+                    instance._image_refs[k] = ImageRef.from_image(image=img)
 
         return instance
 

--- a/titiler/openeo/processes/implementations/filter.py
+++ b/titiler/openeo/processes/implementations/filter.py
@@ -1,0 +1,66 @@
+"""titiler.openeo filter processes."""
+
+from typing import List, Optional
+
+from .data_model import RasterStack
+from .reduce import DimensionNotAvailable, _parse_intervals, _timestamp_in_interval
+
+__all__ = ["filter_temporal"]
+
+
+def filter_temporal(
+    data: RasterStack,
+    extent: List[Optional[str]],
+    dimension: Optional[str] = None,
+) -> RasterStack:
+    """Limits the data cube to the specified interval of dates and/or times.
+
+    The filter checks whether each of the temporal dimension labels is greater
+    than or equal to the lower boundary (start date/time) and less than the
+    upper boundary (end date/time). This corresponds to a left-closed interval,
+    which contains the lower boundary but not the upper boundary.
+
+    Args:
+        data: A data cube with a temporal dimension.
+        extent: Left-closed temporal interval, i.e. an array with exactly two
+            elements. The first element is the (included) start, the second the
+            (excluded) end. RFC 3339 date-time or date strings. One boundary may
+            be ``None`` for an unbounded interval, but never both.
+        dimension: The name of the temporal dimension to filter on. If ``None``,
+            the filter applies to the (single) temporal dimension.
+
+    Returns:
+        A data cube restricted to the specified temporal extent. The temporal
+        dimension may have fewer labels; all other properties remain unchanged.
+
+    Raises:
+        TemporalExtentEmpty: If the extent end is not later than its start.
+        DimensionNotAvailable: If the specified dimension does not exist.
+        ValueError: If the extent is not a two-element interval or both
+            boundaries are ``None``.
+    """
+    if not isinstance(extent, (list, tuple)) or len(extent) != 2:
+        raise ValueError(
+            "The temporal extent must be an array with exactly two elements."
+        )
+
+    if extent[0] is None and extent[1] is None:
+        raise ValueError(
+            "The temporal extent must not have both boundaries set to null."
+        )
+
+    if dimension is not None and dimension.lower() not in ["t", "temporal", "time"]:
+        raise DimensionNotAvailable(dimension)
+
+    if not data:
+        return data
+
+    # Reuse the shared interval parsing/validation (raises TemporalExtentEmpty
+    # when end <= start). filter_temporal only ever has a single interval.
+    (start, end) = _parse_intervals([list(extent)])[0]
+
+    matching_keys = [
+        ts for ts in data.timestamps() if _timestamp_in_interval(ts, start, end)
+    ]
+
+    return data.filter_keys(matching_keys)


### PR DESCRIPTION
## Summary

Adds the [`filter_temporal`](https://github.com/Open-EO/openeo-processes/blob/master/filter_temporal.json) openEO process, which limits a data cube to a temporal interval.

- **Left-closed, right-open** semantics: a timestamp matches when `start <= t < end`.
- Supports **unbounded intervals** (one boundary `null`); rejects both-null.
- Optional `dimension` argument, validated against temporal dimension names (raises `DimensionNotAvailable` otherwise).
- Raises `TemporalExtentEmpty` when `end <= start`.

## Implementation notes

- Reuses the existing temporal helpers in [`reduce.py`](titiler/openeo/processes/implementations/reduce.py) (`_parse_intervals`, `_timestamp_in_interval`) for parsing/validation, keeping behavior consistent with `aggregate_temporal`.
- Adds a lazy `RasterStack.filter_keys()` subset method. **Lazy loading is preserved** — filtering reuses the original task tuples and does not realize any underlying data; pixel data loads only on actual access. Already-cached data is carried over.
- Spec JSON mirrors the official Open-EO definition.

## Changes

| File | Change |
|------|--------|
| `processes/implementations/filter.py` | New `filter_temporal` implementation |
| `processes/implementations/data_model.py` | New lazy `RasterStack.filter_keys()` |
| `processes/implementations/__init__.py` | Wire up `from .filter import *` |
| `processes/data/filter_temporal.json` | Process spec |
| `tests/test_filter_temporal.py` | 19 tests |

## Testing

`tests/test_filter_temporal.py` covers left-closed/right-open semantics, open/unbounded boundaries, tz-aware datetimes, dimension validation, `TemporalExtentEmpty`, and `filter_keys`. All pass, along with the shared-helper suites (`aggregate_temporal`, reduce, dimension reduction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)