### PR TITLE
feat(processes): memory optimization EPIC (#305) [DO NOT MERGE]

### DIFF
--- a/.env.cdse
+++ b/.env.cdse
@@ -12,6 +12,9 @@ GDAL_HTTP_MULTIPLEX=TRUE # Enable HTTP multiplexing
 GDAL_CACHEMAX=500 # Set GDAL cache size
 GDAL_INGESTED_BYTES_AT_OPEN=32768 # Open a larger bytes range when reading
 GDAL_HTTP_MERGE_CONSECUTIVE_RANGES=YES # Merge consecutive ranges\
+# 512 MB PER FILE-HANDLE — local/dev only (single user, low concurrency). Do NOT
+# use this in k8s/prod: it multiplies by every concurrently open file handle and
+# will OOM a pod. The Helm chart default is 5 MB. See docs/src/memory-tuning.md.
 VSI_CACHE_SIZE=536870912 # Set VSI cache size
 VSI_CACHE=TRUE # Enable VSI cache
 

--- a/.env.eoapi
+++ b/.env.eoapi
@@ -8,6 +8,9 @@ GDAL_HTTP_MULTIPLEX=TRUE # Enable HTTP multiplexing
 GDAL_CACHEMAX=500 # Set GDAL cache size
 GDAL_INGESTED_BYTES_AT_OPEN=32768 # Open a larger bytes range when reading
 GDAL_HTTP_MERGE_CONSECUTIVE_RANGES=YES # Merge consecutive ranges\
+# 512 MB PER FILE-HANDLE — local/dev only (single user, low concurrency). Do NOT
+# use this in k8s/prod: it multiplies by every concurrently open file handle and
+# will OOM a pod. The Helm chart default is 5 MB. See docs/src/memory-tuning.md.
 VSI_CACHE_SIZE=536870912 # Set VSI cache size
 VSI_CACHE=TRUE # Enable VSI cache
 

--- a/deployment/k8s/charts/tests/native_cache_test.yaml
+++ b/deployment/k8s/charts/tests/native_cache_test.yaml
@@ -1,0 +1,39 @@
+suite: native cache budget guard
+# Tripwire for EPIC #305 subtask 6: the GDAL/VSI native (off-heap) caches must
+# stay at their bounded defaults. If someone bumps one (e.g. pastes a dev
+# VSI_CACHE_SIZE of 512 MB), these assertions fail and force a conscious review
+# against the memory budget. See docs/src/memory-tuning.md.
+templates:
+  - deployment.yaml
+tests:
+  - it: VSI_CACHE_SIZE stays small (per-file-handle; never the dev 512 MB)
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: VSI_CACHE_SIZE
+            value: "5000000"
+
+  - it: GDAL_CACHEMAX stays bounded (process-global, × WEB_CONCURRENCY)
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GDAL_CACHEMAX
+            value: "200"
+
+  - it: CPL_VSIL_CURL_CACHE_SIZE is pinned (not left to drift)
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CPL_VSIL_CURL_CACHE_SIZE
+            value: "67108864"
+
+  - it: VSI cache is enabled
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: VSI_CACHE
+            value: "TRUE"

--- a/deployment/k8s/charts/values.yaml
+++ b/deployment/k8s/charts/values.yaml
@@ -87,11 +87,31 @@ auth:
 stac:
   apiUrl: "https://stac.eoapi.dev"  # STAC API endpoint URL
 
+# GDAL/VSI native (off-heap) caches. These live OUTSIDE the Python heap and are
+# NOT freed by gc, so they add on top of per-request working memory and must fit
+# under resources.limits.memory. Keep them small and explicit. See the sizing
+# guide: docs/src/memory-tuning.md (and the audit in docs/audits/).
+#
+# Rough native budget per pod:
+#   WEB_CONCURRENCY * (GDAL_CACHEMAX + CPL_VSIL_CURL_CACHE_SIZE)   # process-global
+#   + (concurrently open file handles) * VSI_CACHE_SIZE           # PER-handle!
+# Keep this comfortably below resources.limits.memory, leaving room for the
+# Python heap (the process-graph cubes).
 env:
   CPL_TMPDIR: /tmp
-  GDAL_CACHEMAX: 200   # 200 mb
-  VSI_CACHE: "TRUE"   # Enable VSI cache
-  VSI_CACHE_SIZE: 5000000   # 5 MB (per file-handle)
+  # Process-global block cache. Values <100000 are MB, else bytes -> 200 MB here.
+  # Multiplies by WEB_CONCURRENCY (one cache per worker process).
+  GDAL_CACHEMAX: "200"
+  VSI_CACHE: "TRUE"
+  # PER FILE-HANDLE in-memory cache: total ≈ this × number of concurrently open
+  # files (≈ items × bands × read threads). Keep it small. The dev .env profiles
+  # use 512 MB here for single-user local runs — NEVER ship that to a pod.
+  # NOTE: quote large numbers — unquoted, Helm renders 5000000 as "5e+06", which
+  # GDAL parses as 5 (stops at 'e'), silently disabling the VSI cache.
+  VSI_CACHE_SIZE: "5000000"   # 5 MB per handle
+  # Process-global LRU for /vsicurl chunk reads. Pinned (GDAL defaults to 16 MB)
+  # so it can't drift; raise for read-heavy workloads only if the budget allows.
+  CPL_VSIL_CURL_CACHE_SIZE: "67108864"   # 64 MB
   GDAL_DISABLE_READDIR_ON_OPEN: "EMPTY_DIR"   # Disable directory listing
   GDAL_HTTP_MERGE_CONSECUTIVE_RANGES: "YES"   # Merge consecutive ranges
   GDAL_HTTP_MULTIPLEX: "YES"   # Enable multiplexing

--- a/docs/audits/memory-profiling.md
+++ b/docs/audits/memory-profiling.md
@@ -55,6 +55,12 @@ Reading it:
 - **retention line** — `nodes_pinned` is `len(results_cache)`;
   `retained_bytes` sums unique array buffers (shared `ImageData` counted once).
 
+> Intermediate eviction is **on by default** (subtask 4): the reference-counted
+> `results_cache` frees each node's data once all its consumers have run, so the
+> retention line should report a small `retained_bytes` (≈ the final result).
+> To measure the *un-evicted baseline* (the original keep-everything behavior),
+> set `TITILER_OPENEO_PROCESSING_EVICT_INTERMEDIATE_RESULTS=false`.
+
 The same lines are emitted in-app for `POST /result` and the XYZ tile endpoint
 when the env var is set, so you can profile against a running dev server too.
 

--- a/docs/audits/memory-profiling.md
+++ b/docs/audits/memory-profiling.md
@@ -1,0 +1,94 @@
+# Memory profiling harness
+
+How to measure where a process graph spends memory, so the fixes in EPIC #305
+(see [`memory-oom-audit.md`](memory-oom-audit.md)) can be confirmed with numbers
+instead of guesses. This is **subtask 1** of that EPIC.
+
+The harness separates the two things that look identical to the OOM killer:
+
+- **Python heap** — the retained `ImageData`/numpy cubes (`tracemalloc`).
+- **Native / off-heap** — GDAL block cache, VSI/curl caches (`RSS − heap`).
+
+> ⚠️ Debug only. `tracemalloc` roughly doubles allocation cost and the harness
+> is process-global / not concurrency-safe. Never enable it in production.
+
+## 1. In-process harness (per-node + retention)
+
+Enable with one env var; everything is a no-op otherwise.
+
+| Env var | Default | Effect |
+|---------|---------|--------|
+| `TITILER_OPENEO_PROFILING_MEMORY` | `false` | per-node heap deltas, graph heap/RSS summary, end-of-graph retention |
+| `TITILER_OPENEO_PROFILING_MEMORY_BACKREFS` | `false` | also dump an `objgraph` back-ref graph for a sample retained array (needs `objgraph`) |
+| `TITILER_OPENEO_PROFILING_MEMORY_BACKREFS_DIR` | `/tmp` | where the back-ref image is written |
+
+Run a single graph through the standalone runner (no uvicorn/threads in the way):
+
+```bash
+TITILER_OPENEO_PROFILING_MEMORY=true \
+TITILER_OPENEO_STAC_API_URL=https://stac.eoapi.dev \
+uv run python scripts/profile_memory.py path/to/graph.json
+```
+
+`graph.json` is the same body `POST /result` accepts (a full process definition
+or a bare process graph). You get log lines like:
+
+```
+[mem] profile graph.json START heap=12.3MB rss=180.0MB
+[mem] node=load_collection depth=0 heap_delta=+629.0MB rss_delta=+940.0MB heap_now=641.3MB rss_now=1.1GB native~=470.0MB
+[mem]   node=ndvi depth=1 heap_delta=+900.0MB ...
+[mem] node=aggregate_temporal depth=0 heap_delta=+27.0MB ...
+[mem] profile graph.json END heap=1.5GB (peak=1.7GB) rss=1.9GB native~=400.0MB
+[mem] graph.json: nodes_pinned=5 retained_arrays=204 retained_bytes=1.5GB
+```
+
+Reading it:
+
+- **`heap_delta`** — net bytes a node *kept* (what the graph engine now pins).
+  `load_collection` and `ndvi` both staying large confirms the audit's "two full
+  cubes alive at once".
+- **`depth`** — `0` = top-level graph node; `>0` = nested reducer call
+  (e.g. `aggregate_temporal` → `mean` → `apply_pixel_selection`).
+- **`native~=` / END `native~=`** — `RSS − heap`, the GDAL/VSI off-heap estimate.
+  Large here ⇒ tune `GDAL_CACHEMAX`/`VSI_CACHE_SIZE` (EPIC subtask 6); large
+  `heap` ⇒ the retention/dtype fixes (subtasks 2–5).
+- **retention line** — `nodes_pinned` is `len(results_cache)`;
+  `retained_bytes` sums unique array buffers (shared `ImageData` counted once).
+
+The same lines are emitted in-app for `POST /result` and the XYZ tile endpoint
+when the env var is set, so you can profile against a running dev server too.
+
+## 2. memray (full allocation flamegraph, heap + native)
+
+For an allocation-site flamegraph including native allocations:
+
+```bash
+TITILER_OPENEO_STAC_API_URL=https://stac.eoapi.dev \
+uv run memray run -o /tmp/openeo.bin scripts/profile_memory.py path/to/graph.json
+uv run memray flamegraph /tmp/openeo.bin     # -> /tmp/openeo-flamegraph.html
+# peak-memory view:
+uv run memray flamegraph --temporal --leaks /tmp/openeo.bin
+```
+
+`memray` is not a project dependency; install it ad-hoc (`uv pip install memray`)
+or add it to the dev group when doing a profiling session.
+
+## 3. The reference graph (issue #300)
+
+Use a `load_collection` over a multi-year extent → `ndvi` → `aggregate_temporal`
+(a few intervals) → `reduce_dimension('t')` → `save_result(GTiff)`. Watch for:
+
+1. `load_collection` and `ndvi` heap_delta both staying resident through
+   `aggregate_temporal` (retention; subtasks 4–5).
+2. `ndvi` heap_delta being *larger* than the source it consumed (float64 upcast;
+   subtask 2).
+3. END `peak` ≈ Σ of stages rather than the working set.
+4. `native~=` vs `heap` ratio (which fix family applies).
+
+## 4. Heap vs native, quickly
+
+- `heap_now` close to `rss_now` → almost everything is Python heap → focus on
+  retention + dtype (subtasks 2–5).
+- Large `native~=` (RSS ≫ heap) → off-heap GDAL/VSI caches dominate → focus on
+  cache sizing (subtask 6). Cross-check with `rasterio`/GDAL:
+  `from osgeo import gdal; gdal.GetCacheUsed(), gdal.GetCacheMax()`.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
     - Local Setup: "local-setup.md"
     - Kubernetes Guide: "kubernetes.md"
     - Production PostgreSQL (CloudNativePG): "kubernetes-cloudnativepg.md"
+    - Memory Tuning & Native Caches: "memory-tuning.md"
   - Examples:
     - Overview: "examples/index.md"
     - Parameter Management: "examples/parameter-management.md"

--- a/docs/src/memory-tuning.md
+++ b/docs/src/memory-tuning.md
@@ -1,0 +1,98 @@
+# Memory tuning & native caches
+
+titiler-openeo uses memory in two very different places, and an OOM kill looks
+identical for both:
+
+- **Python heap** — the `ImageData`/numpy cubes produced while evaluating a
+  process graph. Bounded per request and freed mid-graph by the reference-counted
+  results cache (see the [memory audit](https://github.com/sentinel-hub/titiler-openeo/blob/main/docs/audits/memory-oom-audit.md)
+  and EPIC #305).
+- **Native / off-heap** — GDAL and `/vsi*` caches. These live **outside** the
+  Python heap, are **not** freed by the garbage collector, and add *on top* of
+  per-request working memory. This page is about keeping them bounded.
+
+> The single most common production footgun is shipping a **dev** `VSI_CACHE_SIZE`
+> (512 MB) to Kubernetes. It is a *per-file-handle* cache and will OOM a pod.
+
+## The three native knobs
+
+| Variable | Scope | Default | Notes |
+|----------|-------|---------|-------|
+| `GDAL_CACHEMAX` | **process-global** block cache | 5% of RAM | Values `<100000` are **MB**, otherwise **bytes**. One cache per worker process, so it multiplies by `WEB_CONCURRENCY`. |
+| `VSI_CACHE_SIZE` | **per file-handle** | 25 MB | In-memory cache of each open file. Total ≈ `VSI_CACHE_SIZE × (concurrently open handles)`. **This is the dangerous one.** |
+| `CPL_VSIL_CURL_CACHE_SIZE` | **process-global** LRU for `/vsicurl` chunk reads | 16 MB | Pin it so it can't drift; raise only if the budget allows. |
+
+`VSI_CACHE` must be `TRUE` for `VSI_CACHE_SIZE` to apply.
+
+### Why `VSI_CACHE_SIZE` is the trap
+
+It is allocated **once per open file handle**, not once per process. A single
+process-graph request fans out to roughly `items × bands × read_threads` open
+handles (the `ThreadPoolExecutor` reads in `RasterStack` plus rio-tiler's mosaic
+reader). At the dev value of 512 MB per handle, even a few dozen concurrent
+handles blow past a 2 Gi container; at the chart default of 5 MB the same fan-out
+costs a few hundred MB at most.
+
+## The native budget
+
+Per pod, the native caches cost roughly:
+
+```
+native ≈ WEB_CONCURRENCY × (GDAL_CACHEMAX + CPL_VSIL_CURL_CACHE_SIZE)   # process-global
+       + (concurrently open file handles) × VSI_CACHE_SIZE             # per-handle
+```
+
+This must sit comfortably **below** `resources.limits.memory`, leaving the
+remainder for the Python heap (the process-graph cubes). Worked example for the
+chart defaults at a 2 Gi limit, single worker:
+
+```
+GDAL_CACHEMAX            = 200 MB   (process-global)
+CPL_VSIL_CURL_CACHE_SIZE =  64 MB   (process-global)
+VSI_CACHE_SIZE           =   5 MB × ~100 handles ≈ 500 MB (worst case)
+--------------------------------------------------------------
+native peak              ≈ 0.2 + 0.06 + 0.5 ≈ 0.76 GB
+remaining for heap       ≈ 2 Gi − 0.76 ≈ 1.2 GB
+```
+
+If you raise `WEB_CONCURRENCY` (multiple uvicorn workers per pod), remember the
+**process-global** caches multiply by it — `GDAL_CACHEMAX × WEB_CONCURRENCY`
+alone can dominate the limit.
+
+## Recommended production values (Helm chart defaults)
+
+The chart (`deployment/k8s/charts/values.yaml`) ships safe defaults:
+
+```yaml
+env:
+  GDAL_CACHEMAX: 200                  # 200 MB, process-global
+  VSI_CACHE: "TRUE"
+  VSI_CACHE_SIZE: 5000000             # 5 MB PER HANDLE
+  CPL_VSIL_CURL_CACHE_SIZE: 67108864  # 64 MB, pinned
+```
+
+Rules of thumb:
+
+- Keep `VSI_CACHE_SIZE` in the low single-digit MB. Never copy a dev value here.
+- Keep `GDAL_CACHEMAX + CPL_VSIL_CURL_CACHE_SIZE` (× `WEB_CONCURRENCY`) to a small
+  fraction of the limit.
+- Size `WEB_CONCURRENCY` to the pod's CPU, then re-check this budget.
+
+## Dev profiles are not production
+
+`.env.cdse` / `.env.eoapi` are local-developer profiles (single user, low
+concurrency) and intentionally use a large `VSI_CACHE_SIZE` (512 MB) and
+`CPL_VSIL_CURL_CACHE_SIZE` (200 MB) for throughput. **Do not** copy these into a
+Helm release or container deployment — they are flagged inline in those files.
+
+## Guard
+
+A Helm unit test (`deployment/k8s/charts/tests/native_cache_test.yaml`) asserts
+the chart's native-cache env vars stay at their bounded defaults, so an
+accidental bump (e.g. pasting a dev `VSI_CACHE_SIZE`) fails CI and forces a
+conscious review.
+
+## See also
+
+- [`docs/audits/memory-oom-audit.md`](https://github.com/sentinel-hub/titiler-openeo/blob/main/docs/audits/memory-oom-audit.md) — full audit (native vs heap, finding #7).
+- [`docs/audits/memory-profiling.md`](https://github.com/sentinel-hub/titiler-openeo/blob/main/docs/audits/memory-profiling.md) — measuring the heap-vs-native split (`RSS − heap`).

--- a/scripts/profile_memory.py
+++ b/scripts/profile_memory.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+"""Evaluate an openEO process graph standalone, for memory profiling.
+
+This bypasses the HTTP layer so a single graph can be run under ``memray`` (or
+with the built-in tracemalloc harness) without uvicorn/anyio threads in the way.
+It is the "real #300 graph" runner referenced by EPIC #305 subtask 1.
+
+Usage
+-----
+Enable the in-process harness (per-node heap deltas + retention summary)::
+
+    TITILER_OPENEO_PROFILING_MEMORY=true \\
+    TITILER_OPENEO_STAC_API_URL=https://stac.eoapi.dev \\
+    uv run python scripts/profile_memory.py path/to/graph.json
+
+Full native+heap flamegraph with memray::
+
+    TITILER_OPENEO_STAC_API_URL=https://stac.eoapi.dev \\
+    uv run memray run -o /tmp/openeo.bin scripts/profile_memory.py path/to/graph.json
+    uv run memray flamegraph /tmp/openeo.bin        # -> /tmp/openeo-flamegraph.html
+
+The graph JSON is either a bare ``{"process_graph": {...}}`` or a full process
+definition (with ``parameters``/``id``), i.e. the same body ``POST /result``
+accepts.
+"""
+
+import argparse
+import json
+import logging
+import sys
+from typing import Any, Dict
+
+from openeo_pg_parser_networkx.graph import OpenEOProcessGraph
+from openeo_pg_parser_networkx.process_registry import Process
+
+from titiler.openeo.processes import PROCESS_SPECIFICATIONS, process_registry
+from titiler.openeo.profiling import (
+    memory_profiling_enabled,
+    new_results_cache,
+    profile_graph,
+    report_retention,
+)
+from titiler.openeo.settings import BackendSettings
+from titiler.openeo.stacapi import LoadCollection, LoadStac, stacApiBackend
+
+
+def _build_registry() -> None:
+    """Register the backend-specific loaders, mirroring main.py."""
+    backend_settings = BackendSettings()  # type: ignore[call-arg]
+    stac_client = stacApiBackend(
+        str(backend_settings.stac_api_url),
+        exclude_collections=backend_settings.exclude_collections,
+    )  # type: ignore[call-arg]
+
+    loaders = LoadCollection(stac_client)  # type: ignore[call-arg]
+    process_registry["load_collection"] = Process(
+        spec=PROCESS_SPECIFICATIONS["load_collection"],
+        implementation=loaders.load_collection,
+    )
+    process_registry["load_stac"] = Process(
+        spec=PROCESS_SPECIFICATIONS["load_stac"],
+        implementation=LoadStac().load_stac,  # type: ignore[call-arg]
+    )
+
+
+def _resolve_parameters(process: Dict[str, Any]) -> Dict[str, Any]:
+    """Apply process-definition defaults, mirroring the factory's /result path."""
+    parameters: Dict[str, Any] = {}
+    for param in process.get("parameters") or []:
+        name = param.get("name")
+        default = param.get("default")
+        if name and default is not None:
+            parameters[name] = default
+    return parameters
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("graph", help="Path to a process-graph / process JSON file")
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="Show debug-level logs"
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    if not memory_profiling_enabled():
+        logging.warning(
+            "TITILER_OPENEO_PROFILING_MEMORY is not set: the in-process harness "
+            "will be silent. Set it for per-node logs, or run under `memray run`."
+        )
+
+    with open(args.graph) as fh:
+        process = json.load(fh)
+
+    # Accept either a full process definition or a bare process graph.
+    if "process_graph" not in process:
+        process = {"process_graph": process}
+
+    _build_registry()
+
+    parameters = _resolve_parameters(process)
+    parsed_graph = OpenEOProcessGraph(pg_data=process)
+    results_cache = new_results_cache()
+    pg_callable = parsed_graph.to_callable(
+        process_registry=process_registry,
+        parameters=process.get("parameters"),
+        results_cache=results_cache,
+    )
+
+    with profile_graph(f"profile {args.graph}"):
+        result = pg_callable(named_parameters=parameters)
+    report_retention(results_cache, args.graph)
+
+    size = len(result.data) if hasattr(result, "data") else len(str(result))
+    logging.info("Done: result=%s (~%d bytes)", type(result).__name__, size)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/profile_memory.py
+++ b/scripts/profile_memory.py
@@ -36,10 +36,10 @@ from openeo_pg_parser_networkx.process_registry import Process
 from titiler.openeo.processes import PROCESS_SPECIFICATIONS, process_registry
 from titiler.openeo.profiling import (
     memory_profiling_enabled,
-    new_results_cache,
     profile_graph,
     report_retention,
 )
+from titiler.openeo.results_cache import make_results_cache
 from titiler.openeo.settings import BackendSettings
 from titiler.openeo.stacapi import LoadCollection, LoadStac, stacApiBackend
 
@@ -104,7 +104,7 @@ def main() -> int:
 
     parameters = _resolve_parameters(process)
     parsed_graph = OpenEOProcessGraph(pg_data=process)
-    results_cache = new_results_cache()
+    results_cache = make_results_cache(parsed_graph)
     pg_callable = parsed_graph.to_callable(
         process_registry=process_registry,
         parameters=process.get("parameters"),

--- a/tests/test_eviction_integration.py
+++ b/tests/test_eviction_integration.py
@@ -1,0 +1,136 @@
+"""End-to-end A/B verification that intermediate eviction frees memory.
+
+Drives a #300-shaped graph (load_collection -> ndvi -> aggregate_temporal -> save)
+through the *real* graph engine with a synthetic in-memory load_collection, then
+compares end-of-graph retained bytes with eviction off vs on. This is the
+regression guard for EPIC #305 subtask 4 (results_cache eviction).
+"""
+
+from datetime import datetime
+
+import numpy
+import pytest
+from openeo_pg_parser_networkx.graph import OpenEOProcessGraph
+from openeo_pg_parser_networkx.process_registry import Process
+from rio_tiler.models import ImageData
+
+from titiler.openeo import results_cache as rc
+from titiler.openeo.processes import PROCESS_SPECIFICATIONS, process_registry
+from titiler.openeo.processes.implementations.data_model import RasterStack
+from titiler.openeo.profiling import _sum_retained_bytes
+
+N, H, W = 6, 256, 256  # 6 slices, 2-band uint16
+
+
+def _fake_load_collection(id=None, named_parameters=None, **kwargs):
+    """A regenerable load_collection backed by in-memory random slices."""
+
+    def make(i):
+        def task():
+            arr = numpy.ma.MaskedArray(
+                numpy.random.randint(1, 10000, (2, H, W)).astype("uint16"),
+                mask=numpy.zeros((2, H, W), dtype=bool),
+            )
+            return ImageData(arr, bounds=(0, 0, 1, 1))
+
+        return task
+
+    tasks = [(make(i), {"datetime": datetime(2020, 1, 1 + i)}) for i in range(N)]
+    return RasterStack(
+        tasks=tasks,
+        timestamp_fn=lambda a: a["datetime"],
+        allowed_exceptions=(),
+        width=W,
+        height=H,
+        bounds=(0, 0, 1, 1),
+        band_names=["b1", "b2"],
+    )
+
+
+@pytest.fixture
+def registered_load():
+    """Register the synthetic load_collection, restoring the registry afterwards."""
+    sentinel = object()
+    try:
+        previous = process_registry["load_collection"]
+    except Exception:
+        previous = sentinel
+
+    process_registry["load_collection"] = Process(
+        spec=PROCESS_SPECIFICATIONS["load_collection"],
+        implementation=_fake_load_collection,
+    )
+    try:
+        yield
+    finally:
+        if previous is sentinel:
+            del process_registry["load_collection"]
+        else:
+            process_registry["load_collection"] = previous
+
+
+_PG = {
+    "process_graph": {
+        "load": {"process_id": "load_collection", "arguments": {"id": "x"}},
+        "ndvi": {
+            "process_id": "ndvi",
+            "arguments": {"data": {"from_node": "load"}, "nir": 2, "red": 1},
+        },
+        "agg": {
+            "process_id": "aggregate_temporal",
+            "arguments": {
+                "data": {"from_node": "ndvi"},
+                "intervals": [
+                    ["2020-01-01", "2020-01-04"],
+                    ["2020-01-04", "2020-02-01"],
+                ],
+                "reducer": {
+                    "process_graph": {
+                        "mean": {
+                            "process_id": "mean",
+                            "arguments": {"data": {"from_parameter": "data"}},
+                            "result": True,
+                        }
+                    }
+                },
+            },
+        },
+        "save": {
+            "process_id": "save_result",
+            "arguments": {"data": {"from_node": "agg"}, "format": "GTIFF"},
+            "result": True,
+        },
+    }
+}
+
+
+def _run(evict: bool, monkeypatch):
+    monkeypatch.setenv(
+        "TITILER_OPENEO_PROCESSING_EVICT_INTERMEDIATE_RESULTS",
+        "true" if evict else "false",
+    )
+    graph = OpenEOProcessGraph(pg_data=_PG)
+    cache = rc.make_results_cache(graph)
+    fn = graph.to_callable(process_registry=process_registry, results_cache=cache)
+    fn(named_parameters={})
+    retained, n_arrays = _sum_retained_bytes(cache)
+    return cache, retained, n_arrays
+
+
+def test_eviction_frees_intermediates(registered_load, monkeypatch):
+    off_cache, off_bytes, off_arrays = _run(False, monkeypatch)
+    on_cache, on_bytes, on_arrays = _run(True, monkeypatch)
+
+    # Sanity: with eviction off the engine keeps every node's cube.
+    assert type(off_cache) is dict
+    assert isinstance(on_cache, rc.EvictingResultsCache)
+    assert off_bytes > 0
+    assert off_arrays >= N  # at least the source slices are retained
+
+    # Eviction frees the source + index cubes once consumed, leaving ~nothing.
+    assert on_bytes < off_bytes * 0.25
+    assert on_arrays < off_arrays
+    # A single source cube alone would be N*2*H*W*(2+1) bytes; on-retention must
+    # be well under that (only the small final result may linger).
+    one_cube = N * 2 * H * W * 3
+    assert on_bytes < one_cube

--- a/tests/test_eviction_integration.py
+++ b/tests/test_eviction_integration.py
@@ -6,6 +6,8 @@ compares end-of-graph retained bytes with eviction off vs on. This is the
 regression guard for EPIC #305 subtask 4 (results_cache eviction).
 """
 
+import gc
+import weakref
 from datetime import datetime
 
 import numpy
@@ -134,3 +136,95 @@ def test_eviction_frees_intermediates(registered_load, monkeypatch):
     # be well under that (only the small final result may linger).
     one_cube = N * 2 * H * W * 3
     assert on_bytes < one_cube
+
+
+_PG_LINEAR = {
+    "process_graph": {
+        "load": {"process_id": "load_collection", "arguments": {"id": "x"}},
+        "ndvi": {
+            "process_id": "ndvi",
+            "arguments": {"data": {"from_node": "load"}, "nir": 2, "red": 1},
+        },
+        "save": {
+            "process_id": "save_result",
+            "arguments": {"data": {"from_node": "ndvi"}, "format": "GTIFF"},
+            "result": True,
+        },
+    }
+}
+
+
+def _run_tracking_workflow(evict: bool, monkeypatch):
+    """Run load -> ndvi -> save tracking weakrefs to the source ImageData.
+
+    Returns the count still alive after the run while the graph (and thus
+    ``graph.workflow``, which holds the engine's *second* reference to every
+    result) is kept alive but the results_cache is dropped.
+    """
+    refs = []
+
+    def tracking_load(id=None, named_parameters=None, **kwargs):
+        def make(_i):
+            def task():
+                arr = numpy.ma.MaskedArray(
+                    numpy.random.randint(1, 10000, (2, H, W)).astype("uint16"),
+                    mask=numpy.zeros((2, H, W), dtype=bool),
+                )
+                img = ImageData(arr, bounds=(0, 0, 1, 1))
+                refs.append(weakref.ref(img))
+                return img
+
+            return task
+
+        tasks = [(make(i), {"datetime": datetime(2020, 1, 1 + i)}) for i in range(N)]
+        return RasterStack(
+            tasks=tasks,
+            timestamp_fn=lambda a: a["datetime"],
+            allowed_exceptions=(),
+            width=W,
+            height=H,
+            bounds=(0, 0, 1, 1),
+            band_names=["b1", "b2"],
+        )
+
+    sentinel = object()
+    try:
+        previous = process_registry["load_collection"]
+    except Exception:
+        previous = sentinel
+    process_registry["load_collection"] = Process(
+        spec=PROCESS_SPECIFICATIONS["load_collection"], implementation=tracking_load
+    )
+    try:
+        monkeypatch.setenv(
+            "TITILER_OPENEO_PROCESSING_EVICT_INTERMEDIATE_RESULTS",
+            "true" if evict else "false",
+        )
+        graph = OpenEOProcessGraph(pg_data=_PG_LINEAR)
+        cache = rc.make_results_cache(graph)
+        fn = graph.to_callable(process_registry=process_registry, results_cache=cache)
+        fn(named_parameters={})
+        # Drop the cache/callable but KEEP `graph` alive: graph.workflow still
+        # holds the second reference to each result (audit finding #2).
+        del cache, fn
+        gc.collect()
+        alive = sum(1 for r in refs if r() is not None)
+        del graph
+        return alive
+    finally:
+        if previous is sentinel:
+            del process_registry["load_collection"]
+        else:
+            process_registry["load_collection"] = previous
+
+
+def test_eviction_defeats_workflow_double_retention(monkeypatch):
+    """finding #2: the engine also stores each result on ``self.workflow``.
+
+    Eviction must still free the cube, because release() empties the RasterStack
+    in place rather than just dropping the results_cache reference.
+    """
+    # Without eviction, workflow alone keeps every source cube alive.
+    assert _run_tracking_workflow(False, monkeypatch) == N
+    # With eviction, the cubes are freed despite workflow holding the shells.
+    assert _run_tracking_workflow(True, monkeypatch) == 0

--- a/tests/test_indices_streaming.py
+++ b/tests/test_indices_streaming.py
@@ -1,0 +1,109 @@
+"""Streaming ndvi/ndwi: bound the within-node peak (EPIC #305 subtask 7).
+
+A sole-consumer source is streamed slice-by-slice and released as it's consumed,
+so the whole source cube and the whole index cube are never both fully resident.
+"""
+
+from datetime import datetime
+
+import numpy
+from rio_tiler.models import ImageData
+
+from titiler.openeo.processes.implementations.data_model import RasterStack
+from titiler.openeo.processes.implementations.indices import ndvi
+
+
+def _regenerable_stack(n=6, max_workers=2):
+    """Deterministic regenerable stack: red=v, nir=2v -> ndvi == 1/3 everywhere."""
+    calls = {"count": 0}
+
+    def make(v):
+        def task():
+            calls["count"] += 1
+            arr = numpy.ma.MaskedArray(
+                numpy.stack(
+                    [
+                        numpy.full((8, 8), v, dtype="uint16"),  # band1 = red = v
+                        numpy.full((8, 8), 2 * v, dtype="uint16"),  # band2 = nir = 2v
+                    ]
+                ),
+                mask=numpy.zeros((2, 8, 8), dtype=bool),
+            )
+            return ImageData(arr, bounds=(0, 0, 1, 1))
+
+        return task
+
+    tasks = [(make(i + 1), {"datetime": datetime(2020, 1, 1 + i)}) for i in range(n)]
+    stack = RasterStack(
+        tasks=tasks,
+        timestamp_fn=lambda a: a["datetime"],
+        allowed_exceptions=(),
+        max_workers=max_workers,
+        width=8,
+        height=8,
+        bounds=(0, 0, 1, 1),
+        band_names=["b1", "b2"],
+    )
+    return stack, calls
+
+
+def test_streaming_releases_each_slice_and_is_correct():
+    stack, calls = _regenerable_stack(n=6)
+    stack._single_consumer = True  # tagged by the results cache in real graphs
+
+    result = ndvi(stack, nir=2, red=1)
+
+    assert len(result) == 6
+    # Each source slice was loaded exactly once, then released.
+    assert calls["count"] == 6
+    assert stack._data_cache == {}
+    # ndvi of (red=v, nir=2v) is 1/3 everywhere, float32.
+    for img in result.values():
+        assert img.array.dtype == numpy.float32
+        assert numpy.allclose(img.array, 1.0 / 3.0)
+
+
+def test_streaming_bounds_resident_slices_to_window():
+    stack, _ = _regenerable_stack(n=6, max_workers=2)
+    stack._single_consumer = True
+
+    observed = []
+    # Wrap the per-slice work to record how many slices are cached at once.
+    import titiler.openeo.processes.implementations.indices as indices
+
+    real_apply = indices._apply_ndvi
+
+    def spy(img, nir, red):
+        observed.append(len(stack._data_cache))
+        return real_apply(img, nir, red)
+
+    indices._apply_ndvi = spy
+    try:
+        ndvi(stack, nir=2, red=1)
+    finally:
+        indices._apply_ndvi = real_apply
+
+    # Never more than the window (2) slices resident during processing.
+    assert observed and max(observed) <= 2
+
+
+def test_non_single_consumer_falls_back_and_keeps_source():
+    """Without the tag the source may have other consumers: don't mutate it."""
+    stack, _ = _regenerable_stack(n=4)
+    # no _single_consumer attribute set -> fallback (data.items())
+    result = ndvi(stack, nir=2, red=1)
+    assert len(result) == 4
+    # Fallback realizes the whole stack and leaves it cached (not released).
+    assert len(stack._data_cache) == 4
+
+
+def test_streaming_matches_non_streaming():
+    streamed, _ = _regenerable_stack(n=5)
+    streamed._single_consumer = True
+    plain, _ = _regenerable_stack(n=5)
+
+    r1 = ndvi(streamed, nir=2, red=1)
+    r2 = ndvi(plain, nir=2, red=1)
+
+    for k in r2.keys():
+        assert numpy.array_equal(r1[k].array, r2[k].array)

--- a/tests/test_memory_profiling.py
+++ b/tests/test_memory_profiling.py
@@ -34,13 +34,11 @@ def _image(value: int = 1, bands: int = 1, size: int = 8) -> ImageData:
 def test_disabled_by_default():
     """Profiling is off unless explicitly enabled."""
     assert profiling.memory_profiling_enabled() is False
-    assert profiling.new_results_cache() is None
 
 
 def test_enabled_via_env(monkeypatch):
     _enable(monkeypatch)
     assert profiling.memory_profiling_enabled() is True
-    assert profiling.new_results_cache() == {}
 
 
 def test_profile_node_is_noop_when_disabled(caplog):

--- a/tests/test_memory_profiling.py
+++ b/tests/test_memory_profiling.py
@@ -1,0 +1,135 @@
+"""Tests for the optional memory-profiling harness (EPIC #305, subtask 1)."""
+
+from datetime import datetime
+
+import numpy
+import pytest
+from rio_tiler.models import ImageData
+
+from titiler.openeo import profiling
+from titiler.openeo.processes.implementations.data_model import RasterStack
+
+
+@pytest.fixture(autouse=True)
+def _reset_profiling():
+    """Ensure the cached settings flag never leaks between tests."""
+    profiling.reset_profiling_cache()
+    yield
+    profiling.reset_profiling_cache()
+
+
+def _enable(monkeypatch):
+    monkeypatch.setenv("TITILER_OPENEO_PROFILING_MEMORY", "true")
+    profiling.reset_profiling_cache()
+
+
+def _image(value: int = 1, bands: int = 1, size: int = 8) -> ImageData:
+    arr = numpy.ma.MaskedArray(
+        numpy.full((bands, size, size), value, dtype="uint16"),
+        mask=numpy.zeros((bands, size, size), dtype=bool),
+    )
+    return ImageData(arr)
+
+
+def test_disabled_by_default():
+    """Profiling is off unless explicitly enabled."""
+    assert profiling.memory_profiling_enabled() is False
+    assert profiling.new_results_cache() is None
+
+
+def test_enabled_via_env(monkeypatch):
+    _enable(monkeypatch)
+    assert profiling.memory_profiling_enabled() is True
+    assert profiling.new_results_cache() == {}
+
+
+def test_profile_node_is_noop_when_disabled(caplog):
+    """No log output and no tracemalloc start when disabled."""
+    with caplog.at_level("INFO", logger="titiler.openeo.profiling"):
+        with profiling.profile_node("ndvi"):
+            pass
+    assert not [r for r in caplog.records if "[mem]" in r.message]
+
+
+def test_profile_node_logs_when_enabled(monkeypatch, caplog):
+    _enable(monkeypatch)
+    with caplog.at_level("INFO", logger="titiler.openeo.profiling"):
+        with profiling.profile_node("ndvi"):
+            # Allocate something measurable so the delta is non-trivial.
+            _block = numpy.ones((256, 256), dtype="float64")  # noqa: F841
+    messages = [r.message for r in caplog.records]
+    assert any("node=ndvi" in m and "heap_delta=" in m for m in messages)
+
+
+def test_profile_node_tracks_depth(monkeypatch, caplog):
+    """Nested process calls report increasing depth; top-level is depth 0."""
+    _enable(monkeypatch)
+    with caplog.at_level("INFO", logger="titiler.openeo.profiling"):
+        with profiling.profile_node("aggregate_temporal"):
+            with profiling.profile_node("mean"):
+                pass
+    msgs = [r.message for r in caplog.records if "node=" in r.message]
+    assert any("node=mean depth=1" in m for m in msgs)
+    assert any("node=aggregate_temporal depth=0" in m for m in msgs)
+
+
+def test_retention_sums_unique_array_bytes(monkeypatch, caplog):
+    """Shared ImageData across stacks is counted once, not double-counted."""
+    _enable(monkeypatch)
+
+    img = _image()
+    key = datetime(2020, 1, 1)
+    # Two stacks referencing the SAME ImageData (the audit's shared-reference case).
+    stack_a = RasterStack.from_images({key: img})
+    stack_b = RasterStack.from_images({key: img})
+
+    results_cache = {"load": stack_a, "ndvi": stack_b}
+    total, count = profiling._sum_retained_bytes(results_cache)
+
+    assert count == 1  # same array object, counted once
+    expected = img.array.data.nbytes + img.array.mask.nbytes
+    assert total == expected
+
+    with caplog.at_level("INFO", logger="titiler.openeo.profiling"):
+        profiling.report_retention(results_cache, "test")
+    assert any(
+        "nodes_pinned=2" in r.message and "retained_arrays=1" in r.message
+        for r in caplog.records
+    )
+
+
+def test_retention_counts_distinct_arrays(monkeypatch):
+    _enable(monkeypatch)
+    cache = {
+        "a": RasterStack.from_images({datetime(2020, 1, 1): _image(1)}),
+        "b": RasterStack.from_images({datetime(2020, 1, 2): _image(2)}),
+    }
+    total, count = profiling._sum_retained_bytes(cache)
+    assert count == 2
+
+
+def test_report_retention_noop_when_disabled(caplog):
+    with caplog.at_level("INFO", logger="titiler.openeo.profiling"):
+        profiling.report_retention({"a": _image()}, "test")
+    assert not caplog.records
+
+
+def test_array_bytes_includes_mask():
+    img = _image(bands=2, size=16)
+    nbytes = profiling._array_bytes(img.array)
+    assert nbytes == img.array.data.nbytes + img.array.mask.nbytes
+
+
+def test_iter_arrays_only_realized_slices(monkeypatch):
+    """Lazy (unrealized) stack slices hold no pixel data and are skipped."""
+    _enable(monkeypatch)
+    stack = RasterStack.from_images({datetime(2020, 1, 1): _image()})
+    arrays = list(profiling._iter_arrays(stack))
+    assert len(arrays) == 1
+
+
+def test_fmt_bytes():
+    assert profiling._fmt_bytes(0) == "0.0B"
+    assert profiling._fmt_bytes(1536) == "1.5KB"
+    assert profiling._fmt_bytes(-2 * 1024 * 1024) == "-2.0MB"
+    assert profiling._fmt_bytes(None) == "n/a"

--- a/tests/test_normalized_difference.py
+++ b/tests/test_normalized_difference.py
@@ -1,0 +1,84 @@
+"""Tests for normalized_difference dtype/precision (EPIC #305, subtask 2)."""
+
+from datetime import datetime
+
+import numpy
+import pytest
+from rio_tiler.models import ImageData
+
+from titiler.openeo.processes.implementations.data_model import RasterStack
+from titiler.openeo.processes.implementations.indices import ndvi
+from titiler.openeo.processes.implementations.math import normalized_difference
+
+
+def test_uint16_inputs_return_float32():
+    """The common reflectance path (uint16) must not blow up to float64."""
+    x = numpy.array([10000, 4000], dtype="uint16")
+    y = numpy.array([2000, 8000], dtype="uint16")
+    out = normalized_difference(x, y)
+    assert out.dtype == numpy.float32
+
+
+def test_no_integer_wraparound():
+    """y > x must give a negative result, not a wrapped huge positive one.
+
+    In pure uint16, ``10000 - 20000`` wraps to 55536 and ``(x - y)/(x + y)``
+    comes out positive (~1.85) instead of -1/3.
+    """
+    x = numpy.array([10000], dtype="uint16")
+    y = numpy.array([20000], dtype="uint16")
+    out = normalized_difference(x, y)
+    assert out[0] == pytest.approx(-1.0 / 3.0, rel=1e-5)
+
+
+def test_no_addition_overflow():
+    """x + y exceeding the uint16 max (65535) must not overflow."""
+    x = numpy.array([60000], dtype="uint16")
+    y = numpy.array([40000], dtype="uint16")
+    out = normalized_difference(x, y)
+    # (60000 - 40000) / (60000 + 40000) = 0.2
+    assert out[0] == pytest.approx(0.2, rel=1e-5)
+
+
+def test_float64_inputs_are_not_downcast():
+    """Genuine float64 inputs keep their precision (we only promote integers)."""
+    x = numpy.array([0.6], dtype="float64")
+    y = numpy.array([0.2], dtype="float64")
+    out = normalized_difference(x, y)
+    assert out.dtype == numpy.float64
+    assert out[0] == pytest.approx(0.5)
+
+
+def test_float32_inputs_stay_float32():
+    x = numpy.array([0.6], dtype="float32")
+    y = numpy.array([0.2], dtype="float32")
+    out = normalized_difference(x, y)
+    assert out.dtype == numpy.float32
+
+
+def test_mask_is_preserved():
+    """Promotion via astype must not drop the mask."""
+    x = numpy.ma.MaskedArray([10000, 4000], mask=[True, False], dtype="uint16")
+    y = numpy.ma.MaskedArray([2000, 8000], mask=[False, False], dtype="uint16")
+    out = normalized_difference(x, y)
+    assert isinstance(out, numpy.ma.MaskedArray)
+    assert bool(out.mask[0]) is True
+    assert bool(out.mask[1]) is False
+    assert out.dtype == numpy.float32
+
+
+def test_python_scalars_still_work():
+    """Non-array inputs (no .dtype) fall through unchanged."""
+    assert normalized_difference(3, 1) == pytest.approx(0.5)
+
+
+def test_ndvi_end_to_end_is_float32():
+    """The full ndvi() path on a uint16 stack yields a float32 index cube."""
+    arr = numpy.ma.MaskedArray(
+        numpy.random.randint(1, 10000, (2, 8, 8)).astype("uint16"),
+        mask=numpy.zeros((2, 8, 8), dtype=bool),
+    )
+    stack = RasterStack.from_images({datetime(2020, 1, 1): ImageData(arr)})
+    result = ndvi(stack, nir=2, red=1)
+    img = result.first
+    assert img.array.dtype == numpy.float32

--- a/tests/test_raster_stack_eviction.py
+++ b/tests/test_raster_stack_eviction.py
@@ -1,0 +1,87 @@
+"""Tests for RasterStack.release()/clear() (EPIC #305, subtask 4).
+
+These only drop *this stack's* references to its realized slices; deciding *when*
+it is safe to call them is the job of the reference-counted results cache (see
+tests/test_results_cache.py).
+"""
+
+from datetime import datetime
+
+import numpy
+from rio_tiler.models import ImageData
+
+from titiler.openeo.processes.implementations.data_model import RasterStack
+
+
+def _image(value: int = 1, bands: int = 2, size: int = 8) -> ImageData:
+    arr = numpy.ma.MaskedArray(
+        numpy.full((bands, size, size), value, dtype="uint16"),
+        mask=numpy.zeros((bands, size, size), dtype=bool),
+    )
+    return ImageData(arr, bounds=(0, 0, 1, 1))
+
+
+def _regenerable_stack(n: int = 2, bands: int = 2):
+    """A stack backed by real (re-executable) tasks, tracking execution count."""
+    calls = {"count": 0}
+
+    def make_task(value: int):
+        def task() -> ImageData:
+            calls["count"] += 1
+            return _image(value=value, bands=bands)
+
+        return task
+
+    tasks = [
+        (make_task(i + 1), {"datetime": datetime(2020, 1, i + 1)}) for i in range(n)
+    ]
+    stack = RasterStack(
+        tasks=tasks,
+        timestamp_fn=lambda asset: asset["datetime"],
+        allowed_exceptions=(),
+        width=8,
+        height=8,
+        bounds=(0, 0, 1, 1),
+        band_names=["b1", "b2"][:bands],
+    )
+    return stack, calls
+
+
+def test_release_drops_cached_slices():
+    stack, _ = _regenerable_stack(n=2)
+    _ = stack.values()
+    assert len(stack._data_cache) == 2
+
+    stack.release()
+    assert stack._data_cache == {}
+    # Realized ImageRef images are cleared too.
+    assert all(ref._image is None for ref in stack._image_refs.values())
+
+
+def test_release_specific_keys():
+    stack, _ = _regenerable_stack(n=2)
+    keys = stack.timestamps()
+    _ = stack.values()
+    stack.release(keys[0])
+    assert keys[0] not in stack._data_cache
+    assert keys[1] in stack._data_cache
+
+
+def test_release_allows_reread_for_real_task_stack():
+    """A stack backed by real tasks can be re-read after release (re-executes)."""
+    stack, calls = _regenerable_stack(n=1)
+    _ = stack.first
+    assert calls["count"] == 1
+    stack.release()
+    _ = stack.first
+    assert calls["count"] == 2  # task re-executed to reload
+
+
+def test_clear_evicts_all():
+    img = _image()
+    stack = RasterStack.from_images({datetime(2020, 1, 1): _image(2)})
+    assert len(stack._data_cache) == 1
+    stack.clear()
+    assert stack._data_cache == {}
+    # The underlying ImageData object survives if referenced elsewhere.
+    assert img is not None

--- a/tests/test_results_cache.py
+++ b/tests/test_results_cache.py
@@ -134,6 +134,45 @@ def test_make_results_cache_respects_setting(monkeypatch):
     assert isinstance(evicting, EvictingResultsCache)
 
 
+def test_tags_single_consumer(monkeypatch):
+    """A result with exactly one consumer is tagged so it can be streamed."""
+    g, nodes = _graph(_LINEAR)
+    cache = EvictingResultsCache(g)
+    load_val, ndvi_val = _stack(1), _stack(2)
+    cache[nodes["load"]] = load_val  # consumed only by ndvi
+    cache[nodes["ndvi"]] = ndvi_val  # consumed only by save (root)
+    assert load_val._single_consumer is True
+    assert ndvi_val._single_consumer is True
+
+
+def test_fan_out_not_tagged_single_consumer():
+    """A result consumed by two nodes must NOT be tagged single-consumer."""
+    pg = {
+        "load": {"process_id": "load_collection", "arguments": {"id": "x"}},
+        "ndvi": {
+            "process_id": "ndvi",
+            "arguments": {"data": {"from_node": "load"}, "nir": 2, "red": 1},
+        },
+        "ndwi": {
+            "process_id": "ndwi",
+            "arguments": {"data": {"from_node": "load"}, "nir": 2, "swir": 1},
+        },
+        "merge": {
+            "process_id": "merge_cubes",
+            "arguments": {
+                "cube1": {"from_node": "ndvi"},
+                "cube2": {"from_node": "ndwi"},
+            },
+            "result": True,
+        },
+    }
+    g, nodes = _graph(pg)
+    cache = EvictingResultsCache(g)
+    load_val = _stack(1)
+    cache[nodes["load"]] = load_val  # consumed by BOTH ndvi and ndwi
+    assert load_val._single_consumer is False
+
+
 def test_eviction_is_robust_to_restore():
     """Re-storing a node (engine recompute) must not double-decrement parents."""
     g, nodes = _graph(_LINEAR)

--- a/tests/test_results_cache.py
+++ b/tests/test_results_cache.py
@@ -1,0 +1,146 @@
+"""Tests for the reference-counted results cache (EPIC #305, subtask 4)."""
+
+from datetime import datetime
+
+import numpy
+from openeo_pg_parser_networkx.graph import OpenEOProcessGraph
+from rio_tiler.models import ImageData
+
+from titiler.openeo import results_cache as rc
+from titiler.openeo.processes.implementations.data_model import RasterStack
+from titiler.openeo.results_cache import EvictingResultsCache, make_results_cache
+
+
+def _stack(value: int = 1) -> RasterStack:
+    arr = numpy.ma.MaskedArray(
+        numpy.full((1, 8, 8), value, dtype="uint16"),
+        mask=numpy.zeros((1, 8, 8), dtype=bool),
+    )
+    return RasterStack.from_images({datetime(2020, 1, 1): ImageData(arr)})
+
+
+def _graph(pg: dict):
+    """Parse a process graph and return (graph, {prefix: node_id})."""
+    g = OpenEOProcessGraph(pg_data={"process_graph": pg})
+    nodes = {nid.split("-", 1)[0]: nid for nid in g.G.nodes()}
+    return g, nodes
+
+
+_LINEAR = {
+    "load": {"process_id": "load_collection", "arguments": {"id": "x"}},
+    "ndvi": {
+        "process_id": "ndvi",
+        "arguments": {"data": {"from_node": "load"}, "nir": 2, "red": 1},
+    },
+    "save": {
+        "process_id": "save_result",
+        "arguments": {"data": {"from_node": "ndvi"}, "format": "GTIFF"},
+        "result": True,
+    },
+}
+
+
+def test_frees_input_once_consumer_runs():
+    """In load -> ndvi -> save, `load` is freed when `ndvi` is stored."""
+    g, nodes = _graph(_LINEAR)
+    cache = EvictingResultsCache(g)
+    assert cache._enabled is True
+
+    load_val, ndvi_val = _stack(1), _stack(2)
+
+    # Engine stores parents before consumers.
+    cache[nodes["load"]] = load_val
+    assert len(load_val._data_cache) == 1  # still held
+
+    cache[nodes["ndvi"]] = ndvi_val  # ndvi consumes load -> load freed
+    assert load_val._data_cache == {}
+    assert len(ndvi_val._data_cache) == 1  # ndvi result still held
+
+    cache[nodes["root"]] = b"bytes"  # save consumes ndvi -> ndvi freed
+    assert ndvi_val._data_cache == {}
+
+
+def test_result_node_value_not_freed():
+    """A value held by the (consumer) result node is never freed."""
+    g, nodes = _graph(_LINEAR)
+    cache = EvictingResultsCache(g)
+    val = _stack(1)
+    # Final node returns the value directly (identity); it must survive.
+    cache[nodes["load"]] = _stack(9)
+    cache[nodes["ndvi"]] = val
+    cache[nodes["root"]] = val  # aliased under the result node
+    # ndvi's slot is freed only if not reachable elsewhere; here `val` is also
+    # the result, so it must stay intact.
+    assert len(val._data_cache) == 1
+
+
+def test_alias_is_not_freed():
+    """An object reachable via another cache slot is not released."""
+    g, nodes = _graph(_LINEAR)
+    cache = EvictingResultsCache(g)
+    shared = _stack(1)
+    cache[nodes["load"]] = shared
+    cache[nodes["ndvi"]] = shared  # passthrough: same object under two keys
+    # Storing ndvi decrements load to 0, but `shared` is aliased -> kept.
+    assert len(shared._data_cache) == 1
+
+
+def test_disabled_for_recompute_graphs():
+    """Graphs with aggregate_spatial disable eviction (engine re-reads inputs)."""
+    pg = {
+        "load": {"process_id": "load_collection", "arguments": {"id": "x"}},
+        "agg": {
+            "process_id": "aggregate_spatial",
+            "arguments": {
+                "data": {"from_node": "load"},
+                "geometries": {"type": "Point", "coordinates": [0, 0]},
+                "reducer": {
+                    "process_graph": {
+                        "mean": {
+                            "process_id": "mean",
+                            "arguments": {"data": {"from_parameter": "data"}},
+                            "result": True,
+                        }
+                    }
+                },
+            },
+        },
+        "save": {
+            "process_id": "save_result",
+            "arguments": {"data": {"from_node": "agg"}, "format": "JSON"},
+            "result": True,
+        },
+    }
+    g, nodes = _graph(pg)
+    assert rc._graph_has_recompute(g) is True
+
+    cache = EvictingResultsCache(g)
+    assert cache._enabled is False
+    val = _stack(1)
+    cache[nodes["load"]] = val
+    cache[nodes["agg"]] = _stack(2)
+    assert len(val._data_cache) == 1  # nothing freed
+
+
+def test_make_results_cache_respects_setting(monkeypatch):
+    g, _ = _graph(_LINEAR)
+
+    monkeypatch.setenv("TITILER_OPENEO_PROCESSING_EVICT_INTERMEDIATE_RESULTS", "false")
+    plain = make_results_cache(g)
+    assert type(plain) is dict
+
+    monkeypatch.setenv("TITILER_OPENEO_PROCESSING_EVICT_INTERMEDIATE_RESULTS", "true")
+    evicting = make_results_cache(g)
+    assert isinstance(evicting, EvictingResultsCache)
+
+
+def test_eviction_is_robust_to_restore():
+    """Re-storing a node (engine recompute) must not double-decrement parents."""
+    g, nodes = _graph(_LINEAR)
+    cache = EvictingResultsCache(g)
+    cache[nodes["load"]] = _stack(1)
+    ndvi_val = _stack(2)
+    cache[nodes["ndvi"]] = ndvi_val
+    # A second store of the same node (idempotent) must not touch ndvi again.
+    cache[nodes["ndvi"]] = ndvi_val
+    assert len(ndvi_val._data_cache) == 1

--- a/titiler/openeo/factory.py
+++ b/titiler/openeo/factory.py
@@ -24,7 +24,8 @@ from .errors import InvalidProcessGraph
 from .models import openapi
 from .models import udp as udp_models
 from .models.auth import User
-from .profiling import new_results_cache, profile_graph, report_retention
+from .profiling import profile_graph, report_retention
+from .results_cache import make_results_cache
 from .services import ServicesStore, TileAssignmentStore, UdpStore
 from .stacapi import stacApiBackend
 
@@ -1313,7 +1314,7 @@ class EndpointsFactory(BaseFactory):
                         parameters[param_name] = default_value
 
             parsed_graph = OpenEOProcessGraph(pg_data=process)
-            results_cache = new_results_cache()
+            results_cache = make_results_cache(parsed_graph)
             pg_callable = parsed_graph.to_callable(
                 process_registry=self.process_registry,
                 parameters=process.get("parameters"),
@@ -1463,7 +1464,7 @@ class EndpointsFactory(BaseFactory):
             media_type = self._get_media_type(process["process_graph"])
 
             parsed_graph = OpenEOProcessGraph(pg_data=process)
-            results_cache = new_results_cache()
+            results_cache = make_results_cache(parsed_graph)
             pg_callable = parsed_graph.to_callable(
                 process_registry=self.process_registry,
                 parameters=process.get("parameters"),

--- a/titiler/openeo/factory.py
+++ b/titiler/openeo/factory.py
@@ -24,6 +24,7 @@ from .errors import InvalidProcessGraph
 from .models import openapi
 from .models import udp as udp_models
 from .models.auth import User
+from .profiling import new_results_cache, profile_graph, report_retention
 from .services import ServicesStore, TileAssignmentStore, UdpStore
 from .stacapi import stacApiBackend
 
@@ -1312,11 +1313,15 @@ class EndpointsFactory(BaseFactory):
                         parameters[param_name] = default_value
 
             parsed_graph = OpenEOProcessGraph(pg_data=process)
+            results_cache = new_results_cache()
             pg_callable = parsed_graph.to_callable(
                 process_registry=self.process_registry,
                 parameters=process.get("parameters"),
+                results_cache=results_cache,
             )
-            result = pg_callable(named_parameters=parameters)
+            with profile_graph("POST /result"):
+                result = pg_callable(named_parameters=parameters)
+            report_retention(results_cache, "POST /result")
 
             media_type = result.media_type if hasattr(result, "media_type") else None
             if not media_type and isinstance(result, str):
@@ -1458,11 +1463,15 @@ class EndpointsFactory(BaseFactory):
             media_type = self._get_media_type(process["process_graph"])
 
             parsed_graph = OpenEOProcessGraph(pg_data=process)
+            results_cache = new_results_cache()
             pg_callable = parsed_graph.to_callable(
                 process_registry=self.process_registry,
                 parameters=process.get("parameters"),
+                results_cache=results_cache,
                 # parameters=args,  # Use built-in parameter substitution instead of manual
             )
 
-            img = pg_callable(named_parameters=parameters)
+            with profile_graph(f"GET tiles/{z}/{x}/{y}"):
+                img = pg_callable(named_parameters=parameters)
+            report_retention(results_cache, f"GET tiles/{z}/{x}/{y}")
             return Response(img.data, media_type=media_type)

--- a/titiler/openeo/processes/implementations/core.py
+++ b/titiler/openeo/processes/implementations/core.py
@@ -40,6 +40,7 @@ from openeo_pg_parser_networkx.pg_schema import (
 from pydantic import BaseModel, TypeAdapter, ValidationError
 
 from ...errors import ProcessParameterMissing
+from ...profiling import profile_node
 from .data_model import RasterStack
 
 # Union of all GeoJSON types for validation
@@ -637,6 +638,9 @@ def process(f):
 
         logger.debug(f"Running {f.__name__} with: {list(resolved_kwargs.keys())}")
 
-        return f(**resolved_kwargs)
+        # Per-node memory profiling (no-op unless TITILER_OPENEO_PROFILING_MEMORY
+        # is set). Lets us attribute heap growth to individual graph nodes.
+        with profile_node(f.__name__):
+            return f(**resolved_kwargs)
 
     return wrapper

--- a/titiler/openeo/processes/implementations/data_model.py
+++ b/titiler/openeo/processes/implementations/data_model.py
@@ -299,6 +299,11 @@ class RasterStack(Dict[datetime, ImageData]):
     - ImageRef instances enable cutline mask computation without task execution
     """
 
+    # Set by the reference-counted results cache when this stack has exactly one
+    # downstream consumer, so that consumer may stream-and-release it slice by
+    # slice. See titiler.openeo.results_cache and EPIC #305 subtask 7.
+    _single_consumer: bool = False
+
     def __init__(
         self,
         tasks: TaskType,

--- a/titiler/openeo/processes/implementations/data_model.py
+++ b/titiler/openeo/processes/implementations/data_model.py
@@ -687,6 +687,35 @@ class RasterStack(Dict[datetime, ImageData]):
                 continue
         raise KeyError("No successful tasks found in RasterStack")
 
+    def release(self, *keys: datetime) -> None:
+        """Drop realized slices from this stack so their arrays can be collected.
+
+        Removes the given keys from the per-key cache and clears any realized
+        ImageRef image. This only drops *this stack's* references — arrays still
+        referenced elsewhere survive — so the underlying ImageData becomes
+        collectable once nothing else holds it.
+
+        Eviction timing/safety is decided by the caller. The reference-counted
+        results cache (:mod:`titiler.openeo.results_cache`) only calls this once
+        the graph topology guarantees every consumer of the result has run, so
+        nothing re-reads the stack afterwards. See the memory audit (finding #3)
+        and EPIC #305 subtask 4.
+
+        Args:
+            keys: Keys to evict. If none are given, all cached slices are evicted.
+        """
+        target = keys if keys else tuple(self._keys)
+        with self._cache_lock:
+            for key in target:
+                self._data_cache.pop(key, None)
+                ref = self._image_refs.get(key)
+                if ref is not None:
+                    ref._image = None
+
+    def clear(self) -> None:
+        """Evict all realized slices. See :meth:`release`."""
+        self.release()
+
     def filter_keys(self, keys: List[datetime]) -> "RasterStack":
         """Return a new RasterStack restricted to the given keys.
 

--- a/titiler/openeo/processes/implementations/indices.py
+++ b/titiler/openeo/processes/implementations/indices.py
@@ -1,12 +1,49 @@
 """titiler.openeo.processes indices."""
 
 from datetime import datetime
-from typing import Dict
+from typing import Callable, Dict
+
+from rio_tiler.constants import MAX_THREADS
 
 from .data_model import ImageData, RasterStack
 from .math import normalized_difference
 
 __all__ = ["ndvi", "ndwi"]
+
+
+def _apply_per_slice(
+    data: RasterStack, fn: Callable[[ImageData], ImageData]
+) -> RasterStack:
+    """Apply ``fn`` to every slice and return a new stack.
+
+    When ``data`` has a single downstream consumer (tagged by the
+    reference-counted results cache), the source cube is streamed: slices are
+    read in concurrent windows and **released as soon as they are consumed**, so
+    the whole source cube and the whole result cube are never both fully resident
+    (the within-node peak that eviction alone can't remove — EPIC #305 subtask 7).
+    Otherwise the source might be needed by another node, so we fall back to the
+    plain non-mutating realization.
+    """
+    result: Dict[datetime, ImageData] = {}
+
+    if not getattr(data, "_single_consumer", False):
+        for key, img_data in data.items():
+            result[key] = fn(img_data)
+        return RasterStack.from_images(result)
+
+    keys = list(data.keys())
+    window = max(1, getattr(data, "_max_workers", MAX_THREADS))
+    for start in range(0, len(keys), window):
+        batch = keys[start : start + window]
+        data.prefetch(batch)  # load the window concurrently
+        for key in batch:
+            try:
+                img_data = data[key]
+            except KeyError:
+                continue
+            result[key] = fn(img_data)
+            data.release(key)  # safe: this stack has no other consumer
+    return RasterStack.from_images(result)
 
 
 def _apply_ndvi(data: ImageData, nir: int, red: int) -> ImageData:
@@ -52,11 +89,8 @@ def ndwi(data: RasterStack, nir: int, swir: int) -> RasterStack:
     Returns:
         RasterStack with NDWI results
     """
-    # Apply NDWI to each item in the stack
-    result: Dict[datetime, ImageData] = {}
-    for key, img_data in data.items():
-        result[key] = _apply_ndwi(img_data, nir, swir)
-    return RasterStack.from_images(result)
+    # Apply NDWI to each item in the stack (streaming when sole consumer)
+    return _apply_per_slice(data, lambda img: _apply_ndwi(img, nir, swir))
 
 
 def ndvi(data: RasterStack, nir: int, red: int) -> RasterStack:
@@ -70,8 +104,5 @@ def ndvi(data: RasterStack, nir: int, red: int) -> RasterStack:
     Returns:
         RasterStack (Dict[datetime, ImageData]) containing NDVI results
     """
-    # Apply NDVI to each item in the stack
-    result: Dict[datetime, ImageData] = {}
-    for key, img_data in data.items():
-        result[key] = _apply_ndvi(img_data, nir, red)
-    return RasterStack.from_images(result)
+    # Apply NDVI to each item in the stack (streaming when sole consumer)
+    return _apply_per_slice(data, lambda img: _apply_ndvi(img, nir, red))

--- a/titiler/openeo/processes/implementations/math.py
+++ b/titiler/openeo/processes/implementations/math.py
@@ -311,6 +311,30 @@ def count(data, condition=None):
 
 
 def normalized_difference(x, y):
+    """Normalized difference ``(x - y) / (x + y)``.
+
+    Integer inputs are promoted to float32 *before* the arithmetic. This serves
+    two purposes (see ``docs/audits/memory-oom-audit.md`` finding #4):
+
+    * Correctness: with the common uint16 reflectance inputs, evaluating
+      ``x - y`` and ``x + y`` in integer space underflows/overflows (uint16
+      wraps around) before the division. Promoting first makes both safe.
+    * Memory: the result drives a per-slice index cube retained for the whole
+      process graph. float32 — ample for an index bounded in [-1, 1] — halves
+      that cube versus numpy's default float64 promotion of integer division.
+
+    Floating-point inputs keep their own dtype (we never downcast float64 ->
+    float32). Masked arrays keep their mask through ``astype``.
+    """
+
+    def _promote(a):
+        dtype = getattr(a, "dtype", None)
+        if dtype is not None and not numpy.issubdtype(dtype, numpy.floating):
+            return a.astype("float32")
+        return a
+
+    x = _promote(x)
+    y = _promote(y)
     return (x - y) / (x + y)
 
 

--- a/titiler/openeo/profiling.py
+++ b/titiler/openeo/profiling.py
@@ -63,15 +63,6 @@ def memory_profiling_enabled() -> bool:
     return bool(_get_settings().memory)
 
 
-def new_results_cache() -> Optional[dict]:
-    """A fresh ``results_cache`` dict to pass to ``to_callable`` when profiling.
-
-    Returns ``None`` when disabled so the graph engine uses its own internal
-    cache and nothing changes in production.
-    """
-    return {} if memory_profiling_enabled() else None
-
-
 def _ensure_started() -> None:
     if not tracemalloc.is_tracing():
         tracemalloc.start()

--- a/titiler/openeo/profiling.py
+++ b/titiler/openeo/profiling.py
@@ -1,0 +1,310 @@
+"""Optional memory-profiling harness for openEO process-graph evaluation.
+
+This implements subtask 1 of the memory-optimization EPIC (#305): give us the
+measurements needed to *confirm* where the OOM memory goes before changing any
+behavior. See ``docs/audits/memory-oom-audit.md`` for the findings this is meant
+to verify (per-node retention, heap-vs-native split) and
+``docs/audits/memory-profiling.md`` for how to run it (incl. ``memray``).
+
+Three things are provided, all **off by default** and gated behind
+``TITILER_OPENEO_PROFILING_MEMORY``:
+
+* :func:`profile_node` — per-process-node ``tracemalloc`` heap delta + current
+  RSS, so we can attribute heap growth to ``load_collection`` vs ``ndvi`` vs
+  ``aggregate_temporal`` etc. Wired into the ``@process`` decorator so every
+  node passes through it.
+* :func:`profile_graph` — a request-level summary: heap high-water mark and the
+  ``RSS - heap`` split that approximates native (GDAL/VSI) memory.
+* :func:`report_retention` — at ``save_result`` time, how many node results the
+  graph engine is still pinning and how many bytes of array data they hold.
+
+NOTE: this is a debug tool. ``tracemalloc`` is process-global and the RSS
+sampling assumes a single graph is evaluating at a time, so run it on a
+low-concurrency dev instance or via the standalone ``scripts/profile_memory.py``
+runner — not in production.
+"""
+
+import logging
+import threading
+import tracemalloc
+from contextlib import contextmanager
+from typing import Any, Iterator, Optional, Set, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Cached settings instance so the hot-path gate (called once per node) doesn't
+# rebuild a pydantic-settings object every time. Use ``reset_profiling_cache()``
+# in tests after mutating the environment.
+_settings: Optional[Any] = None
+
+# Per-thread nesting depth so nested process calls (e.g. a reducer invoking
+# ``mean`` -> ``apply_pixel_selection``) are indented and the depth==0 lines map
+# to top-level graph nodes.
+_local = threading.local()
+
+
+def _get_settings() -> Any:
+    global _settings
+    if _settings is None:
+        from .settings import ProfilingSettings
+
+        _settings = ProfilingSettings()
+    return _settings
+
+
+def reset_profiling_cache() -> None:
+    """Drop the cached settings so the next call re-reads the environment (tests)."""
+    global _settings
+    _settings = None
+
+
+def memory_profiling_enabled() -> bool:
+    """Whether the memory-profiling harness is switched on."""
+    return bool(_get_settings().memory)
+
+
+def new_results_cache() -> Optional[dict]:
+    """A fresh ``results_cache`` dict to pass to ``to_callable`` when profiling.
+
+    Returns ``None`` when disabled so the graph engine uses its own internal
+    cache and nothing changes in production.
+    """
+    return {} if memory_profiling_enabled() else None
+
+
+def _ensure_started() -> None:
+    if not tracemalloc.is_tracing():
+        tracemalloc.start()
+
+
+def _current_rss_bytes() -> Optional[int]:
+    """Best-effort *current* resident set size (includes native/off-heap memory).
+
+    Reads ``/proc/self/statm`` on Linux (current RSS, what we want for the
+    heap-vs-native split). Falls back to ``ru_maxrss`` (a high-water mark) on
+    platforms without procfs.
+    """
+    try:
+        import resource
+
+        with open("/proc/self/statm") as fh:
+            resident_pages = int(fh.read().split()[1])
+        return resident_pages * resource.getpagesize()
+    except (OSError, IndexError, ValueError):
+        try:
+            import resource
+            import sys
+
+            ru = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+            # ru_maxrss is KiB on Linux, bytes on macOS.
+            return ru if sys.platform == "darwin" else ru * 1024
+        except Exception:  # pragma: no cover - extremely defensive
+            return None
+
+
+def _fmt_bytes(n: Optional[int]) -> str:
+    if n is None:
+        return "n/a"
+    sign = "-" if n < 0 else ""
+    value = float(abs(n))
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if value < 1024 or unit == "TB":
+            return f"{sign}{value:.1f}{unit}"
+        value /= 1024
+    return f"{sign}{value:.1f}TB"  # pragma: no cover
+
+
+def _fmt_native(rss: Optional[int], heap: Optional[int]) -> str:
+    if rss is None or heap is None:
+        return "n/a"
+    return _fmt_bytes(rss - heap)
+
+
+@contextmanager
+def profile_node(name: str) -> Iterator[None]:
+    """Log the heap delta and current RSS across a single process node.
+
+    No-op (and essentially free) when profiling is disabled.
+    """
+    if not memory_profiling_enabled():
+        yield
+        return
+
+    _ensure_started()
+    depth = getattr(_local, "depth", 0)
+    _local.depth = depth + 1
+    heap_before, _ = tracemalloc.get_traced_memory()
+    rss_before = _current_rss_bytes()
+    try:
+        yield
+    finally:
+        _local.depth = depth
+        heap_after, heap_peak = tracemalloc.get_traced_memory()
+        rss_after = _current_rss_bytes()
+        heap_delta = heap_after - heap_before
+        rss_delta = (
+            (rss_after - rss_before)
+            if (rss_after is not None and rss_before is not None)
+            else None
+        )
+        indent = "  " * depth
+        logger.info(
+            "[mem] %snode=%s depth=%d heap_delta=%s rss_delta=%s "
+            "heap_now=%s rss_now=%s native~=%s",
+            indent,
+            name,
+            depth,
+            _fmt_bytes(heap_delta),
+            _fmt_bytes(rss_delta),
+            _fmt_bytes(heap_after),
+            _fmt_bytes(rss_after),
+            _fmt_native(rss_after, heap_after),
+        )
+
+
+@contextmanager
+def profile_graph(label: str = "graph") -> Iterator[None]:
+    """Log heap high-water and the RSS/heap (native) split across a whole graph.
+
+    No-op when profiling is disabled.
+    """
+    if not memory_profiling_enabled():
+        yield
+        return
+
+    _ensure_started()
+    tracemalloc.reset_peak()
+    heap_before, _ = tracemalloc.get_traced_memory()
+    rss_before = _current_rss_bytes()
+    logger.info(
+        "[mem] %s START heap=%s rss=%s",
+        label,
+        _fmt_bytes(heap_before),
+        _fmt_bytes(rss_before),
+    )
+    try:
+        yield
+    finally:
+        heap_after, heap_peak = tracemalloc.get_traced_memory()
+        rss_after = _current_rss_bytes()
+        logger.info(
+            "[mem] %s END heap=%s (peak=%s) rss=%s native~=%s",
+            label,
+            _fmt_bytes(heap_after),
+            _fmt_bytes(heap_peak),
+            _fmt_bytes(rss_after),
+            _fmt_native(rss_after, heap_after),
+        )
+
+
+def _array_bytes(arr: Any) -> int:
+    """Bytes held by a numpy array, including a materialized mask if present."""
+    import numpy
+
+    total = int(getattr(arr, "nbytes", 0) or 0)
+    mask = numpy.ma.getmask(arr)
+    if mask is not numpy.ma.nomask and hasattr(mask, "nbytes"):
+        total += int(mask.nbytes)
+    return total
+
+
+def _iter_arrays(obj: Any) -> Iterator[Any]:
+    """Yield the numpy arrays reachable from a graph result value.
+
+    Handles RasterStack (its realized ``_data_cache``), ImageData, and bare
+    arrays. Anything else is ignored.
+    """
+    import numpy
+    from rio_tiler.models import ImageData
+
+    from .processes.implementations.data_model import RasterStack
+
+    if isinstance(obj, RasterStack):
+        # Only realized slices hold pixel data; lazy refs do not.
+        for img in list(getattr(obj, "_data_cache", {}).values()):
+            yield from _iter_arrays(img)
+    elif isinstance(obj, ImageData):
+        if obj.array is not None:
+            yield obj.array
+    elif isinstance(obj, numpy.ndarray):
+        yield obj
+
+
+def _sum_retained_bytes(results_cache: dict) -> Tuple[int, int]:
+    """Sum unique array bytes pinned by ``results_cache``.
+
+    Arrays shared between nodes (the audit's key finding — a source ImageData
+    referenced by both the load stack and a downstream stack) are counted once,
+    so this reports the real retained footprint, not a double count.
+    """
+    seen: Set[int] = set()
+    total = 0
+    count = 0
+    for value in results_cache.values():
+        for arr in _iter_arrays(value):
+            if id(arr) in seen:
+                continue
+            seen.add(id(arr))
+            total += _array_bytes(arr)
+            count += 1
+    return total, count
+
+
+def report_retention(
+    results_cache: Optional[dict], label: str = "results_cache"
+) -> None:
+    """Log how much the graph engine is still pinning at end-of-graph.
+
+    Pass the same dict handed to ``OpenEOProcessGraph.to_callable(results_cache=...)``.
+    No-op when profiling is disabled or no cache was supplied.
+    """
+    if not memory_profiling_enabled() or results_cache is None:
+        return
+
+    total, count = _sum_retained_bytes(results_cache)
+    logger.info(
+        "[mem] %s: nodes_pinned=%d retained_arrays=%d retained_bytes=%s",
+        label,
+        len(results_cache),
+        count,
+        _fmt_bytes(total),
+    )
+
+    if _get_settings().memory_backrefs:
+        _dump_backrefs(results_cache)
+
+
+def _dump_backrefs(results_cache: dict) -> None:
+    """Best-effort objgraph back-reference dump for a sample retained array.
+
+    Shows *what* is keeping an array alive (e.g. results_cache AND a child
+    stack). Requires the optional ``objgraph`` package; silently skipped if it
+    is not installed.
+    """
+    try:
+        import os
+
+        import objgraph  # type: ignore
+    except ImportError:
+        logger.warning(
+            "[mem] memory_backrefs requested but `objgraph` is not installed; skipping"
+        )
+        return
+
+    sample = None
+    for value in results_cache.values():
+        for arr in _iter_arrays(value):
+            sample = arr
+            break
+        if sample is not None:
+            break
+    if sample is None:
+        return
+
+    out_dir = _get_settings().memory_backrefs_dir
+    path = os.path.join(out_dir, "openeo_array_backrefs.png")
+    try:
+        objgraph.show_backrefs([sample], max_depth=5, filename=path)
+        logger.info("[mem] wrote array back-reference graph to %s", path)
+    except Exception as exc:  # pragma: no cover - graphviz/runtime dependent
+        logger.warning("[mem] objgraph back-ref dump failed: %s", exc)

--- a/titiler/openeo/results_cache.py
+++ b/titiler/openeo/results_cache.py
@@ -10,6 +10,14 @@ except it drops a node's heavy data as soon as the graph topology proves every
 consumer of that node has run. Because we only free *after* the last consumer,
 nothing ever re-reads an evicted result — there are no re-fetches.
 
+Note we free by calling ``RasterStack.release()``, which empties the stack's
+cache *in place*, rather than by dropping the ``results_cache`` reference. That
+also defeats the engine's *second* retention path (finding #2): it keeps a copy
+of every result on ``self.workflow`` (``results_cache_node._info = result``), so
+merely deleting our ``results_cache`` entry would not free anything. Mutating the
+shared object frees the cube no matter how many references point at the shell.
+This is why subtask 5 (results_cache/workflow pruning) needs no separate fix.
+
 Safety rules baked in:
 
 * **Free only when fully consumed.** We count, per node, how many distinct

--- a/titiler/openeo/results_cache.py
+++ b/titiler/openeo/results_cache.py
@@ -1,0 +1,130 @@
+"""Reference-counted results cache that frees intermediates mid-graph.
+
+The openEO graph engine stores every node's return value in a ``results_cache``
+for the whole evaluation and never frees it, so peak memory grows with the *sum*
+of all intermediate cubes rather than the working set (see the memory audit,
+findings #1/#3, and EPIC #305 subtask 4).
+
+:class:`EvictingResultsCache` is the same ``dict`` the engine already uses,
+except it drops a node's heavy data as soon as the graph topology proves every
+consumer of that node has run. Because we only free *after* the last consumer,
+nothing ever re-reads an evicted result — there are no re-fetches.
+
+Safety rules baked in:
+
+* **Free only when fully consumed.** We count, per node, how many distinct
+  consumer nodes reference its result (``ResultReference`` edges) and free it
+  only once that count reaches zero.
+* **Never free a still-reachable object.** If the same object is held under
+  another cache slot (e.g. ``reduce_dimension`` returning its input unchanged),
+  it is left alone — this also means a node that returns the final result is
+  safe, since the result node is a consumer of whatever it returns.
+* **Disable for re-executing graphs.** ``openeo_pg_parser_networkx``
+  force-recomputes nodes that feed ``aggregate_spatial`` /
+  ``aggregate_temporal_period``, which re-reads their inputs. If a graph contains
+  any such node we disable eviction entirely and behave as a plain dict.
+"""
+
+import logging
+from typing import Any, Dict, Set
+
+from openeo_pg_parser_networkx.graph import OpenEOProcessGraph, PGEdgeType
+
+logger = logging.getLogger(__name__)
+
+# Processes whose presence makes the engine re-execute (and thus re-read) upstream
+# nodes. Kept in sync with openeo_pg_parser_networkx's internal special-case; if
+# the library changes this list, the worst case is that we keep more in memory
+# (when we should disable) — never that we free something still needed, because
+# the per-object reachability guard in `_maybe_release` is independent of it.
+_RECOMPUTE_PROCESSES = frozenset({"aggregate_spatial", "aggregate_temporal_period"})
+
+
+def _result_reference_parents(graph: OpenEOProcessGraph, node: Any) -> Set[Any]:
+    """The nodes whose results ``node`` consumes (its data dependencies)."""
+    return {
+        source
+        for _, source, data in graph.G.out_edges(node, data=True)
+        if data.get("reference_type") == PGEdgeType.ResultReference
+    }
+
+
+def _graph_has_recompute(graph: OpenEOProcessGraph) -> bool:
+    return any(
+        data.get("process_id") in _RECOMPUTE_PROCESSES
+        for _node, data in graph.G.nodes(data=True)
+    )
+
+
+def _release_value(value: Any) -> None:
+    """Free a result's heavy data if it knows how (RasterStack.release())."""
+    release = getattr(value, "release", None)
+    if not callable(release):
+        return
+    try:
+        release()
+    except (
+        Exception
+    ) as exc:  # pragma: no cover - defensive; eviction must never break a graph
+        logger.debug("results_cache: release() failed, leaving value in place: %s", exc)
+
+
+class EvictingResultsCache(dict):
+    """``results_cache`` that frees a node's data once all consumers have run."""
+
+    def __init__(self, graph: OpenEOProcessGraph) -> None:
+        """Precompute per-node consumer counts from the graph topology."""
+        super().__init__()
+        self._enabled = not _graph_has_recompute(graph)
+        # remaining[n] = number of consumer nodes that still need n's result.
+        self._remaining: Dict[Any, int] = {}
+        # parents[n] = the nodes n consumes (counted once each).
+        self._parents: Dict[Any, Set[Any]] = {}
+        # nodes whose result has already been stored (decrement parents once).
+        self._stored: Set[Any] = set()
+
+        if self._enabled:
+            for node in graph.G.nodes():
+                parents = _result_reference_parents(graph, node)
+                self._parents[node] = parents
+                for parent in parents:
+                    self._remaining[parent] = self._remaining.get(parent, 0) + 1
+
+    def __setitem__(self, node: Any, value: Any) -> None:
+        """Store a node's result and free any parent whose last consumer this is."""
+        super().__setitem__(node, value)
+        if not self._enabled or node in self._stored:
+            # The engine may re-store a node (e.g. recompute); only the first
+            # store represents this node consuming its parents.
+            return
+        self._stored.add(node)
+        for parent in self._parents.get(node, ()):
+            self._remaining[parent] = self._remaining.get(parent, 0) - 1
+            if self._remaining[parent] <= 0:
+                self._maybe_release(parent)
+
+    def _maybe_release(self, node: Any) -> None:
+        if node not in self:
+            return
+        value = self[node]
+        # Don't free an object still reachable through another cache slot
+        # (identity passthrough such as reduce_dimension returning its input,
+        # or the final result node holding it).
+        if sum(1 for v in self.values() if v is value) > 1:
+            return
+        _release_value(value)
+
+
+def make_results_cache(graph: OpenEOProcessGraph) -> Dict[Any, Any]:
+    """Build the results cache for a graph evaluation.
+
+    Returns an :class:`EvictingResultsCache` when intermediate eviction is
+    enabled (the default; see ``ProcessingSettings.evict_intermediate_results``),
+    otherwise a plain ``dict`` with the engine's original keep-everything
+    behavior. Pass the result to ``OpenEOProcessGraph.to_callable(results_cache=)``.
+    """
+    from .settings import ProcessingSettings
+
+    if not ProcessingSettings().evict_intermediate_results:
+        return {}
+    return EvictingResultsCache(graph)

--- a/titiler/openeo/results_cache.py
+++ b/titiler/openeo/results_cache.py
@@ -23,6 +23,14 @@ Safety rules baked in:
   force-recomputes nodes that feed ``aggregate_spatial`` /
   ``aggregate_temporal_period``, which re-reads their inputs. If a graph contains
   any such node we disable eviction entirely and behave as a plain dict.
+
+  Note this is keyed on the *upstream library's* hardcoded list, not on titiler's
+  registered processes. ``aggregate_temporal_period`` isn't even a titiler
+  process, so in practice only ``aggregate_spatial`` ever trips the fallback. In
+  particular, plain ``aggregate_temporal`` (e.g. issue #300) is NOT a trigger and
+  stays eligible for eviction: it loops over its intervals internally within a
+  single node execution, so the engine reads its input once and we only free that
+  input after the node returns.
 """
 
 import logging
@@ -33,8 +41,12 @@ from openeo_pg_parser_networkx.graph import OpenEOProcessGraph, PGEdgeType
 logger = logging.getLogger(__name__)
 
 # Processes whose presence makes the engine re-execute (and thus re-read) upstream
-# nodes. Kept in sync with openeo_pg_parser_networkx's internal special-case; if
-# the library changes this list, the worst case is that we keep more in memory
+# nodes. This mirrors openeo_pg_parser_networkx's internal special-case verbatim
+# (matched by process_id), NOT titiler's registered processes — `aggregate_temporal_period`
+# is kept only to stay in lockstep with the library and never appears in a real
+# titiler graph, so `aggregate_spatial` is the only practical trigger. Plain
+# `aggregate_temporal` is intentionally absent (safe to evict; see module docstring).
+# If the library changes this list, the worst case is that we keep more in memory
 # (when we should disable) — never that we free something still needed, because
 # the per-object reachability guard in `_maybe_release` is independent of it.
 _RECOMPUTE_PROCESSES = frozenset({"aggregate_spatial", "aggregate_temporal_period"})

--- a/titiler/openeo/results_cache.py
+++ b/titiler/openeo/results_cache.py
@@ -89,6 +89,19 @@ def _release_value(value: Any) -> None:
         logger.debug("results_cache: release() failed, leaving value in place: %s", exc)
 
 
+def _tag_single_consumer(value: Any, is_single: bool) -> None:
+    """Mark a RasterStack result as having exactly one downstream consumer.
+
+    A sole consumer can safely stream-and-release the value slice-by-slice (no
+    other node will ever read it), which lets e.g. ``ndvi`` avoid holding the
+    whole source cube and the whole index cube at once. See EPIC #305 subtask 7.
+    """
+    from .processes.implementations.data_model import RasterStack
+
+    if isinstance(value, RasterStack):
+        value._single_consumer = is_single
+
+
 class EvictingResultsCache(dict):
     """``results_cache`` that frees a node's data once all consumers have run."""
 
@@ -118,6 +131,10 @@ class EvictingResultsCache(dict):
             # store represents this node consuming its parents.
             return
         self._stored.add(node)
+        # Tag whether this result has exactly one consumer (no consumer has run
+        # yet at store time, so _remaining[node] is the full consumer count). A
+        # sole consumer may stream-and-release this value safely.
+        _tag_single_consumer(value, self._remaining.get(node, 0) == 1)
         for parent in self._parents.get(node, ()):
             self._remaining[parent] = self._remaining.get(parent, 0) - 1
             if self._remaining[parent] <= 0:

--- a/titiler/openeo/settings.py
+++ b/titiler/openeo/settings.py
@@ -258,3 +258,30 @@ class CacheSettings(BaseSettings):
             self.maxsize = 0
 
         return self
+
+
+class ProfilingSettings(BaseSettings):
+    """Optional memory-profiling harness settings.
+
+    Everything here is OFF by default and is meant for local/debug runs only —
+    NEVER enable it in production. ``tracemalloc`` roughly doubles allocation
+    cost, and the per-node hooks plus the process-global RSS/heap sampling are
+    not concurrency-safe (they assume one graph evaluating at a time). See
+    ``docs/audits/memory-profiling.md`` and EPIC #305 (subtask 1).
+    """
+
+    # Master switch: per-node tracemalloc heap deltas + RSS/heap split logging
+    # around process-graph evaluation.
+    memory: bool = False
+
+    # Also dump objgraph back-references for a sample retained array at the end
+    # of a graph. Requires the optional ``objgraph`` package; output is written
+    # under ``memory_backrefs_dir``.
+    memory_backrefs: bool = False
+    memory_backrefs_dir: str = "/tmp"  # noqa: S108
+
+    model_config = SettingsConfigDict(
+        env_prefix="TITILER_OPENEO_PROFILING_",
+        env_file=".env",
+        extra="ignore",
+    )

--- a/titiler/openeo/settings.py
+++ b/titiler/openeo/settings.py
@@ -212,6 +212,12 @@ class ProcessingSettings(BaseSettings):
     max_pixels: int = 100_000_000  # 100 million pixels default
     max_items: int = 20
 
+    # Free a process-graph node's intermediate data as soon as every consumer of
+    # that node has run (reference-counted results cache), instead of keeping
+    # every intermediate cube resident for the whole evaluation. Bounds peak
+    # memory to ~the working set. See titiler.openeo.results_cache and EPIC #305.
+    evict_intermediate_results: bool = True
+
     model_config = SettingsConfigDict(
         env_prefix="TITILER_OPENEO_PROCESSING_",
         env_file=".env",


### PR DESCRIPTION
> ⛔️ **DO NOT MERGE** — long-lived integration branch for the memory-optimization
> EPIC (#305). This PR exists to (a) track the EPIC work in one place and (b) get
> CI to build/publish a Docker image (`ghcr.io/...:sha-...` / `:memory-optimization`)
> for testing each increment on a real cluster. It will be reintegrated to `main`
> as individual, reviewable PRs per subtask — not squashed/merged from here.

## Scope

Umbrella branch for EPIC #305 (*Memory optimization & OOM hardening*). Kept up to
date with `main`; each subtask lands here first for image builds, then graduates
to its own focused PR.

### Landed

- [x] **Subtask 1 — Measurement harness** (`feat(processes): memory profiling harness`)
  - `titiler/openeo/profiling.py`: `profile_node()` (per-node `tracemalloc` heap
    delta + RSS, wired through the `@process` decorator), `profile_graph()` (graph
    heap high-water + `RSS − heap` native estimate), `report_retention()`
    (`results_cache` pinning + unique array bytes; optional `objgraph` back-refs).
  - Wired into both factory eval sites (`POST /result`, XYZ tiles); opt-in
    `results_cache` passed to `to_callable` only when profiling.
  - `ProfilingSettings` (`TITILER_OPENEO_PROFILING_*`) — **off by default, no prod
    behavior change**.
  - `scripts/profile_memory.py` standalone runner for `memray`.
  - Docs: `docs/audits/memory-profiling.md`. Tests: `tests/test_memory_profiling.py`.

### Planned (see #305)

- [x] 2. NDVI/indices → float32 + promote-before-arithmetic (`8aa2389`)
- [ ] 3. Memory footprint estimation (metadata-only dry-run) — 📌 split out to #308 (graph-topology-aware; first-search item count over-counts filtered items)
- [x] 4. Reference-counted results cache frees intermediates mid-graph (`383d85c`) — graph-topology-driven (no consumer-side guessing); frees a result once its last consumer runs (no re-reads); guards aliases/passthrough/result-node; disabled for aggregate_spatial/aggregate_temporal_period graphs
- [x] 5. Prune graph `results_cache`/`workflow` retention (`d4515bc`) — subsumed by `#4`; in-place release() also defeats the `self.workflow` second reference (finding `#2`), proven by a weakref test
- [x] 6. Bound & document native caches (`2e90374`) — pinned curl cache, docs + helm-unittest guard, flagged dev 512 MB values; fixed latent `VSI_CACHE_SIZE` "5e+06" rendering bug (quote large env numbers)
- [x] 7. Streaming ndvi/ndwi (`d586bc3`) — single-consumer-tagged inputs read in windows and released as consumed; −45% within-ndvi peak (harness), byte-identical. GTiff/spectral parts deferred
- [ ] 8. Per-request memory backpressure (reject vs OOM) — ⏸️ deferred (adds surface area for limited marginal benefit after 2/4/5/6/7; revisit with EPIC #304)

## Validation (subtask 1)

- `tests/test_memory_profiling.py` — 11 passing; regression suites green.
- `pre-commit` (ruff, ruff-format, isort, mypy) clean.
- Smoke run already reproduces audit finding #4 live (`ndvi` output is `float64`,
  retaining more bytes than its uint16 source).

Refs #305. Audit: `docs/audits/memory-oom-audit.md`.







