### PR TITLE
fix: seed pixel-selection band count from the realized image

### DIFF
--- a/tests/test_pixel_selection_reducers.py
+++ b/tests/test_pixel_selection_reducers.py
@@ -360,3 +360,47 @@ class TestApplyPixelSelectionMethods:
         result = apply_pixel_selection(stack, pixel_selection="lastbandhight")
         assert isinstance(result, RasterStack)
         assert result.first is not None
+
+    def test_multiband_asset_with_single_declared_band_name(self):
+        """Regression: a lazy stack whose decoded images have more bands than the
+        declared band_names must not raise 'Assets HAVE TO have the same number of
+        bands'.
+
+        load_collection declares band_names from asset names (e.g. one entry) but
+        a multi-band asset decodes to several bands. The pixel-selection count must
+        be seeded from the realized image, not the declared metadata. Regression
+        introduced in #215 (count seeded from LazyImageRef.count == len(band_names)).
+        """
+
+        def make_task(val):
+            def task():
+                return ImageData(
+                    np.ma.ones((3, 4, 4), dtype="float32") * val,
+                    crs="EPSG:4326",
+                    bounds=(-180, -90, 180, 90),
+                    band_descriptions=["b1", "b2", "b3"],
+                )
+
+            return task
+
+        # band_names declares a SINGLE asset name; the decoded images have 3 bands.
+        tasks = [
+            (make_task(1.0), {"datetime": datetime(2020, 1, 1)}),
+            (make_task(3.0), {"datetime": datetime(2020, 2, 1)}),
+        ]
+        stack = RasterStack(
+            tasks=tasks,
+            timestamp_fn=lambda asset: asset["datetime"],
+            width=4,
+            height=4,
+            bounds=(-180, -90, 180, 90),
+            dst_crs="EPSG:4326",
+            band_names=["visual"],
+        )
+
+        result = apply_pixel_selection(stack, pixel_selection="mean")
+        assert isinstance(result, RasterStack)
+        img = result.first
+        # All 3 decoded bands are preserved and averaged (mean of 1.0 and 3.0).
+        assert img.array.shape == (3, 4, 4)
+        np.testing.assert_array_almost_equal(img.array.data, 2.0)

--- a/titiler/openeo/processes/implementations/reduce.py
+++ b/titiler/openeo/processes/implementations/reduce.py
@@ -236,14 +236,27 @@ def apply_pixel_selection(
     cutline_masks = [ref.cutline_mask() for _, ref in all_items]
     aggregated_cutline = _compute_aggregated_cutline_mask(cutline_masks)
 
-    # Initialize pixsel_method from first ref's metadata
+    # Initialize pixsel_method from the first image.
+    #
+    # The band COUNT must come from the first *realized* image, not from declared
+    # metadata: a band-name list (e.g. a single asset name produced by
+    # load_collection's default) can map to a different number of decoded bands
+    # when the asset is multi-band. Seeding the count from declared metadata makes
+    # the per-slice assertion below fail on the very first slice even when every
+    # slice is perfectly consistent. Width/height/cutline stay metadata-derived so
+    # they remain aligned with the precomputed cutline mask.
     first_key, first_ref = all_items[0]
+    first_img = first_ref.realize()
     pixsel_method.width = first_ref.width
     pixsel_method.height = first_ref.height
-    pixsel_method.count = first_ref.count
+    pixsel_method.count = first_img.count
     crs = first_ref.crs
     bounds = first_ref.bounds
-    band_names = first_ref.band_names
+    band_names = (
+        list(first_img.band_descriptions)
+        if first_img.band_descriptions
+        else first_ref.band_names
+    )
 
     # Set the aggregated cutline mask
     if aggregated_cutline is not None:


### PR DESCRIPTION
## Problem

A multi-slice temporal reduce (`mean`/`median`/`stdev`/`count`/…) over a multi-band collection fails at runtime:

```
AssertionError: Assets HAVE TO have the same number of bands
  File ".../processes/implementations/reduce.py", line 259, in apply_pixel_selection
    img.count == pixsel_method.count
```

## Root cause

`apply_pixel_selection` seeds `pixsel_method.count` from the first **ImageRef's declared count**. For a lazy `ImageRef` (the `load_collection` path) that is `len(band_names)`. When an asset is multi-band, the decoded image has more bands than `band_names` declares — `load_collection` even defaults `bands` to a *single* asset name (`stacapi.py:770`), so `band_names=["visual"]` (length 1) vs. e.g. 3 decoded bands. The per-slice assertion then fails on the very first slice, even though every slice is perfectly consistent.

### When it was introduced

- **#215** ("feat: make LazyRasterStack truly lazy with deferred task execution", `7103ff1`, 2026-01-29) changed the count seed from the realized image (`img.count`) to the lazy ref's declared `first_item.count` (== `len(band_names)`, see `data_model.py` `_count=len(self._band_names)`).
- **#216** (`455141a`, 2026-02-03) collapsed the branches into the current `pixsel_method.count = first_ref.count`.

Before #215 the count was seeded from the realized image and this worked. It stayed latent because it requires three conditions at once: a **multi-slice temporal reduce** (single-slice short-circuits in `reduce_dimension`), a **still-lazy** stack (an eager `from_images` stack already carries the real count), and a **multi-band asset with fewer declared band names**.

## Fix

Seed the band **count** from the first **realized** image, so the assertion validates genuine cross-slice consistency instead of declared-vs-actual. Width/height/cutline stay metadata-derived (aligned with the precomputed cutline mask); band names prefer the decoded descriptions when available.

This also protects `aggregate_temporal`'s `mean` path, which has the identical exposure.

## Tests

Adds `test_multiband_asset_with_single_declared_band_name`: a lazy `RasterStack` whose images decode to 3 bands under a single declared band name (`["visual"]`), reduced with `mean`. Asserts the result is `(3,4,4)` and averaged correctly — reproduces the crash and locks the fix.

`tests/test_pixel_selection_reducers.py` → 36 passed. Related suites (`pixel`/`reduce`/`aggregate`/`math`/`filter`) → 158 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)