### PR TITLE
fix: make /healthz async so liveness isn't starved under load

### DIFF
--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -10,6 +10,24 @@ def test_healthz(app_no_auth):
     assert response.json() == {"status": "ok"}
 
 
+def test_healthz_handler_is_async(app_no_auth):
+    """Regression: /healthz must be an async handler.
+
+    A sync handler is dispatched to the shared anyio threadpool, which the sync
+    compute endpoints saturate under load, starving the liveness probe and
+    causing needless pod restarts. Keeping it async runs it on the event loop,
+    decoupled from threadpool/compute load.
+    """
+    import inspect
+
+    endpoint = next(
+        r.endpoint
+        for r in app_no_auth.app.routes
+        if getattr(r, "path", None) == "/healthz"
+    )
+    assert inspect.iscoroutinefunction(endpoint), "/healthz must be async def"
+
+
 def test_healthz_not_in_openapi(app_no_auth):
     """Health endpoints must not pollute the OpenAPI document."""
     openapi = app_no_auth.get("/api").json()

--- a/titiler/openeo/health.py
+++ b/titiler/openeo/health.py
@@ -111,8 +111,15 @@ def register_health_endpoints(
     router = APIRouter(tags=["health"], include_in_schema=False)
 
     @router.get("/healthz")
-    def healthz() -> Dict[str, str]:
-        """Liveness probe. Always returns 200 if the process is alive."""
+    async def healthz() -> Dict[str, str]:
+        """Liveness probe. Always returns 200 if the event loop is responsive.
+
+        Declared ``async`` on purpose: a sync handler is dispatched to the shared
+        anyio threadpool, which the (sync) compute endpoints saturate under load,
+        starving the probe and triggering needless liveness restarts. As an async
+        no-op this runs directly on the event loop and stays responsive
+        regardless of threadpool/compute load.
+        """
         return {"status": "ok"}
 
     @router.get("/readyz")


### PR DESCRIPTION
## Problem

Under heavy load the `/healthz` liveness probe stops responding, so the kubelet restarts pods mid-load — which redistributes traffic to the remaining pods and cascades.

## Root cause

`/healthz` does no work, but it was declared as a **sync `def`** ([health.py](https://github.com/sentinel-hub/titiler-openeo/blob/main/titiler/openeo/health.py)). Starlette dispatches sync route handlers to the shared **anyio threadpool** (default 40 threads). The compute endpoints (`openeo_result`, the XYZ tile service) are also sync and run in that same pool, so once ~40 heavy requests are in flight the pool is saturated and the sync `/healthz` can't get a thread → the liveness probe times out → pod restart.

Extending the probe `timeoutSeconds`/`failureThreshold` would only postpone the restart while the pool stays saturated — it doesn't decouple the probe from the load.

## Fix

Declare `/healthz` as `async def`. As an async no-op it runs directly on the event loop (which isn't blocked by threadpool work), so liveness stays responsive regardless of compute load. One-line change; behavior of the response is unchanged.

`/readyz` is intentionally left as-is for now (it already isolates its dependency checks to a dedicated executor; making it fully async is part of a broader load-resilience follow-up).

## Test

`test_healthz_handler_is_async` asserts the route handler is a coroutine function — a deterministic guard against regressing to sync `def` (a full threadpool-saturation load test would be flaky in CI).

`tests/test_health.py` → 20 passed.

## Follow-up (separate)

A broader async/threadpool audit is planned: making the compute endpoints async or sizing the threadpool, and reserving capacity for critical endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)