### PR TITLE
feat: array_apply over temporal dimension + thread pool

### DIFF
--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -260,7 +260,7 @@ def test_array_apply_runs_concurrently_and_preserves_order():
     import threading
 
     n = 4
-    barrier = threading.Barrier(n, timeout=5)
+    barrier = threading.Barrier(n, timeout=30)
     seen_threads: set = set()
 
     def proc(x, positional_parameters=None, named_parameters=None):
@@ -636,18 +636,18 @@ def test_apply_dimension_temporal(sample_raster_stack):
 def test_apply_dimension_temporal_with_array_apply(sample_raster_stack):
     """Regression: array_apply works as the apply_dimension temporal callback.
 
-    Previously array_apply only accepted ``ArrayLike`` and rejected the
-    RasterStack passed by apply_dimension with
+    Previously apply_dimension passed the whole RasterStack to the temporal
+    callback, so array_apply (array-only per its spec) rejected it with
     ``TypeError: Parameter 'data' in process 'array_apply': expected 'array'
-    but got 'datacube'``. array_apply now accepts a RasterStack and maps the
-    process over the temporal dimension.
+    but got 'datacube'``. apply_dimension now passes an array-like lazy view, so
+    array_apply works as the callback without needing to accept a RasterStack.
     """
 
     def double(x, **kwargs):
         return x * 2.0
 
     def temporal_callback(data, **kwargs):
-        # data is the RasterStack; array_apply maps over the temporal dimension
+        # data is the lazy array view; array_apply maps over the temporal dimension
         return array_apply(data, double)
 
     result = apply_dimension(sample_raster_stack, temporal_callback, "temporal")

--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -255,6 +255,49 @@ def test_array_apply_with_simple_process():
     assert np.array_equal(result, np.array([2, 4, 6, 8, 10]))
 
 
+def test_array_apply_runs_concurrently_and_preserves_order():
+    """array_apply processes elements on a thread pool while keeping order."""
+    import threading
+
+    n = 4
+    barrier = threading.Barrier(n, timeout=5)
+    seen_threads: set = set()
+
+    def proc(x, positional_parameters=None, named_parameters=None):
+        seen_threads.add(threading.current_thread().name)
+        # If elements ran serially this would block until the timeout and raise
+        # BrokenBarrierError, so reaching past it proves concurrent execution.
+        barrier.wait()
+        return x + named_parameters["index"]
+
+    data = np.zeros((n, 2), dtype=float)
+    result = array_apply(data, proc, max_workers=n)
+
+    # Order preserved: element i is incremented by its own index.
+    for i in range(n):
+        np.testing.assert_array_equal(result[i], np.full((2,), i, dtype=float))
+    # Actually ran on more than one thread.
+    assert len(seen_threads) > 1
+
+
+def test_array_apply_serial_when_single_worker():
+    """max_workers=1 falls back to serial execution (no thread pool)."""
+    import threading
+
+    main_thread = threading.current_thread().name
+    used_threads: set = set()
+
+    def proc(x, positional_parameters=None, named_parameters=None):
+        used_threads.add(threading.current_thread().name)
+        return x * 2
+
+    data = np.array([1, 2, 3, 4])
+    result = array_apply(data, proc, max_workers=1)
+
+    assert np.array_equal(result, np.array([2, 4, 6, 8]))
+    assert used_threads == {main_thread}
+
+
 def test_array_apply_with_index_parameter():
     """Test array_apply with process that uses index parameter."""
 
@@ -521,17 +564,60 @@ def test_add_dimension():
         add_dimension(data=result, name="x", label="1", type="spatial")
 
 
+def test_lazy_temporal_array_defers_realization():
+    """The temporal callback receives a lazy array view that does not realize
+    pixels until it is actually consumed, and then yields one timestamp at a time.
+    """
+    from titiler.openeo.processes.implementations.apply import _LazyTemporalArray
+
+    realized = []
+
+    class _Img:
+        def __init__(self, key):
+            self._key = key
+
+        @property
+        def array(self):
+            realized.append(self._key)
+            return np.ma.array(np.full((1, 2, 2), self._key, np.uint8))
+
+    class _Stack(dict):
+        def keys(self):  # temporal order
+            return ["a", "b", "c"]
+
+        def __getitem__(self, k):
+            return _Img({"a": 1, "b": 2, "c": 3}[k])
+
+        def __len__(self):
+            return 3
+
+    lazy = _LazyTemporalArray(_Stack())
+
+    # Construction and len must not realize anything.
+    assert len(lazy) == 3
+    assert realized == []
+
+    # Iteration realizes lazily, one timestamp at a time, in order.
+    first = next(iter(lazy))
+    assert realized == [1]
+    assert first.shape == (1, 2, 2)
+
+    # numpy.asarray realizes the whole stack via the __array__ protocol.
+    realized.clear()
+    arr = np.asarray(lazy)
+    assert arr.shape == (3, 1, 2, 2)
+    assert realized == [1, 2, 3]
+
+
 def test_apply_dimension_temporal(sample_raster_stack):
     """Test apply_dimension on temporal dimension."""
 
     # Define a process that doubles values
     def double_process(data, **kwargs):
         """Process that doubles all values in the temporal series."""
-        # data is a RasterStack
-        result = []
-        for img in data.values():
-            result.append(img.array * 2)
-        return np.array(result)
+        # data is a lazy array view (n_times, bands, height, width); realize it
+        # like a real consumer (e.g. array_apply) would.
+        return np.asarray(data).astype(float) * 2
 
     result = apply_dimension(sample_raster_stack, double_process, "temporal")
 
@@ -547,14 +633,41 @@ def test_apply_dimension_temporal(sample_raster_stack):
         np.testing.assert_array_equal(doubled, original * 2)
 
 
+def test_apply_dimension_temporal_with_array_apply(sample_raster_stack):
+    """Regression: array_apply works as the apply_dimension temporal callback.
+
+    Previously array_apply only accepted ``ArrayLike`` and rejected the
+    RasterStack passed by apply_dimension with
+    ``TypeError: Parameter 'data' in process 'array_apply': expected 'array'
+    but got 'datacube'``. array_apply now accepts a RasterStack and maps the
+    process over the temporal dimension.
+    """
+
+    def double(x, **kwargs):
+        return x * 2.0
+
+    def temporal_callback(data, **kwargs):
+        # data is the RasterStack; array_apply maps over the temporal dimension
+        return array_apply(data, double)
+
+    result = apply_dimension(sample_raster_stack, temporal_callback, "temporal")
+
+    assert isinstance(result, dict)
+    assert len(result) == len(sample_raster_stack)
+    for key, img_data in result.items():
+        original = sample_raster_stack[key].array.data.astype("float")
+        doubled = img_data.array.data.astype("float")
+        np.testing.assert_array_equal(doubled, original * 2)
+
+
 def test_apply_dimension_temporal_with_target(sample_raster_stack):
     """Test apply_dimension on temporal dimension with target_dimension."""
 
     # Define a process that returns mean across time
     def mean_process(data, **kwargs):
         """Process that computes mean across temporal dimension."""
-        arrays = [img.array for img in data.values()]
-        return np.array([np.mean(arrays, axis=0)])
+        # data is a lazy array view (n_times, bands, height, width)
+        return np.array([np.mean(np.asarray(data), axis=0)])
 
     result = apply_dimension(
         sample_raster_stack, mean_process, "temporal", target_dimension="mean_time"
@@ -633,9 +746,9 @@ def test_apply_dimension_single_temporal_image(sample_image_data):
     dt = datetime.now()
     stack = RasterStack.from_images({dt: sample_image_data})
 
-    # Define a process
+    # Define a process (never invoked for a single-image stack)
     def some_process(data, **kwargs):
-        return np.array([img.array for img in data.values()])
+        return data
 
     # Should return unchanged when only one temporal image
     result = apply_dimension(stack, some_process, "temporal")
@@ -653,8 +766,8 @@ def test_apply_dimension_with_context(sample_raster_stack):
         """Process that uses context value."""
         context = kwargs.get("named_parameters", {}).get("context", {})
         multiplier = context.get("multiplier", 1)
-        arrays = [img.array * multiplier for img in data.values()]
-        return np.array(arrays)
+        # data is a lazy array view (n_times, bands, height, width)
+        return np.asarray(data).astype(float) * multiplier
 
     context = {"multiplier": 3}
     result = apply_dimension(
@@ -866,9 +979,9 @@ def test_apply_dimension_dimension_name_normalization(sample_raster_stack):
     """Test that dimension names are normalized correctly."""
 
     def temporal_process(data, **kwargs):
-        """Process for temporal dimension - receives RasterStack."""
-        arrays = [img.array * 2 for img in data.values()]
-        return np.array(arrays)
+        """Process for temporal dimension - receives a lazy array view."""
+        # data is a lazy array view (n_times, bands, height, width)
+        return np.asarray(data).astype(float) * 2
 
     def spectral_process(data, **kwargs):
         """Process for spectral dimension - receives numpy array."""

--- a/titiler/openeo/processes/implementations/apply.py
+++ b/titiler/openeo/processes/implementations/apply.py
@@ -11,6 +11,38 @@ from .data_model import ImageData, RasterStack
 __all__ = ["apply", "apply_dimension", "xyz_to_bbox", "xyz_to_tileinfo"]
 
 
+class _LazyTemporalArray:
+    """Lazy array view over the temporal dimension of a :class:`RasterStack`.
+
+    Presents an ``array`` interface so that array processes such as ``array_apply``
+    accept it (per the openEO ``apply_dimension`` spec the callback receives a
+    labeled array, not a datacube), while deferring pixel realization until a
+    consumer actually accesses the values. Iterating yields one timestamp's array
+    at a time; ``numpy.asarray`` stacks them into ``(n_times, bands, height, width)``
+    on demand.
+
+    This keeps ``_apply_temporal_dimension`` itself lazy — it never forces the whole
+    stack into memory; the consumer decides what to realize, mirroring how
+    ``reduce_dimension`` hands the RasterStack to its reducer.
+    """
+
+    def __init__(self, data: RasterStack):
+        self._data = data
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __iter__(self) -> Any:
+        # Realize one timestamp at a time, in temporal order, instead of
+        # ``values()`` which executes every task up front.
+        for key in self._data.keys():
+            yield self._data[key].array
+
+    def __array__(self, dtype: Optional[Any] = None) -> numpy.ndarray:
+        stacked = numpy.ma.stack(list(self))
+        return stacked.astype(dtype) if dtype is not None else stacked
+
+
 class DimensionNotAvailable(Exception):
     """Exception raised when a dimension is not available."""
 
@@ -117,6 +149,10 @@ def _apply_temporal_dimension(
 ) -> RasterStack:
     """Apply a process to the temporal dimension of a RasterStack.
 
+    The callback receives the temporal series as a lazy array view of shape
+    ``(n_times, bands, height, width)`` (realized on access via ``numpy.asarray``)
+    and must return a numpy array.
+
     Args:
         data: A RasterStack with temporal dimension
         process: A process function to apply on the temporal dimension
@@ -135,10 +171,16 @@ def _apply_temporal_dimension(
             "Expected a non-empty RasterStack for temporal dimension processing"
         )
 
+    # Per the openEO ``apply_dimension`` spec the callback receives the values
+    # along the dimension as an array (a labeled array), not the datacube itself.
+    # Pass a lazy array view so this function does not realize the whole stack;
+    # the consumer (e.g. ``array_apply`` via ``numpy.asarray``) drives realization,
+    # keeping the temporal path as lazy as the spectral path and ``reduce_dimension``.
+    stacked = _LazyTemporalArray(data)
+
     # Apply the process to the temporal dimension
-    # The process receives the entire stack and should return modified data
     result_array = process(
-        data,  # Pass as positional argument
+        stacked,  # Pass as positional argument (a lazy (n_times, ...) array view)
         positional_parameters=positional_parameters,
         named_parameters=named_parameters,
     )

--- a/titiler/openeo/processes/implementations/arrays.py
+++ b/titiler/openeo/processes/implementations/arrays.py
@@ -1,11 +1,13 @@
 """titiler.processes.implementations arrays."""
 
 import logging
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import numpy
 from numpy.typing import ArrayLike
+from rio_tiler.constants import MAX_THREADS
 from rio_tiler.models import ImageData
 
 from ...errors import OpenEOException
@@ -427,11 +429,17 @@ def array_apply(
     data: ArrayLike,
     process: Callable,
     context: Optional[Any] = None,
+    max_workers: int = MAX_THREADS,
 ) -> ArrayLike:
     """Apply a process to each element in an array.
 
     Applies a process to each individual value in the array. This is basically
     what other languages call either a `for each` loop or a `map` function.
+
+    Elements are processed concurrently with a thread pool: the per-element calls
+    are independent, numpy releases the GIL during array operations, and any lazy
+    data realization (e.g. a temporal array view backed by a RasterStack) is
+    I/O-bound, so threading gives real speedups. Result order is preserved.
 
     Args:
         data: An array to process
@@ -442,6 +450,7 @@ def array_apply(
                  - label: The label of the element (only for labeled arrays, optional)
                  - context: Additional data passed by the user (optional)
         context: Additional data to be passed to the process
+        max_workers: Maximum number of threads used to process elements concurrently
 
     Returns:
         An array with the newly computed values. The number of elements is the
@@ -454,10 +463,7 @@ def array_apply(
     if arr.ndim == 0:
         arr = numpy.array([arr.item()])
 
-    # Process each element along the first dimension
-    result_list: List[Any] = []
-
-    for index, value in enumerate(arr):
+    def _apply_one(index: int, value: Any) -> Any:
         # Set up parameters for the process
         # Only 'x' is passed as positional parameter (position 0)
         positional_parameters = {"x": 0}
@@ -467,14 +473,22 @@ def array_apply(
             "label": None,
             "context": context,
         }
-
-        # Call the process with the current value
-        processed_value = process(
+        return process(
             value,
             positional_parameters=positional_parameters,
             named_parameters=named_parameters,
         )
-        result_list.append(processed_value)
+
+    # Process each element along the first dimension
+    n = len(arr)
+    if n <= 1 or max_workers <= 1:
+        # Avoid thread-pool overhead for trivial cases
+        result_list: List[Any] = [_apply_one(i, v) for i, v in enumerate(arr)]
+    else:
+        # ``executor.map`` preserves input order, so results stay aligned with
+        # the original elements.
+        with ThreadPoolExecutor(max_workers=min(max_workers, n)) as executor:
+            result_list = list(executor.map(_apply_one, range(n), arr))
 
     # Convert result back to array
     result_arr = numpy.array(result_list)

--- a/titiler/openeo/processes/implementations/arrays.py
+++ b/titiler/openeo/processes/implementations/arrays.py
@@ -437,9 +437,11 @@ def array_apply(
     what other languages call either a `for each` loop or a `map` function.
 
     Elements are processed concurrently with a thread pool: the per-element calls
-    are independent, numpy releases the GIL during array operations, and any lazy
-    data realization (e.g. a temporal array view backed by a RasterStack) is
-    I/O-bound, so threading gives real speedups. Result order is preserved.
+    are independent and numpy releases the GIL during array operations, so the
+    per-element work can overlap. Note that ``data`` is materialized up front via
+    ``numpy.asarray`` (a lazy view such as ``_LazyTemporalArray`` is realized at
+    that point), so the speedup comes from the concurrent ``process`` calls, not
+    from the realization. Result order is preserved.
 
     Args:
         data: An array to process


### PR DESCRIPTION
## Why

`apply_dimension(dimension="t")` passed the whole `RasterStack` (a datacube) to its callback, so `array_apply` — array-only per its spec — failed with:

```
TypeError: Parameter 'data' in process 'array_apply': expected 'array' but got 'datacube'
```

## What

- **Temporal callback now receives an array, not a datacube.** `_apply_temporal_dimension` hands the callback a lazy `_LazyTemporalArray` view of shape `(n_times, bands, h, w)` via the numpy `__array__` protocol. This matches the openEO `apply_dimension` contract (callback gets a labeled array) and the existing spectral path's axis-0 convention, while deferring pixel realization to the consumer (mirroring `reduce_dimension`'s laziness). `array_apply` stays unchanged per its spec.
- **`array_apply` runs on a thread pool.** Elements are processed concurrently (`executor.map` preserves order); `max_workers` defaults to `MAX_THREADS` with a serial fallback for `max_workers<=1` or single-element arrays.

## Tests

- `test_apply_dimension_temporal_with_array_apply` — the original failing composition.
- `test_lazy_temporal_array_defers_realization` — construction/`len` don't realize; iteration realizes one timestamp at a time; `asarray` realizes the full stack.
- `test_array_apply_runs_concurrently_and_preserves_order` (Barrier-based concurrency proof) and `test_array_apply_serial_when_single_worker`.
- Existing temporal `apply_dimension` callbacks updated to realize the view via `np.asarray`, as real consumers do.

Full suite: 691 passed, 12 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)