### PR TITLE
perf: compute float math in float32 (promote integer inputs)

### DIFF
--- a/tests/test_math_float32.py
+++ b/tests/test_math_float32.py
@@ -7,6 +7,7 @@ from titiler.openeo.processes.implementations.math import (
     divide,
     linear_scale_range,
     ln,
+    log,
     normalized_difference,
     sqrt,
 )
@@ -54,6 +55,24 @@ def test_linear_scale_range_integer_input_returns_float32():
 def test_transcendental_integer_input_returns_float32():
     assert sqrt(numpy.array([4, 9], dtype="uint16")).dtype == numpy.float32
     assert ln(numpy.array([1, 2], dtype="int32")).dtype == numpy.float32
+
+
+def test_log_with_integer_base_scalar_stays_float32():
+    """A Python int `base` must not pull the result back to float64."""
+    out = log(numpy.array([100, 1000], dtype="uint16"), base=10)
+    assert out.dtype == numpy.float32
+    assert numpy.allclose(out, [2.0, 3.0])
+
+
+def test_non_numeric_dtypes_are_left_untouched():
+    """Only integer/bool arrays are promoted; other dtypes pass through."""
+    dt = numpy.array(["2020-01-01", "2020-01-02"], dtype="datetime64[D]")
+    from titiler.openeo.processes.implementations.math import _promote
+
+    assert _promote(dt).dtype == dt.dtype  # datetime64 untouched
+    f64 = numpy.array([1.0, 2.0], dtype="float64")
+    assert _promote(f64).dtype == numpy.float64  # float64 not downcast
+    assert _promote(numpy.array([1, 2], dtype="uint16")).dtype == numpy.float32
 
 
 def test_float64_inputs_are_not_downcast():

--- a/tests/test_math_float32.py
+++ b/tests/test_math_float32.py
@@ -1,0 +1,85 @@
+"""Float-producing math ops compute integer inputs in float32, not float64."""
+
+import numpy
+import pytest
+
+from titiler.openeo.processes.implementations.math import (
+    divide,
+    linear_scale_range,
+    ln,
+    normalized_difference,
+    sqrt,
+)
+
+
+def test_normalized_difference_uint16_returns_float32():
+    x = numpy.array([10000, 4000], dtype="uint16")
+    y = numpy.array([2000, 8000], dtype="uint16")
+    out = normalized_difference(x, y)
+    assert out.dtype == numpy.float32
+
+
+def test_normalized_difference_no_integer_wraparound():
+    """y > x must give a negative result, not a wrapped huge positive one.
+
+    In pure uint16, ``10000 - 20000`` wraps to 55536 and the ratio comes out
+    positive (~1.85) instead of -1/3.
+    """
+    x = numpy.array([10000], dtype="uint16")
+    y = numpy.array([20000], dtype="uint16")
+    assert normalized_difference(x, y)[0] == pytest.approx(-1.0 / 3.0, rel=1e-5)
+
+
+def test_normalized_difference_no_addition_overflow():
+    x = numpy.array([60000], dtype="uint16")
+    y = numpy.array([40000], dtype="uint16")
+    # (60000 - 40000) / (60000 + 40000) = 0.2 — would overflow uint16 in (x + y)
+    assert normalized_difference(x, y)[0] == pytest.approx(0.2, rel=1e-5)
+
+
+def test_divide_integer_inputs_return_float32():
+    out = divide(
+        numpy.array([6, 9], dtype="uint16"), numpy.array([2, 3], dtype="int32")
+    )
+    assert out.dtype == numpy.float32
+    assert numpy.allclose(out, [3.0, 3.0])
+
+
+def test_linear_scale_range_integer_input_returns_float32():
+    out = linear_scale_range(numpy.array([0, 5, 10], dtype="uint16"), 0, 10)
+    assert out.dtype == numpy.float32
+    assert numpy.allclose(out, [0.0, 0.5, 1.0])
+
+
+def test_transcendental_integer_input_returns_float32():
+    assert sqrt(numpy.array([4, 9], dtype="uint16")).dtype == numpy.float32
+    assert ln(numpy.array([1, 2], dtype="int32")).dtype == numpy.float32
+
+
+def test_float64_inputs_are_not_downcast():
+    """Genuine float64 inputs keep their precision (we only promote integers)."""
+    x = numpy.array([0.6], dtype="float64")
+    y = numpy.array([0.2], dtype="float64")
+    out = normalized_difference(x, y)
+    assert out.dtype == numpy.float64
+    assert out[0] == pytest.approx(0.5)
+
+
+def test_float32_inputs_stay_float32():
+    x = numpy.array([0.6], dtype="float32")
+    y = numpy.array([0.2], dtype="float32")
+    assert normalized_difference(x, y).dtype == numpy.float32
+
+
+def test_mask_is_preserved():
+    x = numpy.ma.MaskedArray([10000, 4000], mask=[True, False], dtype="uint16")
+    y = numpy.ma.MaskedArray([2000, 8000], mask=[False, False], dtype="uint16")
+    out = normalized_difference(x, y)
+    assert isinstance(out, numpy.ma.MaskedArray)
+    assert bool(out.mask[0]) is True
+    assert out.dtype == numpy.float32
+
+
+def test_python_scalars_still_work():
+    assert normalized_difference(3, 1) == pytest.approx(0.5)
+    assert divide(6, 2) == pytest.approx(3.0)

--- a/titiler/openeo/processes/implementations/math.py
+++ b/titiler/openeo/processes/implementations/math.py
@@ -10,17 +10,30 @@ from .reduce import apply_pixel_selection
 
 
 def _promote(a):
-    """Promote an integer/bool array to float32; leave floats and scalars as-is.
+    """Promote integer/boolean inputs to float32; leave everything else as-is.
 
     numpy resolves integer inputs to float64 for division and transcendental
     functions. For raster math that produces an index/derived cube, float32 is
     ample and halves the result. Source rasters stay at their compact integer
     dtype (we only convert at the point of a float-producing op), and existing
     floating inputs keep their precision. Masks are preserved by ``astype``.
+
+    Only integer/boolean dtypes are converted — other dtypes (float, complex,
+    datetime, object) are left untouched. Python ``int``/``bool`` scalars are
+    promoted too, so a scalar operand (e.g. ``log(x, base=10)``) doesn't pull the
+    result back to float64.
     """
     dtype = getattr(a, "dtype", None)
-    if dtype is not None and not numpy.issubdtype(dtype, numpy.floating):
-        return a.astype("float32")
+    if dtype is not None:
+        if numpy.issubdtype(dtype, numpy.integer) or numpy.issubdtype(
+            dtype, numpy.bool_
+        ):
+            return a.astype("float32")
+        return a
+    # Python scalars: promote int (incl. bool); leave float/other untouched so
+    # they don't upcast a float32 array.
+    if isinstance(a, int):
+        return numpy.float32(a)
     return a
 
 

--- a/titiler/openeo/processes/implementations/math.py
+++ b/titiler/openeo/processes/implementations/math.py
@@ -1,11 +1,47 @@
 """titiler.openeo processes Math."""
 
 import builtins
+import functools
 
 import numpy
 
 from .data_model import RasterStack
 from .reduce import apply_pixel_selection
+
+
+def _promote(a):
+    """Promote an integer/bool array to float32; leave floats and scalars as-is.
+
+    numpy resolves integer inputs to float64 for division and transcendental
+    functions. For raster math that produces an index/derived cube, float32 is
+    ample and halves the result. Source rasters stay at their compact integer
+    dtype (we only convert at the point of a float-producing op), and existing
+    floating inputs keep their precision. Masks are preserved by ``astype``.
+    """
+    dtype = getattr(a, "dtype", None)
+    if dtype is not None and not numpy.issubdtype(dtype, numpy.floating):
+        return a.astype("float32")
+    return a
+
+
+def _float32_for_integers(func):
+    """Decorator: promote integer array arguments to float32 before calling.
+
+    Applied to element-wise ops that already convert integer input to float64
+    (divide, transcendental functions, normalized_difference, ...), so their
+    result is float32 instead. Only narrows existing float64 results; never
+    changes an integer-only result, since those ops are not decorated.
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(
+            *(_promote(a) for a in args),
+            **{k: _promote(v) for k, v in kwargs.items()},
+        )
+
+    return wrapper
+
 
 __all__ = [
     "absolute",
@@ -89,6 +125,7 @@ def constant(x):
     return x
 
 
+@_float32_for_integers
 def divide(x, y):
     return x / y
 
@@ -121,66 +158,82 @@ def _round(x, p=0):
     return numpy.around(x, decimals=p)
 
 
+@_float32_for_integers
 def exp(p):
     return numpy.exp(p)
 
 
+@_float32_for_integers
 def log(x, base):
     return numpy.log(x) / numpy.log(base)
 
 
+@_float32_for_integers
 def ln(x):
     return numpy.log(x)
 
 
+@_float32_for_integers
 def cos(x):
     return numpy.cos(x)
 
 
+@_float32_for_integers
 def sin(x):
     return numpy.sin(x)
 
 
+@_float32_for_integers
 def tan(x):
     return numpy.tan(x)
 
 
+@_float32_for_integers
 def arccos(x):
     return numpy.arccos(x)
 
 
+@_float32_for_integers
 def arcsin(x):
     return numpy.arcsin(x)
 
 
+@_float32_for_integers
 def arctan(x):
     return numpy.arctan(x)
 
 
+@_float32_for_integers
 def cosh(x):
     return numpy.cosh(x)
 
 
+@_float32_for_integers
 def sinh(x):
     return numpy.sinh(x)
 
 
+@_float32_for_integers
 def tanh(x):
     return numpy.tanh(x)
 
 
+@_float32_for_integers
 def arcosh(x):
     return numpy.arccosh(x)
 
 
+@_float32_for_integers
 def arsinh(x):
     return numpy.arcsinh(x)
 
 
+@_float32_for_integers
 def artanh(x):
     return numpy.arctanh(x)
 
 
+@_float32_for_integers
 def arctan2(y, x):
     return numpy.arctan2(y, x)
 
@@ -197,6 +250,7 @@ def sgn(x):
     return numpy.sign(x)
 
 
+@_float32_for_integers
 def sqrt(x):
     return numpy.sqrt(x)
 
@@ -310,6 +364,7 @@ def count(data, condition=None):
         raise TypeError("Unsupported data type for count function.")
 
 
+@_float32_for_integers
 def normalized_difference(x, y):
     return (x - y) / (x + y)
 
@@ -318,6 +373,7 @@ def clip(x, min, max):
     return numpy.clip(x, min, max)
 
 
+@_float32_for_integers
 def linear_scale_range(
     x,
     inputMin: float,


### PR DESCRIPTION
Several element-wise math ops convert integer inputs to **float64** (`divide`, `linear_scale_range`, `ln`/`log`/`exp`/`sqrt`, the trig family, `normalized_difference`), producing index/derived cubes at twice the needed width.

A small `_float32_for_integers` decorator promotes integer/bool array arguments to **float32** before the op, so these results are float32 instead:
- source rasters stay at their compact integer dtype (we only convert at the float-producing op),
- existing floating inputs keep their precision, masks are preserved,
- only narrows results that were already float64 — integer-only ops (`add`/`subtract`/`multiply`/`mod`/`power`) are untouched.

For `normalized_difference` it also fixes a latent **uint16 wrap/overflow** in `(x - y) / (x + y)` (now computed in float32).

Tests in `tests/test_math_float32.py`.