### PR TITLE
fix: load_collection no longer silently caps items at 100

### DIFF
--- a/tests/test_stacapi.py
+++ b/tests/test_stacapi.py
@@ -191,3 +191,95 @@ def test_resolution_based_dimension_calculation(monkeypatch):
     height = result.height or 0
     assert 950 <= width <= 1050, f"Width {width} is not within expected range"
     assert 950 <= height <= 1050, f"Height {height} is not within expected range"
+
+
+def _stac_item_dict(dt: str) -> dict:
+    """Minimal valid STAC item dict for the given datetime string."""
+    return {
+        "type": "Feature",
+        "id": f"item-{dt}",
+        "stac_version": "1.0.0",
+        "stac_extensions": [
+            "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+        ],
+        "bbox": [0, 0, 1, 1],
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+        },
+        "properties": {
+            "datetime": dt,
+            "proj:crs": "EPSG:4326",
+            "proj:transform": [0.0002, 0.0, 0.0, 0.0, -0.0002, 0.0],
+        },
+        "assets": {
+            "B01": {
+                "href": "https://example.com/B01.tif",
+                "type": "image/tiff; application=geotiff",
+            }
+        },
+        "links": [],
+    }
+
+
+def test_load_collection_requests_items_beyond_limit(monkeypatch):
+    """load_collection must request max_items + 1 so overflow is detectable.
+
+    Regression for #300: the STAC search silently capped at the first page
+    (100, newest-first), dropping whole months/years from wide temporal extents.
+    """
+    from titiler.openeo.settings import ProcessingSettings
+
+    settings = ProcessingSettings(max_items=20)
+    monkeypatch.setattr("titiler.openeo.stacapi.processing_settings", settings)
+    monkeypatch.setattr("titiler.openeo.reader.SimpleSTACReader", MockReader)
+
+    captured = {}
+
+    def mock_get_items(self, *args, max_items=None, **kwargs):
+        captured["max_items"] = max_items
+        return [Item.from_dict(_stac_item_dict("2021-01-01T00:00:00Z"))]
+
+    monkeypatch.setattr(LoadCollection, "_get_items", mock_get_items)
+
+    backend = stacApiBackend(url="https://example.com")
+    loader = LoadCollection(stac_api=backend)
+
+    loader.load_collection(
+        id="test",
+        spatial_extent=BoundingBox(west=0, south=0, east=1, north=1, crs="EPSG:4326"),
+        width=64,
+        height=64,
+    )
+    # +1 lets the item-limit guard detect genuine overflow instead of truncating.
+    assert captured["max_items"] == settings.max_items + 1
+
+
+def test_load_collection_raises_when_items_exceed_limit(monkeypatch):
+    """Too many items in the extent fails loudly instead of silently truncating."""
+    from titiler.openeo.errors import ItemsLimitExceeded
+    from titiler.openeo.settings import ProcessingSettings
+
+    settings = ProcessingSettings(max_items=2)
+    monkeypatch.setattr("titiler.openeo.stacapi.processing_settings", settings)
+    monkeypatch.setattr("titiler.openeo.reader.SimpleSTACReader", MockReader)
+
+    # Backend reports 3 items (> max_items=2); previously this was hidden by the
+    # hardcoded 100-item cap and produced silent partial/empty results.
+    items = [
+        Item.from_dict(_stac_item_dict(f"2021-0{i + 1}-01T00:00:00Z")) for i in range(3)
+    ]
+    monkeypatch.setattr(LoadCollection, "_get_items", lambda self, *a, **k: items)
+
+    backend = stacApiBackend(url="https://example.com")
+    loader = LoadCollection(stac_api=backend)
+
+    with pytest.raises(ItemsLimitExceeded):
+        loader.load_collection(
+            id="test",
+            spatial_extent=BoundingBox(
+                west=0, south=0, east=1, north=1, crs="EPSG:4326"
+            ),
+            width=64,
+            height=64,
+        )

--- a/titiler/openeo/stacapi.py
+++ b/titiler/openeo/stacapi.py
@@ -737,17 +737,24 @@ class LoadCollection:
             named_parameters: Named parameters for process graph evaluation
             target_crs: Target CRS for output. If None, uses native CRS from source images.
         """
+        # Retrieve up to one item beyond the configured processing limit so the
+        # guard below can detect genuine overflow. Without an explicit max_items
+        # the STAC search silently caps at the first page (100, newest-first),
+        # which drops whole months/years from wide temporal extents and yields
+        # empty aggregate_temporal buckets (all-no-data). See issue #300.
         items = self._get_items(
             id,
             spatial_extent=spatial_extent,
             temporal_extent=temporal_extent,
             properties=properties,
+            max_items=processing_settings.max_items + 1,
             named_parameters=named_parameters,
         )
         if not items:
             raise NoDataAvailable("There is no data available for the given extents.")
 
-        # Check the items limit
+        # Check the items limit. Fail loudly when the extent genuinely contains
+        # more items than allowed rather than silently truncating the result.
         if len(items) > processing_settings.max_items:
             raise ItemsLimitExceeded(len(items), processing_settings.max_items)
 


### PR DESCRIPTION
Closes #300.

## Root cause (confirmed on the live CDSE backend)

`stacApiBackend.get_items` defaults `max_items` to **100** ([stacapi.py:257](https://github.com/sentinel-hub/titiler-openeo/blob/main/titiler/openeo/stacapi.py#L257)), and `load_collection` never overrode it. So every STAC search returned only the **first page (100 items, newest-first)**. For a wide temporal extent this silently drops whole months/years.

Reproduced with the issue's AOI against `stac.dataspace.copernicus.eu`, `sentinel-2-l2a`:

```
load [2015-08-01 .. 2017-09-01]  -> 50 scenes, ALL in 2017-04..2017-08
                                    (2016-08 and 2015-08 entirely absent)
INDIVIDUAL 2017-08 finite%: 100.0
AGG bucket 2017-08 finite%: 100.0
AGG bucket 2016-08 finite%:   0.0   # no scenes -> no-data composite
```

`aggregate_temporal` over the 2016/2015 intervals finds no slices → no-data buckets → the reported **all-NaN with HTTP 200**. The narrow per-interval downloads work because each month fits under the 100-item cap. The item-limit guard never fired because the truncated count (100) was not greater than the configured limit.

This is **not** the geometry/`from_images` theory in #301 — that PR is unrelated to #300 and I'll re-scope it.

## Fix

`load_collection` now requests `processing_settings.max_items + 1`, so the existing guard raises `ItemsLimitExceeded` on genuine overflow instead of silently truncating to the newest 100. You either get **all** items in the extent or a clear error — never a silent partial result.

## Verification (live backend, after fix)

```
load [2015-08-01 .. 2017-09-01], MAX_ITEMS=500 -> 170 scenes
INDIVIDUAL 2015/2016/2017-08 finite%: 100.0 / 100.0 / 100.0
AGG buckets 2015/2016/2017-08 finite%: 100.0 / 100.0 / 100.0
2016-08 matched scenes: 6 (all 100% finite)
```

## Tests

- `test_load_collection_requests_items_beyond_limit` — asserts the search is asked for `max_items + 1`.
- `test_load_collection_raises_when_items_exceed_limit` — asserts `ItemsLimitExceeded` instead of silent truncation.

`tests/test_stacapi.py` → 5 passed; related suites (`stacapi`/`load_collection`/`service`) → 41 passed.

## Note / follow-up

For very large extents (e.g. 3+ years of monthly scenes feeding `aggregate_temporal`), this now surfaces `ItemsLimitExceeded` rather than wrong data — deployments may need a higher `TITILER_OPENEO_PROCESSING_MAX_ITEMS`. A future enhancement could push the temporal-interval selection down into the STAC query so only needed periods are fetched. The generic `max_items or 100` default in `get_items` remains a latent footgun for any other caller that doesn't pass `max_items`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)