### PR TITLE
fix: bound & document GDAL/VSI native caches

### DIFF
--- a/.env.cdse
+++ b/.env.cdse
@@ -12,6 +12,9 @@ GDAL_HTTP_MULTIPLEX=TRUE # Enable HTTP multiplexing
 GDAL_CACHEMAX=500 # Set GDAL cache size
 GDAL_INGESTED_BYTES_AT_OPEN=32768 # Open a larger bytes range when reading
 GDAL_HTTP_MERGE_CONSECUTIVE_RANGES=YES # Merge consecutive ranges\
+# 512 MB PER FILE-HANDLE — local/dev only (single user, low concurrency). Do NOT
+# use this in k8s/prod: it multiplies by every concurrently open file handle and
+# will OOM a pod. The Helm chart default is 5 MB. See docs/src/memory-tuning.md.
 VSI_CACHE_SIZE=536870912 # Set VSI cache size
 VSI_CACHE=TRUE # Enable VSI cache
 

--- a/.env.eoapi
+++ b/.env.eoapi
@@ -8,6 +8,9 @@ GDAL_HTTP_MULTIPLEX=TRUE # Enable HTTP multiplexing
 GDAL_CACHEMAX=500 # Set GDAL cache size
 GDAL_INGESTED_BYTES_AT_OPEN=32768 # Open a larger bytes range when reading
 GDAL_HTTP_MERGE_CONSECUTIVE_RANGES=YES # Merge consecutive ranges\
+# 512 MB PER FILE-HANDLE — local/dev only (single user, low concurrency). Do NOT
+# use this in k8s/prod: it multiplies by every concurrently open file handle and
+# will OOM a pod. The Helm chart default is 5 MB. See docs/src/memory-tuning.md.
 VSI_CACHE_SIZE=536870912 # Set VSI cache size
 VSI_CACHE=TRUE # Enable VSI cache
 

--- a/deployment/k8s/charts/tests/native_cache_test.yaml
+++ b/deployment/k8s/charts/tests/native_cache_test.yaml
@@ -1,0 +1,39 @@
+suite: native cache budget guard
+# Tripwire: the GDAL/VSI native (off-heap) caches must stay at their bounded
+# defaults. If someone bumps one (e.g. pastes a dev
+# VSI_CACHE_SIZE of 512 MB), these assertions fail and force a conscious review
+# against the memory budget. See docs/src/memory-tuning.md.
+templates:
+  - deployment.yaml
+tests:
+  - it: VSI_CACHE_SIZE stays small (per-file-handle; never the dev 512 MB)
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: VSI_CACHE_SIZE
+            value: "5000000"
+
+  - it: GDAL_CACHEMAX stays bounded (process-global, × WEB_CONCURRENCY)
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GDAL_CACHEMAX
+            value: "200"
+
+  - it: CPL_VSIL_CURL_CACHE_SIZE is pinned (not left to drift)
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CPL_VSIL_CURL_CACHE_SIZE
+            value: "67108864"
+
+  - it: VSI cache is enabled
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: VSI_CACHE
+            value: "TRUE"

--- a/deployment/k8s/charts/values.yaml
+++ b/deployment/k8s/charts/values.yaml
@@ -87,11 +87,31 @@ auth:
 stac:
   apiUrl: "https://stac.eoapi.dev"  # STAC API endpoint URL
 
+# GDAL/VSI native (off-heap) caches. These live OUTSIDE the Python heap and are
+# NOT freed by gc, so they add on top of per-request working memory and must fit
+# under resources.limits.memory. Keep them small and explicit. See the sizing
+# guide: docs/src/memory-tuning.md.
+#
+# Rough native budget per pod:
+#   WEB_CONCURRENCY * (GDAL_CACHEMAX + CPL_VSIL_CURL_CACHE_SIZE)   # process-global
+#   + (concurrently open file handles) * VSI_CACHE_SIZE           # PER-handle!
+# Keep this comfortably below resources.limits.memory, leaving room for the
+# Python heap (the process-graph cubes).
 env:
   CPL_TMPDIR: /tmp
-  GDAL_CACHEMAX: 200   # 200 mb
-  VSI_CACHE: "TRUE"   # Enable VSI cache
-  VSI_CACHE_SIZE: 5000000   # 5 MB (per file-handle)
+  # Process-global block cache. Values <100000 are MB, else bytes -> 200 MB here.
+  # Multiplies by WEB_CONCURRENCY (one cache per worker process).
+  GDAL_CACHEMAX: "200"
+  VSI_CACHE: "TRUE"
+  # PER FILE-HANDLE in-memory cache: total ≈ this × number of concurrently open
+  # files (≈ items × bands × read threads). Keep it small. The dev .env profiles
+  # use 512 MB here for single-user local runs — NEVER ship that to a pod.
+  # NOTE: quote large numbers — unquoted, Helm renders 5000000 as "5e+06", which
+  # GDAL parses as 5 (stops at 'e'), silently disabling the VSI cache.
+  VSI_CACHE_SIZE: "5000000"   # 5 MB per handle
+  # Process-global LRU for /vsicurl chunk reads. Pinned (GDAL defaults to 16 MB)
+  # so it can't drift; raise for read-heavy workloads only if the budget allows.
+  CPL_VSIL_CURL_CACHE_SIZE: "67108864"   # 64 MB
   GDAL_DISABLE_READDIR_ON_OPEN: "EMPTY_DIR"   # Disable directory listing
   GDAL_HTTP_MERGE_CONSECUTIVE_RANGES: "YES"   # Merge consecutive ranges
   GDAL_HTTP_MULTIPLEX: "YES"   # Enable multiplexing

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
     - Local Setup: "local-setup.md"
     - Kubernetes Guide: "kubernetes.md"
     - Production PostgreSQL (CloudNativePG): "kubernetes-cloudnativepg.md"
+    - Memory Tuning & Native Caches: "memory-tuning.md"
   - Examples:
     - Overview: "examples/index.md"
     - Parameter Management: "examples/parameter-management.md"

--- a/docs/src/memory-tuning.md
+++ b/docs/src/memory-tuning.md
@@ -63,10 +63,10 @@ The chart (`deployment/k8s/charts/values.yaml`) ships safe defaults:
 
 ```yaml
 env:
-  GDAL_CACHEMAX: 200                  # 200 MB, process-global
+  GDAL_CACHEMAX: "200"                # 200 MB, process-global
   VSI_CACHE: "TRUE"
-  VSI_CACHE_SIZE: 5000000             # 5 MB PER HANDLE
-  CPL_VSIL_CURL_CACHE_SIZE: 67108864  # 64 MB, pinned
+  VSI_CACHE_SIZE: "5000000"           # 5 MB PER HANDLE
+  CPL_VSIL_CURL_CACHE_SIZE: "67108864"  # 64 MB, pinned
 ```
 
 Rules of thumb:

--- a/docs/src/memory-tuning.md
+++ b/docs/src/memory-tuning.md
@@ -1,0 +1,91 @@
+# Memory tuning & native caches
+
+titiler-openeo uses memory in two very different places, and an OOM kill looks
+identical for both:
+
+- **Python heap** — the `ImageData`/numpy cubes produced while evaluating a
+  process graph.
+- **Native / off-heap** — GDAL and `/vsi*` caches. These live **outside** the
+  Python heap, are **not** freed by the garbage collector, and add *on top* of
+  per-request working memory. This page is about keeping them bounded.
+
+> The single most common production footgun is shipping a **dev** `VSI_CACHE_SIZE`
+> (512 MB) to Kubernetes. It is a *per-file-handle* cache and will OOM a pod.
+
+## The three native knobs
+
+| Variable | Scope | Default | Notes |
+|----------|-------|---------|-------|
+| `GDAL_CACHEMAX` | **process-global** block cache | 5% of RAM | Values `<100000` are **MB**, otherwise **bytes**. One cache per worker process, so it multiplies by `WEB_CONCURRENCY`. |
+| `VSI_CACHE_SIZE` | **per file-handle** | 25 MB | In-memory cache of each open file. Total ≈ `VSI_CACHE_SIZE × (concurrently open handles)`. **This is the dangerous one.** |
+| `CPL_VSIL_CURL_CACHE_SIZE` | **process-global** LRU for `/vsicurl` chunk reads | 16 MB | Pin it so it can't drift; raise only if the budget allows. |
+
+`VSI_CACHE` must be `TRUE` for `VSI_CACHE_SIZE` to apply.
+
+### Why `VSI_CACHE_SIZE` is the trap
+
+It is allocated **once per open file handle**, not once per process. A single
+process-graph request fans out to roughly `items × bands × read_threads` open
+handles (the `ThreadPoolExecutor` reads in `RasterStack` plus rio-tiler's mosaic
+reader). At the dev value of 512 MB per handle, even a few dozen concurrent
+handles blow past a 2 Gi container; at the chart default of 5 MB the same fan-out
+costs a few hundred MB at most.
+
+## The native budget
+
+Per pod, the native caches cost roughly:
+
+```
+native ≈ WEB_CONCURRENCY × (GDAL_CACHEMAX + CPL_VSIL_CURL_CACHE_SIZE)   # process-global
+       + (concurrently open file handles) × VSI_CACHE_SIZE             # per-handle
+```
+
+This must sit comfortably **below** `resources.limits.memory`, leaving the
+remainder for the Python heap (the process-graph cubes). Worked example for the
+chart defaults at a 2 Gi limit, single worker:
+
+```
+GDAL_CACHEMAX            = 200 MB   (process-global)
+CPL_VSIL_CURL_CACHE_SIZE =  64 MB   (process-global)
+VSI_CACHE_SIZE           =   5 MB × ~100 handles ≈ 500 MB (worst case)
+--------------------------------------------------------------
+native peak              ≈ 0.2 + 0.06 + 0.5 ≈ 0.76 GB
+remaining for heap       ≈ 2 Gi − 0.76 ≈ 1.2 GB
+```
+
+If you raise `WEB_CONCURRENCY` (multiple uvicorn workers per pod), remember the
+**process-global** caches multiply by it — `GDAL_CACHEMAX × WEB_CONCURRENCY`
+alone can dominate the limit.
+
+## Recommended production values (Helm chart defaults)
+
+The chart (`deployment/k8s/charts/values.yaml`) ships safe defaults:
+
+```yaml
+env:
+  GDAL_CACHEMAX: 200                  # 200 MB, process-global
+  VSI_CACHE: "TRUE"
+  VSI_CACHE_SIZE: 5000000             # 5 MB PER HANDLE
+  CPL_VSIL_CURL_CACHE_SIZE: 67108864  # 64 MB, pinned
+```
+
+Rules of thumb:
+
+- Keep `VSI_CACHE_SIZE` in the low single-digit MB. Never copy a dev value here.
+- Keep `GDAL_CACHEMAX + CPL_VSIL_CURL_CACHE_SIZE` (× `WEB_CONCURRENCY`) to a small
+  fraction of the limit.
+- Size `WEB_CONCURRENCY` to the pod's CPU, then re-check this budget.
+
+## Dev profiles are not production
+
+`.env.cdse` / `.env.eoapi` are local-developer profiles (single user, low
+concurrency) and intentionally use a large `VSI_CACHE_SIZE` (512 MB) and
+`CPL_VSIL_CURL_CACHE_SIZE` (200 MB) for throughput. **Do not** copy these into a
+Helm release or container deployment — they are flagged inline in those files.
+
+## Guard
+
+A Helm unit test (`deployment/k8s/charts/tests/native_cache_test.yaml`) asserts
+the chart's native-cache env vars stay at their bounded defaults, so an
+accidental bump (e.g. pasting a dev `VSI_CACHE_SIZE`) fails CI and forces a
+conscious review.


### PR DESCRIPTION
Native GDAL/VSI caches live **off-heap** and add on top of per-request memory; `VSI_CACHE_SIZE` is **per file-handle** (the dev `.env` profiles use 512 MB, which would OOM a pod if shipped).

- **Bugfix:** unquoted `VSI_CACHE_SIZE: 5000000` was rendered by Helm as `"5e+06"`, which GDAL parses as `5` (stops at `e`) — silently **disabling the VSI cache** in prod. Large numeric env values are now quoted so they render exactly.
- Pin `CPL_VSIL_CURL_CACHE_SIZE` (was unset → GDAL default) to a bounded 64 MB; document per-handle vs process-global semantics and the `WEB_CONCURRENCY` multiplier.
- Add `docs/src/memory-tuning.md` (budget formula + worked 2 Gi example) and a nav entry.
- Flag the 512 MB dev values inline in `.env.cdse`/`.env.eoapi` as dev-only.
- Add a helm-unittest guard (`native_cache_test.yaml`) so a future bump fails CI.