### PR TITLE
perf: concurrently prefetch in-interval slices

### DIFF
--- a/tests/test_aggregate_temporal.py
+++ b/tests/test_aggregate_temporal.py
@@ -108,6 +108,44 @@ def _make_raster_stack(dates_values):
     return RasterStack.from_images(images)
 
 
+def _make_lazy_raster_stack(dates_values, executed):
+    """Helper: create a *lazy* RasterStack whose per-slice tasks record execution.
+
+    Unlike ``_make_raster_stack`` (which uses ``from_images`` and pre-populates the
+    cache), this builds genuine lazy tasks via the ``RasterStack`` constructor. Each
+    task adds its datetime to the ``executed`` set when (and only when) it is run,
+    so a test can assert exactly which time slices were actually fetched/decoded.
+    """
+    tasks = []
+    for dt, val in dates_values:
+
+        def make_task(dt=dt, val=val):
+            def task():
+                executed.add(dt)
+                array = np.ma.ones((2, 4, 4)) * val
+                return ImageData(
+                    array,
+                    assets=[f"asset_{dt.isoformat()}"],
+                    crs="EPSG:4326",
+                    bounds=(-180, -90, 180, 90),
+                    band_descriptions=["red", "green"],
+                )
+
+            return task
+
+        tasks.append((make_task(), {"datetime": dt}))
+
+    return RasterStack(
+        tasks=tasks,
+        timestamp_fn=lambda asset: asset["datetime"],
+        width=4,
+        height=4,
+        bounds=(-180, -90, 180, 90),
+        dst_crs="EPSG:4326",
+        band_names=["red", "green"],
+    )
+
+
 class TestAggregateTemporalBasic:
     """Basic aggregate_temporal tests."""
 
@@ -620,6 +658,178 @@ class TestAggregateTemporalPreservesMetadata:
         )
         img = result.first
         assert img.array.shape == (2, 4, 4)
+
+
+class TestAggregateTemporalNonContiguousIntervals:
+    """Scenario: explicit, non-contiguous single-month intervals across years.
+
+    The cube is loaded over a CONTINUOUS extent spanning several months across
+    four years; most slices fall OUTSIDE every interval. These tests assert both
+    correctness (only in-interval slices contribute) and performance (only
+    in-interval slices are actually read).
+    """
+
+    # One month per year is requested, in reverse chronological order to also
+    # exercise output ordering. Single-month, non-contiguous intervals.
+    INTERVALS = [
+        ["2021-07-01", "2021-08-01"],
+        ["2020-07-01", "2020-08-01"],
+        ["2019-07-01", "2019-08-01"],
+    ]
+
+    # Continuous monthly-ish coverage across 2019..2022.
+    #   In-interval slices (July of 2019/2020/2021):
+    IN_INTERVAL = [
+        (datetime(2019, 7, 15), 10.0),  # -> 2019 bucket
+        (datetime(2020, 7, 15), 20.0),  # -> 2020 bucket
+        (datetime(2021, 7, 10), 30.0),  # -> 2021 bucket (mean with next)
+        (datetime(2021, 7, 20), 40.0),  # -> 2021 bucket (mean -> 35)
+    ]
+    #   Out-of-interval slices that must NOT affect any bucket:
+    OUT_OF_INTERVAL = [
+        (datetime(2019, 1, 1), 444.0),
+        (datetime(2019, 8, 15), 111.0),  # Aug 2019 (just after interval)
+        (datetime(2020, 6, 15), 222.0),  # Jun 2020 (just before interval)
+        (datetime(2021, 6, 30), 555.0),
+        (datetime(2022, 7, 15), 333.0),  # 2022 has no interval at all
+        (datetime(2022, 8, 1), 666.0),
+    ]
+    #   Boundary slice exactly on an interval END must be EXCLUDED ([start, end)):
+    BOUNDARY = [
+        (datetime(2021, 8, 1), 999.0),  # == end of the 2021 interval -> excluded
+    ]
+
+    def _all_slices(self):
+        return self.IN_INTERVAL + self.OUT_OF_INTERVAL + self.BOUNDARY
+
+    def test_only_in_interval_slices_contribute(self):
+        """Exactly 3 buckets, each the mean of ONLY its in-interval slices."""
+        data = _make_raster_stack(self._all_slices())
+        result = aggregate_temporal(
+            data=data,
+            intervals=self.INTERVALS,
+            reducer=mean_reducer,
+        )
+
+        # Exactly three output buckets (one per interval).
+        assert len(result) == 3
+
+        # Default labels = interval starts; output is temporally sorted regardless
+        # of the (reverse-chronological) interval input order.
+        keys = sorted(result.keys())
+        assert keys == [
+            datetime(2019, 7, 1),
+            datetime(2020, 7, 1),
+            datetime(2021, 7, 1),
+        ]
+
+        # Each bucket equals the mean of ONLY the in-interval slices.
+        np.testing.assert_array_almost_equal(result[keys[0]].array.data, 10.0)
+        np.testing.assert_array_almost_equal(result[keys[1]].array.data, 20.0)
+        np.testing.assert_array_almost_equal(result[keys[2]].array.data, 35.0)
+
+    def test_boundary_slice_on_interval_end_excluded(self):
+        """A slice exactly on an interval end (2021-08-01) is excluded."""
+        data = _make_raster_stack(self._all_slices())
+        result = aggregate_temporal(
+            data=data,
+            intervals=self.INTERVALS,
+            reducer=mean_reducer,
+        )
+        key_2021 = datetime(2021, 7, 1)
+        # If 2021-08-01 (value 999) had leaked in, the mean would be far from 35.
+        np.testing.assert_array_almost_equal(result[key_2021].array.data, 35.0)
+
+    def test_out_of_interval_slices_are_not_read(self):
+        """Performance: only in-interval slices are fetched/decoded.
+
+        Uses a lazy RasterStack so each slice records when its task runs. After
+        aggregate_temporal, the set of executed slices must equal exactly the
+        in-interval slices -- proving out-of-interval (and boundary) slices are
+        never materialized.
+        """
+        executed: set = set()
+        data = _make_lazy_raster_stack(self._all_slices(), executed)
+
+        # Sanity: nothing read yet just from constructing the stack / reading keys.
+        assert executed == set()
+        _ = data.timestamps()
+        assert executed == set()
+
+        result = aggregate_temporal(
+            data=data,
+            intervals=self.INTERVALS,
+            reducer=mean_reducer,
+        )
+
+        # Only the four in-interval slices were ever realized.
+        expected_read = {dt for dt, _ in self.IN_INTERVAL}
+        assert executed == expected_read
+
+        # And the boundary / out-of-interval slices were definitely not read.
+        assert datetime(2021, 8, 1) not in executed  # boundary
+        assert datetime(2022, 7, 15) not in executed  # year with no interval
+
+        # Correctness still holds on the lazy path.
+        keys = sorted(result.keys())
+        np.testing.assert_array_almost_equal(result[keys[2]].array.data, 35.0)
+
+    def test_in_interval_slices_are_read_concurrently(self):
+        """The in-interval slices are pre-loaded in parallel, not serially.
+
+        Each task sleeps briefly; if reads were serial the call would take at
+        least N * delay. Concurrent prefetch brings it well under that bound.
+        """
+        import time as _time
+
+        executed: set = set()
+        delay = 0.2
+        n_in_interval = len(self.IN_INTERVAL)
+
+        def _make_slow_stack(dates_values):
+            tasks = []
+            for dt, val in dates_values:
+
+                def make_task(dt=dt, val=val):
+                    def task():
+                        _time.sleep(delay)
+                        executed.add(dt)
+                        array = np.ma.ones((2, 4, 4)) * val
+                        return ImageData(
+                            array,
+                            assets=[f"asset_{dt.isoformat()}"],
+                            crs="EPSG:4326",
+                            bounds=(-180, -90, 180, 90),
+                            band_descriptions=["red", "green"],
+                        )
+
+                    return task
+
+                tasks.append((make_task(), {"datetime": dt}))
+            return RasterStack(
+                tasks=tasks,
+                timestamp_fn=lambda asset: asset["datetime"],
+                width=4,
+                height=4,
+                bounds=(-180, -90, 180, 90),
+                dst_crs="EPSG:4326",
+                band_names=["red", "green"],
+            )
+
+        data = _make_slow_stack(self._all_slices())
+
+        start = _time.monotonic()
+        aggregate_temporal(
+            data=data,
+            intervals=self.INTERVALS,
+            reducer=mean_reducer,
+        )
+        elapsed = _time.monotonic() - start
+
+        # Only the in-interval slices were read.
+        assert executed == {dt for dt, _ in self.IN_INTERVAL}
+        # Concurrent: far below the serial lower bound (n * delay).
+        assert elapsed < n_in_interval * delay
 
 
 class TestParseTemporalValue:

--- a/tests/test_aggregate_temporal.py
+++ b/tests/test_aggregate_temporal.py
@@ -809,6 +809,7 @@ class TestAggregateTemporalNonContiguousIntervals:
             return RasterStack(
                 tasks=tasks,
                 timestamp_fn=lambda asset: asset["datetime"],
+                max_workers=n_in_interval,
                 width=4,
                 height=4,
                 bounds=(-180, -90, 180, 90),

--- a/titiler/openeo/processes/implementations/data_model.py
+++ b/titiler/openeo/processes/implementations/data_model.py
@@ -9,6 +9,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Iterable,
     List,
     Optional,
     Set,
@@ -447,6 +448,20 @@ class RasterStack(Dict[datetime, ImageData]):
                     band_names=self._band_names,
                     geometry=geometry,
                 )
+
+    def prefetch(self, keys: Iterable[datetime]) -> None:
+        """Eagerly load the given timestamps concurrently into the cache.
+
+        Reads run in parallel via the thread pool; keys already cached or not
+        present in the stack are skipped. Subsequent ``__getitem__`` calls for
+        these keys return the cached result without further I/O. This lets
+        callers that otherwise read slice-by-slice (e.g. aggregate_temporal,
+        apply_pixel_selection) benefit from concurrency.
+
+        Args:
+            keys: The datetime keys to pre-load.
+        """
+        self._execute_selected_tasks(set(keys))
 
     def _execute_task(self, key: datetime, task_func: Any) -> ImageData:
         """Execute a single task and return the result.

--- a/titiler/openeo/processes/implementations/reduce.py
+++ b/titiler/openeo/processes/implementations/reduce.py
@@ -850,6 +850,20 @@ def aggregate_temporal(
     output_keys = _resolve_output_keys(labels, parsed_intervals)
     timestamps = data.timestamps()
 
+    # Concurrently pre-load ONLY the slices inside the union of all intervals.
+    # Out-of-interval slices are still never read; in-interval slices are read
+    # in parallel instead of one-at-a-time, so the per-interval loop below (and
+    # any reducer that pulls slices, e.g. mean -> apply_pixel_selection) hits the
+    # cache rather than blocking on serial I/O.
+    union_keys = {
+        ts
+        for (start, end) in parsed_intervals
+        for ts in timestamps
+        if _timestamp_in_interval(ts, start, end)
+    }
+    if union_keys:
+        data.prefetch(union_keys)
+
     result_images: Dict[datetime, ImageData] = {}
 
     for idx, (start, end) in enumerate(parsed_intervals):

--- a/titiler/openeo/processes/implementations/reduce.py
+++ b/titiler/openeo/processes/implementations/reduce.py
@@ -850,26 +850,27 @@ def aggregate_temporal(
     output_keys = _resolve_output_keys(labels, parsed_intervals)
     timestamps = data.timestamps()
 
+    # Resolve in-interval timestamps once per interval (each runs the
+    # _timestamp_in_interval comparison, incl. UTC normalization), then reuse
+    # the lists below instead of re-scanning the stack inside the loop.
+    matching_keys_per_interval = [
+        [ts for ts in timestamps if _timestamp_in_interval(ts, start, end)]
+        for (start, end) in parsed_intervals
+    ]
+
     # Concurrently pre-load ONLY the slices inside the union of all intervals.
     # Out-of-interval slices are still never read; in-interval slices are read
     # in parallel instead of one-at-a-time, so the per-interval loop below (and
     # any reducer that pulls slices, e.g. mean -> apply_pixel_selection) hits the
     # cache rather than blocking on serial I/O.
-    union_keys = {
-        ts
-        for (start, end) in parsed_intervals
-        for ts in timestamps
-        if _timestamp_in_interval(ts, start, end)
-    }
+    union_keys = {ts for keys in matching_keys_per_interval for ts in keys}
     if union_keys:
         data.prefetch(union_keys)
 
     result_images: Dict[datetime, ImageData] = {}
 
-    for idx, (start, end) in enumerate(parsed_intervals):
-        matching_keys = [
-            ts for ts in timestamps if _timestamp_in_interval(ts, start, end)
-        ]
+    for idx in range(len(parsed_intervals)):
+        matching_keys = matching_keys_per_interval[idx]
         output_key = output_keys[idx]
 
         if not matching_keys:


### PR DESCRIPTION
## Summary

`aggregate_temporal` read its in-interval slices **serially** — one blocking I/O per slice in the per-interval `data[key]` loop, and again in the production `mean` reducer (which calls `apply_pixel_selection`, realizing slices one-at-a-time). `RasterStack` already has a concurrent read path (`_execute_selected_tasks`, a bounded `ThreadPoolExecutor`), but `aggregate_temporal` never used it.

This PR adds a small, targeted fix:

- **`RasterStack.prefetch(keys)`** — a thin public wrapper over the existing concurrent task executor.
- **`aggregate_temporal`** computes the union of in-interval timestamps and pre-warms them concurrently before the per-interval loop. Subsequent `data[key]` and `ref.realize()` calls then hit the cache instead of blocking on serial reads.

## Behavior unchanged

- Out-of-interval slices are still **never read** (filtering happens before any read).
- Overlapping intervals share the warmed cache (a shared slice is read once).
- `from_images` stacks (already cached) are a no-op — `_execute_selected_tasks` skips cached/unknown keys.

## Tests

Added to `tests/test_aggregate_temporal.py` (`TestAggregateTemporalNonContiguousIntervals`), modeling non-contiguous single-month intervals across 4 years:

- `test_only_in_interval_slices_contribute` — exactly 3 buckets, each the mean of only its in-interval slices.
- `test_boundary_slice_on_interval_end_excluded` — a slice exactly on an interval end is excluded (`[start, end)`).
- `test_out_of_interval_slices_are_not_read` — on a lazy stack, only in-interval slices are realized.
- `test_in_interval_slices_are_read_concurrently` — sleep-per-task proves elapsed time is below the serial lower bound.

`tests/test_aggregate_temporal.py` → 49 passed; related suites (`data_model`/`reduce`/`raster`/`math`/`aggregate`) → 166 passed.

## Follow-up

This is a targeted patch for `aggregate_temporal`. The remaining serial-read paths (selector-aware concurrency in `apply_pixel_selection`, other process call sites, a shared concurrency budget) are tracked in #285.

🤖 Generated with [Claude Code](https://claude.com/claude-code)