### PR TITLE
fix: accept TemporalInterval extent from the graph parser

### DIFF
--- a/tests/test_filter_temporal.py
+++ b/tests/test_filter_temporal.py
@@ -123,6 +123,73 @@ class TestFilterTemporalBasic:
         assert img.band_descriptions == ["red", "green"]
 
 
+class TestFilterTemporalTemporalIntervalInput:
+    """Graph path: extent arrives as a TemporalInterval (parsed datetimes).
+
+    The openEO process-graph parser converts a temporal-interval into a
+    ``TemporalInterval`` whose bounds are pendulum datetimes, not strings.
+    """
+
+    def test_temporal_interval_extent(self):
+        """A TemporalInterval extent filters the same as a string list."""
+        from openeo_pg_parser_networkx.pg_schema import TemporalInterval
+
+        data = _make_raster_stack(
+            [
+                (datetime(2020, 1, 15), 1.0),
+                (datetime(2020, 6, 15), 2.0),
+                (datetime(2021, 3, 1), 3.0),
+            ]
+        )
+        result = filter_temporal(
+            data, extent=TemporalInterval(["2020-01-01", "2021-01-01"])
+        )
+        assert sorted(result.keys()) == [
+            datetime(2020, 1, 15),
+            datetime(2020, 6, 15),
+        ]
+
+    def test_temporal_interval_open_start(self):
+        """A TemporalInterval with a null lower bound is supported."""
+        from openeo_pg_parser_networkx.pg_schema import TemporalInterval
+
+        data = _make_raster_stack(
+            [
+                (datetime(2019, 1, 1), 1.0),
+                (datetime(2020, 6, 15), 2.0),
+                (datetime(2021, 3, 1), 3.0),
+            ]
+        )
+        result = filter_temporal(data, extent=TemporalInterval([None, "2021-01-01"]))
+        assert sorted(result.keys()) == [
+            datetime(2019, 1, 1),
+            datetime(2020, 6, 15),
+        ]
+
+    def test_temporal_interval_passes_type_validation(self):
+        """Regression: the @process validation layer must accept a TemporalInterval.
+
+        Previously ``extent: List[Optional[str]]`` made _validate_parameter_types
+        reject the parser-supplied TemporalInterval (DateTime elements), raising
+        ``TypeError: expected 'List' but got 'temporal-interval'``.
+        """
+        from openeo_pg_parser_networkx.pg_schema import TemporalInterval
+
+        from titiler.openeo.processes.implementations.core import process
+
+        data = _make_raster_stack(
+            [
+                (datetime(2020, 6, 15), 2.0),
+                (datetime(2022, 7, 15), 4.0),
+            ]
+        )
+        wrapped = process(filter_temporal)
+        result = wrapped(
+            data=data, extent=TemporalInterval(["2022-07-01", "2022-08-01"])
+        )
+        assert list(result.keys()) == [datetime(2022, 7, 15)]
+
+
 class TestFilterTemporalDimension:
     """Tests for the optional dimension parameter."""
 

--- a/titiler/openeo/processes/implementations/filter.py
+++ b/titiler/openeo/processes/implementations/filter.py
@@ -1,6 +1,8 @@
 """titiler.openeo filter processes."""
 
-from typing import List, Optional
+from typing import Any, List, Optional, Union
+
+from openeo_pg_parser_networkx.pg_schema import TemporalInterval
 
 from .data_model import RasterStack
 from .reduce import DimensionNotAvailable, _parse_intervals, _timestamp_in_interval
@@ -8,9 +10,35 @@ from .reduce import DimensionNotAvailable, _parse_intervals, _timestamp_in_inter
 __all__ = ["filter_temporal"]
 
 
+def _extent_to_pair(extent: Any) -> List[Optional[str]]:
+    """Normalize a temporal extent to a ``[start, end]`` list of RFC 3339 strings.
+
+    The openEO graph parser passes ``extent`` as a ``TemporalInterval`` whose
+    bounds are already parsed into pendulum datetimes, while direct Python/test
+    callers pass a two-element list/tuple of strings (or ``None``). Both are
+    reduced here to the string-pair form understood by ``_parse_intervals``.
+    """
+    if isinstance(extent, TemporalInterval):
+
+        def _bound(value: Any) -> Optional[str]:
+            if value is None:
+                return None
+            # Year/Date/DateTime/Time wrappers expose the parsed value as .root
+            # (a pendulum datetime/date/time), which serializes to RFC 3339.
+            root = getattr(value, "root", value)
+            return root.isoformat() if hasattr(root, "isoformat") else str(root)
+
+        return [_bound(extent.start), _bound(extent.end)]
+
+    if isinstance(extent, (list, tuple)):
+        return list(extent)
+
+    raise ValueError("The temporal extent must be an array with exactly two elements.")
+
+
 def filter_temporal(
     data: RasterStack,
-    extent: List[Optional[str]],
+    extent: Union[TemporalInterval, List[Optional[str]]],
     dimension: Optional[str] = None,
 ) -> RasterStack:
     """Limits the data cube to the specified interval of dates and/or times.
@@ -39,12 +67,13 @@ def filter_temporal(
         ValueError: If the extent is not a two-element interval or both
             boundaries are ``None``.
     """
-    if not isinstance(extent, (list, tuple)) or len(extent) != 2:
+    pair = _extent_to_pair(extent)
+    if len(pair) != 2:
         raise ValueError(
             "The temporal extent must be an array with exactly two elements."
         )
 
-    if extent[0] is None and extent[1] is None:
+    if pair[0] is None and pair[1] is None:
         raise ValueError(
             "The temporal extent must not have both boundaries set to null."
         )
@@ -57,7 +86,7 @@ def filter_temporal(
 
     # Reuse the shared interval parsing/validation (raises TemporalExtentEmpty
     # when end <= start). filter_temporal only ever has a single interval.
-    (start, end) = _parse_intervals([list(extent)])[0]
+    (start, end) = _parse_intervals([pair])[0]
 
     matching_keys = [
         ts for ts in data.timestamps() if _timestamp_in_interval(ts, start, end)


### PR DESCRIPTION
## Problem

Running `filter_temporal` through an openEO process graph fails at parameter validation:

```
TypeError: Parameter 'extent' in process 'filter_temporal':
expected 'List' but got 'temporal-interval'. Details: 2 validation errors for list[nullable[str]]
0  Input should be a valid string [input_value=DateTime(2022, 7, 1, ...)]
1  Input should be a valid string [input_value=DateTime(2022, 8, 1, ...)]
```

## Root cause

The `openeo_pg_parser_networkx` parser converts a `temporal-interval` argument into a `TemporalInterval` object whose bounds are already parsed into pendulum `DateTime`s **before** our code runs. `filter_temporal` declared `extent: List[Optional[str]]`, so the `@process` type-validation layer (`_validate_parameter_types`) rejected the parsed object.

`aggregate_temporal` is **not** affected — its `intervals` parameter is a list *of* intervals (`temporal-intervals`), which the parser does not convert to `TemporalInterval`, so it stays as plain string lists.

This is independent of #286 (the prefetch perf change); it's a pre-existing mismatch in the `filter_temporal` process added in #282, surfaced when exercising the graph path.

## Fix

- Widen the annotation to `Union[TemporalInterval, List[Optional[str]]]` so validation accepts the parser-supplied object (and still documents the plain-list form used by direct callers).
- Add `_extent_to_pair(...)` to normalize either form to an RFC 3339 `[start, end]` string pair, then reuse the existing `_parse_intervals` / `_timestamp_in_interval` logic unchanged (left-closed/right-open, open-ended bounds, `TemporalExtentEmpty` on `end <= start`).

Behavior for existing list/tuple callers is unchanged.

## Tests

Added `TestFilterTemporalTemporalIntervalInput`:
- `test_temporal_interval_extent` — body path with a `TemporalInterval`.
- `test_temporal_interval_open_start` — `TemporalInterval([None, end])`.
- `test_temporal_interval_passes_type_validation` — wraps `filter_temporal` with `@process` and calls it with a `TemporalInterval`, reproducing the exact validation failure and locking the fix.

`tests/test_filter_temporal.py` → 23 passed. Related suites (`filter`/`core`/`process`/`aggregate`/`data_model`) → 244 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)