### PR TITLE
perf: stream ndvi/ndwi to bound the within-node peak

### DIFF
--- a/docs/src/memory-management.md
+++ b/docs/src/memory-management.md
@@ -47,6 +47,17 @@ The cache is conservative by construction:
   `aggregate_spatial`, which the engine re-executes and would re-read, fall back
   to the original keep-everything behavior.
 
+## Streaming index operations
+
+Eviction frees a cube *after* the node that produced it is done, but a single
+node can still briefly hold two full cubes — e.g. `ndvi` reads the whole source
+stack and builds the whole index stack. When the cache determines a result has a
+single downstream consumer, that consumer is allowed to **stream**: `ndvi`/`ndwi`
+read the source in concurrent windows and release each slice as soon as it is
+consumed, so the whole source cube and the whole index cube are never both fully
+resident. Inputs with more than one consumer fall back to the plain (non-mutating)
+path, so this never affects correctness.
+
 ## Configuration
 
 Eviction is **on by default**. To restore the engine's original behavior (keep

--- a/tests/test_indices_streaming.py
+++ b/tests/test_indices_streaming.py
@@ -87,10 +87,9 @@ def test_streaming_bounds_resident_slices_to_window():
 
 
 def test_non_single_consumer_falls_back_and_keeps_source():
-    """Without the tag the source may have other consumers: don't mutate it."""
+    """Without the single-consumer tag enabled the source may have other consumers: don't mutate it."""
     stack, _ = _regenerable_stack(n=4)
-    # no _single_consumer attribute set -> fallback (data.items())
-    result = ndvi(stack, nir=2, red=1)
+    # `_single_consumer` defaults to False -> fallback (data.items())
     assert len(result) == 4
     # Fallback realizes the whole stack and leaves it cached (not released).
     assert len(stack._data_cache) == 4

--- a/tests/test_indices_streaming.py
+++ b/tests/test_indices_streaming.py
@@ -1,0 +1,108 @@
+"""Streaming ndvi/ndwi: bound the within-node peak.
+
+A sole-consumer source is streamed slice-by-slice and released as it's consumed,
+so the whole source cube and the whole index cube are never both fully resident.
+"""
+
+from datetime import datetime
+
+import numpy
+from rio_tiler.models import ImageData
+
+from titiler.openeo.processes.implementations.data_model import RasterStack
+from titiler.openeo.processes.implementations.indices import ndvi
+
+
+def _regenerable_stack(n=6, max_workers=2):
+    """Deterministic regenerable stack: red=v, nir=2v -> ndvi == 1/3 everywhere."""
+    calls = {"count": 0}
+
+    def make(v):
+        def task():
+            calls["count"] += 1
+            arr = numpy.ma.MaskedArray(
+                numpy.stack(
+                    [
+                        numpy.full((8, 8), v, dtype="uint16"),  # band1 = red = v
+                        numpy.full((8, 8), 2 * v, dtype="uint16"),  # band2 = nir = 2v
+                    ]
+                ),
+                mask=numpy.zeros((2, 8, 8), dtype=bool),
+            )
+            return ImageData(arr, bounds=(0, 0, 1, 1))
+
+        return task
+
+    tasks = [(make(i + 1), {"datetime": datetime(2020, 1, 1 + i)}) for i in range(n)]
+    stack = RasterStack(
+        tasks=tasks,
+        timestamp_fn=lambda a: a["datetime"],
+        allowed_exceptions=(),
+        max_workers=max_workers,
+        width=8,
+        height=8,
+        bounds=(0, 0, 1, 1),
+        band_names=["b1", "b2"],
+    )
+    return stack, calls
+
+
+def test_streaming_releases_each_slice_and_is_correct():
+    stack, calls = _regenerable_stack(n=6)
+    stack._single_consumer = True  # tagged by the results cache in real graphs
+
+    result = ndvi(stack, nir=2, red=1)
+
+    assert len(result) == 6
+    # Each source slice was loaded exactly once, then released.
+    assert calls["count"] == 6
+    assert stack._data_cache == {}
+    # ndvi of (red=v, nir=2v) is 1/3 everywhere.
+    for img in result.values():
+        assert numpy.allclose(img.array, 1.0 / 3.0)
+
+
+def test_streaming_bounds_resident_slices_to_window():
+    stack, _ = _regenerable_stack(n=6, max_workers=2)
+    stack._single_consumer = True
+
+    observed = []
+    # Wrap the per-slice work to record how many slices are cached at once.
+    import titiler.openeo.processes.implementations.indices as indices
+
+    real_apply = indices._apply_ndvi
+
+    def spy(img, nir, red):
+        observed.append(len(stack._data_cache))
+        return real_apply(img, nir, red)
+
+    indices._apply_ndvi = spy
+    try:
+        ndvi(stack, nir=2, red=1)
+    finally:
+        indices._apply_ndvi = real_apply
+
+    # Never more than the window (2) slices resident during processing.
+    assert observed and max(observed) <= 2
+
+
+def test_non_single_consumer_falls_back_and_keeps_source():
+    """Without the tag the source may have other consumers: don't mutate it."""
+    stack, _ = _regenerable_stack(n=4)
+    # no _single_consumer attribute set -> fallback (data.items())
+    result = ndvi(stack, nir=2, red=1)
+    assert len(result) == 4
+    # Fallback realizes the whole stack and leaves it cached (not released).
+    assert len(stack._data_cache) == 4
+
+
+def test_streaming_matches_non_streaming():
+    streamed, _ = _regenerable_stack(n=5)
+    streamed._single_consumer = True
+    plain, _ = _regenerable_stack(n=5)
+
+    r1 = ndvi(streamed, nir=2, red=1)
+    r2 = ndvi(plain, nir=2, red=1)
+
+    for k in r2.keys():
+        assert numpy.array_equal(r1[k].array, r2[k].array)

--- a/tests/test_indices_streaming.py
+++ b/tests/test_indices_streaming.py
@@ -90,6 +90,7 @@ def test_non_single_consumer_falls_back_and_keeps_source():
     """Without the single-consumer tag enabled the source may have other consumers: don't mutate it."""
     stack, _ = _regenerable_stack(n=4)
     # `_single_consumer` defaults to False -> fallback (data.items())
+    result = ndvi(stack, nir=2, red=1)
     assert len(result) == 4
     # Fallback realizes the whole stack and leaves it cached (not released).
     assert len(stack._data_cache) == 4

--- a/tests/test_indices_streaming.py
+++ b/tests/test_indices_streaming.py
@@ -70,17 +70,17 @@ def test_streaming_bounds_resident_slices_to_window():
     # Wrap the per-slice work to record how many slices are cached at once.
     import titiler.openeo.processes.implementations.indices as indices
 
-    real_apply = indices._apply_ndvi
+    real_apply = indices._normalized_difference_image
 
-    def spy(img, nir, red):
+    def spy(img, first, second, name, target_band):
         observed.append(len(stack._data_cache))
-        return real_apply(img, nir, red)
+        return real_apply(img, first, second, name, target_band)
 
-    indices._apply_ndvi = spy
+    indices._normalized_difference_image = spy
     try:
         ndvi(stack, nir=2, red=1)
     finally:
-        indices._apply_ndvi = real_apply
+        indices._normalized_difference_image = real_apply
 
     # Never more than the window (2) slices resident during processing.
     assert observed and max(observed) <= 2

--- a/tests/test_results_cache.py
+++ b/tests/test_results_cache.py
@@ -134,6 +134,45 @@ def test_make_results_cache_respects_setting(monkeypatch):
     assert isinstance(evicting, EvictingResultsCache)
 
 
+def test_tags_single_consumer():
+    """A result with exactly one consumer is tagged so it can be streamed."""
+    g, nodes = _graph(_LINEAR)
+    cache = EvictingResultsCache(g)
+    load_val, ndvi_val = _stack(1), _stack(2)
+    cache[nodes["load"]] = load_val  # consumed only by ndvi
+    cache[nodes["ndvi"]] = ndvi_val  # consumed only by save (root)
+    assert load_val._single_consumer is True
+    assert ndvi_val._single_consumer is True
+
+
+def test_fan_out_not_tagged_single_consumer():
+    """A result consumed by two nodes must NOT be tagged single-consumer."""
+    pg = {
+        "load": {"process_id": "load_collection", "arguments": {"id": "x"}},
+        "ndvi": {
+            "process_id": "ndvi",
+            "arguments": {"data": {"from_node": "load"}, "nir": 2, "red": 1},
+        },
+        "ndwi": {
+            "process_id": "ndwi",
+            "arguments": {"data": {"from_node": "load"}, "nir": 2, "swir": 1},
+        },
+        "merge": {
+            "process_id": "merge_cubes",
+            "arguments": {
+                "cube1": {"from_node": "ndvi"},
+                "cube2": {"from_node": "ndwi"},
+            },
+            "result": True,
+        },
+    }
+    g, nodes = _graph(pg)
+    cache = EvictingResultsCache(g)
+    load_val = _stack(1)
+    cache[nodes["load"]] = load_val  # consumed by BOTH ndvi and ndwi
+    assert load_val._single_consumer is False
+
+
 def test_eviction_is_robust_to_restore():
     """Re-storing a node (engine recompute) must not double-decrement parents."""
     g, nodes = _graph(_LINEAR)

--- a/titiler/openeo/processes/implementations/data_model.py
+++ b/titiler/openeo/processes/implementations/data_model.py
@@ -300,6 +300,11 @@ class RasterStack(Dict[datetime, ImageData]):
     - ImageRef instances enable cutline mask computation without task execution
     """
 
+    # Set by the reference-counted results cache when this stack has exactly one
+    # downstream consumer, so that consumer may stream-and-release it slice by
+    # slice. See titiler.openeo.results_cache.
+    _single_consumer: bool = False
+
     def __init__(
         self,
         tasks: TaskType,

--- a/titiler/openeo/processes/implementations/indices.py
+++ b/titiler/openeo/processes/implementations/indices.py
@@ -2,9 +2,10 @@
 
 import re
 from datetime import datetime
-from typing import Dict, List, Optional, Union
+from typing import Callable, Dict, List, Optional, Union
 
 import numpy
+from rio_tiler.constants import MAX_THREADS
 
 from .data_model import ImageData, RasterStack
 from .math import normalized_difference
@@ -18,6 +19,43 @@ BandIdentifier = Union[int, str]
 # requested band ``B08_10m`` into a cube band ``B08_10m_b1``, so band-name
 # lookups must tolerate that trailing ``_b<n>`` suffix.
 _BAND_SUFFIX_RE = re.compile(r"_b\d+$")
+
+
+def _apply_per_slice(
+    data: RasterStack, fn: Callable[[ImageData], ImageData]
+) -> RasterStack:
+    """Apply ``fn`` to every slice and return a new stack.
+
+    When ``data`` has a single downstream consumer (tagged by the
+    reference-counted results cache), the source cube is streamed: slices are
+    read in concurrent windows and **released as soon as they are consumed**, so
+    the whole source cube and the whole result cube are never both fully resident
+    (the within-node peak that reference-counted eviction alone can't remove).
+    Otherwise the source might be needed by another node, so we fall back to the
+    plain non-mutating realization.
+    """
+    result: Dict[datetime, ImageData] = {}
+
+    if not getattr(data, "_single_consumer", False):
+        for key, img_data in data.items():
+            result[key] = fn(img_data)
+        return RasterStack.from_images(result)
+
+    keys = list(data.keys())
+    window = max(1, getattr(data, "_max_workers", MAX_THREADS))
+    for start in range(0, len(keys), window):
+        batch = keys[start : start + window]
+        data.prefetch(batch)  # load the window concurrently
+        for key in batch:
+            # Avoid re-executing tasks that failed during prefetch (prefetch skips
+            # allowed exceptions without caching).
+            with data._cache_lock:
+                img_data = data._data_cache.get(key)
+            if img_data is None:
+                continue
+            result[key] = fn(img_data)
+            data.release(key)  # safe: this stack has no other consumer
+    return RasterStack.from_images(result)
 
 
 def _resolve_band_index(data: ImageData, band: BandIdentifier) -> int:
@@ -130,12 +168,11 @@ def ndwi(
     Returns:
         RasterStack with NDWI results
     """
-    result: Dict[datetime, ImageData] = {}
-    for key, img_data in data.items():
-        result[key] = _normalized_difference_image(
-            img_data, nir, swir, "ndwi", target_band
-        )
-    return RasterStack.from_images(result)
+    # Apply NDWI to each item in the stack (streaming when sole consumer)
+    return _apply_per_slice(
+        data,
+        lambda img: _normalized_difference_image(img, nir, swir, "ndwi", target_band),
+    )
 
 
 def ndvi(
@@ -156,9 +193,8 @@ def ndvi(
     Returns:
         RasterStack (Dict[datetime, ImageData]) containing NDVI results
     """
-    result: Dict[datetime, ImageData] = {}
-    for key, img_data in data.items():
-        result[key] = _normalized_difference_image(
-            img_data, nir, red, "ndvi", target_band
-        )
-    return RasterStack.from_images(result)
+    # Apply NDVI to each item in the stack (streaming when sole consumer)
+    return _apply_per_slice(
+        data,
+        lambda img: _normalized_difference_image(img, nir, red, "ndvi", target_band),
+    )

--- a/titiler/openeo/results_cache.py
+++ b/titiler/openeo/results_cache.py
@@ -79,6 +79,19 @@ def _release_value(value: Any) -> None:
         logger.debug("results_cache: release() failed, leaving value in place: %s", exc)
 
 
+def _tag_single_consumer(value: Any, is_single: bool) -> None:
+    """Mark a RasterStack result as having exactly one downstream consumer.
+
+    A sole consumer can stream-and-release the value slice-by-slice (no other node
+    will ever read it), which lets e.g. ``ndvi`` avoid holding the whole source
+    cube and the whole index cube at once.
+    """
+    from .processes.implementations.data_model import RasterStack
+
+    if isinstance(value, RasterStack):
+        value._single_consumer = is_single
+
+
 class EvictingResultsCache(dict):
     """``results_cache`` that frees a node's data once all consumers have run."""
 
@@ -108,6 +121,10 @@ class EvictingResultsCache(dict):
             # store represents this node consuming its parents.
             return
         self._stored.add(node)
+        # Tag whether this result has exactly one consumer (no consumer has run
+        # yet at store time, so _remaining[node] is the full consumer count). A
+        # sole consumer may stream-and-release this value safely.
+        _tag_single_consumer(value, self._remaining.get(node, 0) == 1)
         for parent in self._parents.get(node, ()):
             self._remaining[parent] = self._remaining.get(parent, 0) - 1
             if self._remaining[parent] <= 0:

--- a/titiler/openeo/results_cache.py
+++ b/titiler/openeo/results_cache.py
@@ -123,8 +123,12 @@ class EvictingResultsCache(dict):
         self._stored.add(node)
         # Tag whether this result has exactly one consumer (no consumer has run
         # yet at store time, so _remaining[node] is the full consumer count). A
-        # sole consumer may stream-and-release this value safely.
-        _tag_single_consumer(value, self._remaining.get(node, 0) == 1)
+        # sole consumer may stream-and-release this value safely. However, if the
+        # same object is reachable via multiple cache slots (identity passthrough),
+        # streaming would be unsafe, so disable the tag in that case.
+        is_single = self._remaining.get(node, 0) == 1
+        is_unique = sum(1 for v in self.values() if v is value) == 1
+        _tag_single_consumer(value, is_single and is_unique)
         for parent in self._parents.get(node, ()):
             self._remaining[parent] = self._remaining.get(parent, 0) - 1
             if self._remaining[parent] <= 0:


### PR DESCRIPTION
**Stacked on #311** (reference-counted eviction).

Eviction frees a cube *after* its producing node is done, but a single node can still briefly hold two full cubes — `ndvi` reads the whole source stack and builds the whole index stack at once.

The results cache tags a result whose graph has exactly **one** downstream consumer. `ndvi`/`ndwi` on such a sole-consumer input read the source in **concurrent windows** and `release()` each slice as soon as it is consumed, so the source and index cubes are never both fully resident. There are **no re-reads** (the sole consumer is the only reader); inputs with other consumers fall back to the plain non-mutating path.

> Review #311 first — this branch targets it, not `main`. (Diff shows only the streaming delta.)