### PR TITLE
fix: save_result GTiff preserves data instead of uint8/RGB

### DIFF
--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -142,6 +142,91 @@ def test_save_result_geotiff():
     assert len(result.data) > 0  # Should contain TIFF bytes
 
 
+def _read_geotiff(result):
+    """Open a SaveResultData GeoTIFF payload with rasterio."""
+    import io as _io
+
+    import rasterio
+
+    return rasterio.open(_io.BytesIO(result.data))
+
+
+def test_save_result_geotiff_preserves_float_single_band():
+    """GTiff must preserve float dtype/values (not cast to uint8/RGB). Issue #296."""
+    arr = numpy.ma.array(
+        (numpy.linspace(-0.7, 0.7, 64, dtype="float32")).reshape(1, 8, 8),
+        mask=numpy.zeros((1, 8, 8), dtype=bool),
+    )
+    data = RasterStack.from_images(
+        {
+            datetime(2021, 7, 1): ImageData(
+                arr,
+                crs="EPSG:4326",
+                bounds=(-180, -90, 180, 90),
+                band_descriptions=["ndvi"],
+            )
+        }
+    )
+
+    result = save_result(data, "GTiff")
+    assert result.media_type == "image/tiff"
+    with _read_geotiff(result) as ds:
+        assert ds.count == 1  # single band, no RGB render / alpha band
+        assert ds.dtypes[0] == "float32"  # native dtype preserved (not uint8)
+        assert ds.crs is not None  # georeferenced
+        band = ds.read(1)
+        numpy.testing.assert_allclose(band.min(), -0.7, atol=1e-3)
+        numpy.testing.assert_allclose(band.max(), 0.7, atol=1e-3)
+
+
+def test_save_result_geotiff_float_masked_uses_nodata():
+    """Masked float pixels are encoded as NaN nodata, real values preserved."""
+    a = numpy.ones((1, 4, 4), dtype="float32") * 0.42
+    mask = numpy.zeros((1, 4, 4), dtype=bool)
+    mask[0, 0, 0] = True
+    data = RasterStack.from_images(
+        {
+            datetime(2021, 7, 1): ImageData(
+                numpy.ma.array(a, mask=mask),
+                crs="EPSG:4326",
+                bounds=(-180, -90, 180, 90),
+                band_descriptions=["ndvi"],
+            )
+        }
+    )
+
+    result = save_result(data, "gtiff")
+    with _read_geotiff(result) as ds:
+        assert ds.dtypes[0] == "float32"
+        assert numpy.isnan(ds.nodata)
+        band = ds.read(1)
+        assert numpy.isnan(band[0, 0])  # masked pixel -> nodata
+        assert numpy.nanmax(band) == numpy.float32(0.42)  # values preserved
+
+
+def test_save_result_geotiff_multi_slice_preserves_float():
+    """Multi-slice float cube -> multi-band float GeoTIFF (was uint8 RGB). Issue #296."""
+
+    def _img(v):
+        a = numpy.ones((1, 4, 4), dtype="float32") * v
+        return ImageData(
+            numpy.ma.array(a, mask=numpy.zeros_like(a, dtype=bool)),
+            crs="EPSG:4326",
+            bounds=(-180, -90, 180, 90),
+            band_descriptions=["ndvi"],
+        )
+
+    data = RasterStack.from_images(
+        {datetime(2021, 7, 1): _img(-0.5), datetime(2022, 7, 1): _img(0.3)}
+    )
+    result = save_result(data, "gtiff")
+    with _read_geotiff(result) as ds:
+        assert ds.count == 2  # one band per slice
+        assert ds.dtypes[0] == "float32"
+        numpy.testing.assert_allclose(ds.read(1).min(), -0.5, atol=1e-6)
+        numpy.testing.assert_allclose(ds.read(2).max(), 0.3, atol=1e-6)
+
+
 def test_save_result_single_image():
     """Test save_result with single image."""
     array = numpy.array([[1, 2], [3, 4]], dtype=numpy.uint8)[

--- a/titiler/openeo/processes/implementations/io.py
+++ b/titiler/openeo/processes/implementations/io.py
@@ -92,6 +92,77 @@ class SaveResultData:
         return self.data
 
 
+def _render_geotiff_result(
+    image_data: ImageData, options: Optional[Dict] = None
+) -> SaveResultData:
+    """Render an ImageData to a data GeoTIFF, preserving dtype, bands and nodata.
+
+    Unlike PNG/JPEG, GTiff is a data output format: no uint8 cast, no
+    colormap/RGB rendering and no alpha band. Masked pixels are encoded with a
+    nodata value (NaN for floats, the array fill value otherwise) so the result
+    round-trips as analysis-ready raster data. See issue #296.
+    """
+    opts = dict(options or {})
+    arr = image_data.array
+    nodata = opts.pop("nodata", None)
+
+    # Only encode nodata when there are actually masked pixels. For floats NaN is
+    # the natural nodata; for integers use the array fill value, clamped to the
+    # dtype range (the default masked fill of 999999 overflows e.g. uint8).
+    has_mask = isinstance(arr, numpy.ma.MaskedArray) and bool(numpy.ma.is_masked(arr))
+    if nodata is None and has_mask:
+        if numpy.issubdtype(arr.dtype, numpy.floating):
+            nodata = float(numpy.nan)
+        else:
+            info = numpy.iinfo(arr.dtype)
+            fill = int(arr.fill_value)
+            nodata = fill if info.min <= fill <= info.max else int(info.max)
+
+    if has_mask and nodata is not None:
+        # Bake the mask into the data band as nodata (rendered with add_mask=False
+        # below), so masked pixels are written as nodata rather than raw values.
+        image_data = ImageData(
+            numpy.ma.array(arr.filled(nodata), mask=False),
+            crs=image_data.crs,
+            bounds=image_data.bounds,
+            band_descriptions=image_data.band_descriptions,
+            metadata=image_data.metadata,
+        )
+
+    render_kwargs: Dict[str, Any] = {"add_mask": False}
+    if nodata is not None:
+        render_kwargs["nodata"] = nodata
+    render_kwargs.update(opts)
+
+    rendered = image_data.render(img_format="GTIFF", **render_kwargs)
+    return SaveResultData(data=rendered, media_type="image/tiff")
+
+
+def _save_feature_collection(data: Dict, format: str) -> SaveResultData:
+    """Serialize a GeoJSON FeatureCollection to JSON or CSV."""
+    if format.lower() == "json":
+        return SaveResultData(
+            data=json.dumps(data).encode("utf-8"), media_type="application/json"
+        )
+
+    if format.lower() == "csv":
+        # CSV output with date, feature_index, and value columns
+        output = io.StringIO()
+        writer = csv.writer(output)
+        writer.writerow(["date", "feature_index", "value"])
+        for idx, feature in enumerate(data.get("features", [])):
+            values_dict = feature.get("properties", {}).get("values", {})
+            for date, value in values_dict.items():
+                writer.writerow([date, idx, value])
+        return SaveResultData(
+            data=output.getvalue().encode("utf-8"), media_type="text/csv"
+        )
+
+    raise ValueError(
+        "Only GeoJSON and CSV formats are supported for FeatureCollection data"
+    )
+
+
 def _save_single_result(
     data: Union[ImageData, numpy.ndarray, numpy.ma.MaskedArray, dict],
     format: str,
@@ -107,37 +178,7 @@ def _save_single_result(
         return SaveResultData(data=bytes, media_type="application/json")
 
     if isinstance(data, dict) and data.get("type") == "FeatureCollection":
-        if format.lower() == "json":
-            # convert json to bytes
-            bytes = json.dumps(data).encode("utf-8")
-            return SaveResultData(data=bytes, media_type="application/json")
-        elif format.lower() == "csv":
-            # Extract features from the FeatureCollection
-            features = data.get("features", [])
-
-            # Create CSV output with date, feature_index, and value columns
-            output = io.StringIO()
-            writer = csv.writer(output)
-
-            # Write header
-            writer.writerow(["date", "feature_index", "value"])
-
-            # Write data rows
-            for idx, feature in enumerate(features):
-                properties = feature.get("properties", {})
-                values_dict = properties.get("values", {})
-
-                # For each date-value pair in the values dictionary
-                for date, value in values_dict.items():
-                    writer.writerow([date, idx, value])
-
-            # Convert to bytes
-            csv_bytes = output.getvalue().encode("utf-8")
-            return SaveResultData(data=csv_bytes, media_type="text/csv")
-
-        raise ValueError(
-            "Only GeoJSON and CSV formats are supported for FeatureCollection data"
-        )
+        return _save_feature_collection(data, format)
 
     if isinstance(data, (numpy.ma.MaskedArray, numpy.ndarray)):
         data = ImageData(data)
@@ -149,6 +190,11 @@ def _save_single_result(
 
     image_data: ImageData = data
     options = options or {}
+
+    # GTiff is a DATA format: preserve dtype, bands and nodata; never apply the
+    # uint8/RGB image rendering used for PNG/JPEG. See issue #296.
+    if format.lower() in ["tiff", "gtiff"]:
+        return _render_geotiff_result(image_data, options)
 
     if format.lower() in ["jpeg", "jpg", "png"] and image_data.array.dtype != "uint8":
         # Convert to uint8 while preserving the mask if it's a masked array
@@ -255,8 +301,10 @@ def _handle_raster_geotiff(data: Dict[datetime, ImageData]) -> ImageData:
     # Each input array should be (1, height, width), and we want (bands, height, width)
     arrays = []
     for img in image_data_list:
-        # Get the array and ensure it's uint8
-        arr = img.array.astype(numpy.uint8)
+        # Preserve the native dtype and mask: GTiff is a DATA format. Casting to
+        # uint8 here collapses float index/reflectance values (e.g. NDVI in
+        # [-1, 1] -> all zeros). See issue #296.
+        arr = img.array
         # If array is 2D (height, width), add band dimension
         if arr.ndim == 2:
             arr = arr[numpy.newaxis, ...]


### PR DESCRIPTION
Closes #296.

## Problem

`save_result(format="GTiff")` on a quantitative (float) datacube returned a **3-band uint8 RGB** GeoTIFF with the data destroyed — e.g. an NDVI cube in `[-0.7, 0.7]` came back as constant `(0, 0, 255)`, `dtype uint8`, `nodata None`. The same graph on CDSE/VITO returns a single-band `float32` GeoTIFF with `nodata=nan`.

## Root cause

In `io.py`:
1. `_handle_raster_geotiff` cast every array with `arr.astype(numpy.uint8)` — collapsing float index/reflectance values (`|v| < 1` → 0).
2. `_save_single_result` then ran the **PNG/JPEG image render** path (`ImageData.render`), adding RGB + alpha and dropping nodata.

GTiff is a **data** output format, not an image format.

## Fix

- `_handle_raster_geotiff` keeps the **native dtype and mask** (no uint8 cast).
- New `_render_geotiff_result` writes a proper data GeoTIFF: native dtype, one band per data band, georeferencing preserved, `add_mask=False` (no RGB/alpha). Masked pixels are encoded as **nodata** — `NaN` for floats; for integers the array fill value **clamped to the dtype range** (the default masked fill `999999` overflows e.g. `uint8`, which is what broke the first attempt). nodata is only set when pixels are actually masked, and an explicit `nodata` option is honored.
- PNG/JPEG keep their existing uint8/render behavior.
- FeatureCollection JSON/CSV serialization factored into `_save_feature_collection` to keep `_save_single_result` under the complexity limit.

## Verification

Before: multi-slice float cube → `count=3, uint8, band3=255`.
After: `count=N, float32, nodata=nan, CRS preserved, values intact`.

Regression tests added: single-band float preservation, masked-float → NaN nodata, multi-slice float → multi-band float GeoTIFF. `tests/test_io.py` → 14 passed; related suites (`io`/`save`/`service`/`factory`) → 336 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)