### PR TITLE
fix: accept TemporalIntervals in aggregate_temporal

### DIFF
--- a/tests/test_aggregate_temporal.py
+++ b/tests/test_aggregate_temporal.py
@@ -233,6 +233,75 @@ class TestAggregateTemporalBasic:
         assert len(result) == 5
 
 
+class TestAggregateTemporalIntervalsInput:
+    """Graph path: intervals arrive as a TemporalIntervals (parsed datetimes).
+
+    The openEO process-graph parser converts temporal-intervals into a
+    ``TemporalIntervals`` whose bounds are pendulum datetimes, not strings.
+    """
+
+    def test_temporal_intervals_object(self):
+        """A TemporalIntervals argument aggregates the same as a list of lists."""
+        from openeo_pg_parser_networkx.pg_schema import TemporalIntervals
+
+        data = _make_raster_stack(
+            [
+                (datetime(2021, 6, 15), 10.0),
+                (datetime(2022, 6, 15), 20.0),
+                (datetime(2023, 6, 15), 30.0),
+                (datetime(2024, 1, 1), 99.0),  # outside all intervals
+            ]
+        )
+        intervals = TemporalIntervals(
+            [
+                ["2023-06-01", "2023-07-01"],
+                ["2022-06-01", "2022-07-01"],
+                ["2021-06-01", "2021-07-01"],
+            ]
+        )
+        result = aggregate_temporal(
+            data=data, intervals=intervals, reducer=mean_reducer
+        )
+        assert len(result) == 3
+        keys = sorted(result.keys())
+        assert keys == [
+            datetime(2021, 6, 1),
+            datetime(2022, 6, 1),
+            datetime(2023, 6, 1),
+        ]
+        np.testing.assert_array_almost_equal(result[keys[0]].array.data, 10.0)
+        np.testing.assert_array_almost_equal(result[keys[1]].array.data, 20.0)
+        np.testing.assert_array_almost_equal(result[keys[2]].array.data, 30.0)
+
+    def test_temporal_intervals_passes_type_validation(self):
+        """Regression: the @process validation layer must accept a TemporalIntervals.
+
+        Previously ``intervals: List[List[Optional[str]]]`` made
+        _validate_parameter_types reject the parser-supplied TemporalIntervals
+        (DateTime elements), raising
+        ``TypeError: expected 'List' but got 'TemporalIntervals'``.
+        """
+        from openeo_pg_parser_networkx.pg_schema import TemporalIntervals
+
+        from titiler.openeo.processes.implementations.core import process
+
+        data = _make_raster_stack(
+            [
+                (datetime(2021, 6, 15), 10.0),
+                (datetime(2022, 6, 15), 20.0),
+            ]
+        )
+        intervals = TemporalIntervals(
+            [
+                ["2021-06-01", "2021-07-01"],
+                ["2022-06-01", "2022-07-01"],
+            ]
+        )
+        wrapped = process(aggregate_temporal)
+        result = wrapped(data=data, intervals=intervals, reducer=mean_reducer)
+        assert len(result) == 2
+
+
 class TestAggregateTemporalIntervalSemantics:
     """Test left-closed, right-open interval semantics."""
 

--- a/titiler/openeo/processes/implementations/filter.py
+++ b/titiler/openeo/processes/implementations/filter.py
@@ -5,7 +5,12 @@ from typing import Any, List, Optional, Union
 from openeo_pg_parser_networkx.pg_schema import TemporalInterval
 
 from .data_model import RasterStack
-from .reduce import DimensionNotAvailable, _parse_intervals, _timestamp_in_interval
+from .reduce import (
+    DimensionNotAvailable,
+    _interval_to_pair,
+    _parse_intervals,
+    _timestamp_in_interval,
+)
 
 __all__ = ["filter_temporal"]
 
@@ -16,22 +21,11 @@ def _extent_to_pair(extent: Any) -> List[Optional[str]]:
     The openEO graph parser passes ``extent`` as a ``TemporalInterval`` whose
     bounds are already parsed into pendulum datetimes, while direct Python/test
     callers pass a two-element list/tuple of strings (or ``None``). Both are
-    reduced here to the string-pair form understood by ``_parse_intervals``.
+    reduced here (via the shared ``_interval_to_pair``) to the string-pair form
+    understood by ``_parse_intervals``.
     """
-    if isinstance(extent, TemporalInterval):
-
-        def _bound(value: Any) -> Optional[str]:
-            if value is None:
-                return None
-            # Year/Date/DateTime/Time wrappers expose the parsed value as .root
-            # (a pendulum datetime/date/time), which serializes to RFC 3339.
-            root = getattr(value, "root", value)
-            return root.isoformat() if hasattr(root, "isoformat") else str(root)
-
-        return [_bound(extent.start), _bound(extent.end)]
-
-    if isinstance(extent, (list, tuple)):
-        return list(extent)
+    if isinstance(extent, (TemporalInterval, list, tuple)):
+        return _interval_to_pair(extent)
 
     raise ValueError("The temporal extent must be an array with exactly two elements.")
 

--- a/titiler/openeo/processes/implementations/reduce.py
+++ b/titiler/openeo/processes/implementations/reduce.py
@@ -43,6 +43,7 @@ from datetime import datetime, time, timedelta, timezone
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
 
 import numpy
+from openeo_pg_parser_networkx.pg_schema import TemporalInterval, TemporalIntervals
 from rasterio.crs import CRS
 from rio_tiler.models import ImageData
 from rio_tiler.mosaic.methods import PixelSelectionMethod
@@ -816,9 +817,58 @@ def _coerce_reduced_array(reduced_array: Any) -> numpy.ndarray:
     return reduced_array
 
 
+def _temporal_bound_to_str(value: Any) -> Optional[str]:
+    """Serialize a single temporal-interval bound to an RFC 3339 string.
+
+    Handles the raw strings/None passed by direct callers as well as the parsed
+    wrapper objects (Year/Date/DateTime/Time) the openEO graph parser produces,
+    whose parsed value lives in ``.root`` (a pendulum datetime/date/time).
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    root = getattr(value, "root", value)
+    return root.isoformat() if hasattr(root, "isoformat") else str(root)
+
+
+def _interval_to_pair(interval: Any) -> List[Optional[str]]:
+    """Normalize a single interval to a ``[start, end]`` list of RFC 3339 strings.
+
+    Accepts a parser-produced ``TemporalInterval`` or a two-element list/tuple of
+    strings/None. The length is preserved so downstream validation can still
+    reject malformed intervals.
+    """
+    if isinstance(interval, TemporalInterval):
+        return [
+            _temporal_bound_to_str(interval.start),
+            _temporal_bound_to_str(interval.end),
+        ]
+    if isinstance(interval, (list, tuple)):
+        return [_temporal_bound_to_str(v) for v in interval]
+    raise ValueError("Each temporal interval must be a two-element array.")
+
+
+def _normalize_intervals(intervals: Any) -> List[List[Optional[str]]]:
+    """Normalize the ``intervals`` argument to a list of string pairs.
+
+    The openEO graph parser passes ``intervals`` as a ``TemporalIntervals`` whose
+    bounds are already parsed into pendulum datetimes, while direct Python/test
+    callers pass a list of two-element string lists. Both are reduced here to the
+    string-pair form understood by :func:`_parse_intervals`.
+    """
+    if isinstance(intervals, TemporalIntervals):
+        items: List[Any] = list(intervals)
+    elif isinstance(intervals, (list, tuple)):
+        items = list(intervals)
+    else:
+        raise ValueError("At least one temporal interval must be provided")
+    return [_interval_to_pair(iv) for iv in items]
+
+
 def aggregate_temporal(
     data: RasterStack,
-    intervals: List[List[Optional[str]]],
+    intervals: Union[TemporalIntervals, List[List[Optional[str]]]],
     reducer: Callable,
     labels: Optional[List[Union[float, str]]] = None,
     dimension: Optional[Literal["t", "temporal", "time"]] = None,
@@ -852,14 +902,16 @@ def aggregate_temporal(
     """
     if not data:
         raise ValueError("Expected a non-empty data cube")
-    if not intervals:
+
+    normalized_intervals = _normalize_intervals(intervals)
+    if not normalized_intervals:
         raise ValueError("At least one temporal interval must be provided")
 
     if dimension is not None:
         if dimension.lower() not in ["t", "temporal", "time"]:
             raise DimensionNotAvailable(dimension)
 
-    parsed_intervals = _parse_intervals(intervals)
+    parsed_intervals = _parse_intervals(normalized_intervals)
     output_keys = _resolve_output_keys(labels, parsed_intervals)
     timestamps = data.timestamps()
 


### PR DESCRIPTION
## Problem

Running `aggregate_temporal` through an openEO process graph fails at parameter validation:

```
TypeError: Parameter 'intervals' in process 'aggregate_temporal':
expected 'List' but got 'TemporalIntervals'. Details: 6 validation errors for list[list[nullable[str]]]
0.0  Input should be a valid string [input_value=DateTime(2023, 6, 1, ...)]
...
```

## Root cause

This is the same class of bug as #288 (`filter_temporal`). The `openeo_pg_parser_networkx` parser converts the `temporal-intervals` argument into a `TemporalIntervals` object whose bounds are already parsed into pendulum `DateTime`s **before** our code runs. `aggregate_temporal` declared `intervals: List[List[Optional[str]]]`, so the `@process` type-validation layer (`_validate_parameter_types`) rejected the parsed object.

This corrects my earlier statement that `aggregate_temporal` was unaffected — it is affected, because `TemporalIntervals` (a `RootModel` wrapping `list[TemporalInterval]`) is also parser-converted.

## Fix

- Widen the annotation to `Union[TemporalIntervals, List[List[Optional[str]]]]` so validation accepts the parser-supplied object.
- Normalize both forms to RFC 3339 string pairs before the existing `_parse_intervals` / `_timestamp_in_interval` logic (unchanged: left-closed/right-open, open-ended bounds, `TemporalExtentEmpty`, distinct-label handling).
- Factor the single-interval conversion into shared helpers (`_temporal_bound_to_str`, `_interval_to_pair`) in `reduce.py`, and reuse them from `filter._extent_to_pair` to remove the duplication introduced in #288.

Behavior for existing list-of-lists callers is unchanged.

## Tests

Added `TestAggregateTemporalIntervalsInput`:
- `test_temporal_intervals_object` — body path with a `TemporalIntervals` (incl. an out-of-interval slice that must be dropped, reverse-ordered intervals).
- `test_temporal_intervals_passes_type_validation` — wraps `aggregate_temporal` with `@process` and calls it with a `TemporalIntervals`, reproducing the exact validation failure and locking the fix.

`tests/test_aggregate_temporal.py` → 51 passed. Related suites (`aggregate`/`filter`/`reduce`/`core`/`process`/`pixel`/`math`) → 304 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)