### PR TITLE
fix: evaluate callbacks exactly once + graph integration tests

### DIFF
--- a/tests/test_apply_graph_integration.py
+++ b/tests/test_apply_graph_integration.py
@@ -1,0 +1,151 @@
+"""Process-graph integration tests for apply / apply_dimension / array_apply.
+
+These run the processes through the real openEO executor
+(``OpenEOProcessGraph.to_callable``), so the callback is the actual
+``node_callable`` with its shared ``results_cache`` — the path that plain-Python
+callback unit tests bypass.
+
+They guard against the class of bug documented in apply.py / reduce.py: invoking
+a callback more than once returns the first call's cached result (or, run
+concurrently, crashes with the child process missing its ``data``). Each test
+below would fail on the previous per-element / per-image implementations.
+"""
+
+from datetime import datetime
+
+import numpy as np
+from openeo_pg_parser_networkx.graph import OpenEOProcessGraph
+from rio_tiler.models import ImageData
+
+from titiler.openeo.processes import process_registry
+from titiler.openeo.processes.implementations.data_model import RasterStack
+
+
+def _run(pg: dict, **named_parameters):
+    """Compile and execute a process graph against the real registry."""
+    callable_ = OpenEOProcessGraph(pg_data={"process_graph": pg}).to_callable(
+        process_registry=process_registry
+    )
+    return callable_(named_parameters=named_parameters)
+
+
+def _two_image_stack() -> RasterStack:
+    """A 2-timestamp stack with distinct constant values (1 and 5)."""
+    return RasterStack.from_images(
+        {
+            datetime(2021, 1, 1): ImageData(
+                np.ma.array(np.full((1, 2, 2), 1, np.uint8))
+            ),
+            datetime(2021, 1, 2): ImageData(
+                np.ma.array(np.full((1, 2, 2), 5, np.uint8))
+            ),
+        }
+    )
+
+
+def test_array_apply_via_graph_maps_each_element():
+    """array_apply must apply the child process to every element, not just the first.
+
+    The old per-element loop returned the first element's cached result for all
+    elements (e.g. [10, 10, 10, 10]).
+    """
+    pg = {
+        "data": {
+            "process_id": "array_create",
+            "arguments": {"data": [1.0, 2.0, 3.0, 4.0]},
+        },
+        "apply": {
+            "process_id": "array_apply",
+            "arguments": {
+                "data": {"from_node": "data"},
+                "process": {
+                    "process_graph": {
+                        "mul": {
+                            "process_id": "multiply",
+                            "arguments": {"x": {"from_parameter": "x"}, "y": 10},
+                            "result": True,
+                        }
+                    }
+                },
+            },
+            "result": True,
+        },
+    }
+    result = np.asarray(_run(pg))
+    np.testing.assert_array_equal(result, np.array([10.0, 20.0, 30.0, 40.0]))
+
+
+def test_apply_via_graph_maps_each_image():
+    """apply must apply the callback to every image in the stack independently.
+
+    The old per-image loop returned the first image's cached result for every
+    timestamp.
+    """
+    pg = {
+        "ap": {
+            "process_id": "apply",
+            "arguments": {
+                "data": {"from_parameter": "data"},
+                "process": {
+                    "process_graph": {
+                        "mul": {
+                            "process_id": "multiply",
+                            "arguments": {"x": {"from_parameter": "x"}, "y": 10},
+                            "result": True,
+                        }
+                    }
+                },
+            },
+            "result": True,
+        }
+    }
+    result = _run(pg, data=_two_image_stack())
+    by_ts = {k: v.array.data.ravel().tolist() for k, v in result.items()}
+    assert by_ts[datetime(2021, 1, 1)] == [10, 10, 10, 10]
+    assert by_ts[datetime(2021, 1, 2)] == [50, 50, 50, 50]
+
+
+def test_apply_dimension_temporal_array_apply_via_graph():
+    """The originally reported scenario: apply_dimension(t) -> array_apply -> multiply.
+
+    Previously this raised ``expected 'array' but got 'datacube'`` (datacube passed
+    to array_apply) and later crashed under the thread pool. It must now compute
+    each timestamp correctly.
+    """
+    pg = {
+        "ad": {
+            "process_id": "apply_dimension",
+            "arguments": {
+                "data": {"from_parameter": "data"},
+                "dimension": "t",
+                "process": {
+                    "process_graph": {
+                        "aa": {
+                            "process_id": "array_apply",
+                            "arguments": {
+                                "data": {"from_parameter": "data"},
+                                "process": {
+                                    "process_graph": {
+                                        "mul": {
+                                            "process_id": "multiply",
+                                            "arguments": {
+                                                "x": {"from_parameter": "x"},
+                                                "y": 2,
+                                            },
+                                            "result": True,
+                                        }
+                                    }
+                                },
+                            },
+                            "result": True,
+                        }
+                    }
+                },
+            },
+            "result": True,
+        }
+    }
+    result = _run(pg, data=_two_image_stack())
+    by_ts = {k: v.array.data.ravel().tolist() for k, v in result.items()}
+    assert by_ts[datetime(2021, 1, 1)] == [2, 2, 2, 2]
+    assert by_ts[datetime(2021, 1, 2)] == [10, 10, 10, 10]

--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -144,9 +144,10 @@ def test_ndwi(sample_raster_stack):
 def test_apply(sample_raster_stack):
     """Test the apply function."""
 
-    # Apply a simple function that doubles values
+    # Apply a simple function that doubles values. The callback receives a lazy
+    # array view, so realize it like a real openEO callback would.
     def double(x, **kwargs):
-        return x * 2
+        return np.asarray(x).astype(float) * 2
 
     result = apply(sample_raster_stack, double)
 
@@ -255,49 +256,6 @@ def test_array_apply_with_simple_process():
     assert np.array_equal(result, np.array([2, 4, 6, 8, 10]))
 
 
-def test_array_apply_runs_concurrently_and_preserves_order():
-    """array_apply processes elements on a thread pool while keeping order."""
-    import threading
-
-    n = 4
-    barrier = threading.Barrier(n, timeout=30)
-    seen_threads: set = set()
-
-    def proc(x, positional_parameters=None, named_parameters=None):
-        seen_threads.add(threading.current_thread().name)
-        # If elements ran serially this would block until the timeout and raise
-        # BrokenBarrierError, so reaching past it proves concurrent execution.
-        barrier.wait()
-        return x + named_parameters["index"]
-
-    data = np.zeros((n, 2), dtype=float)
-    result = array_apply(data, proc, max_workers=n)
-
-    # Order preserved: element i is incremented by its own index.
-    for i in range(n):
-        np.testing.assert_array_equal(result[i], np.full((2,), i, dtype=float))
-    # Actually ran on more than one thread.
-    assert len(seen_threads) > 1
-
-
-def test_array_apply_serial_when_single_worker():
-    """max_workers=1 falls back to serial execution (no thread pool)."""
-    import threading
-
-    main_thread = threading.current_thread().name
-    used_threads: set = set()
-
-    def proc(x, positional_parameters=None, named_parameters=None):
-        used_threads.add(threading.current_thread().name)
-        return x * 2
-
-    data = np.array([1, 2, 3, 4])
-    result = array_apply(data, proc, max_workers=1)
-
-    assert np.array_equal(result, np.array([2, 4, 6, 8]))
-    assert used_threads == {main_thread}
-
-
 def test_array_apply_with_index_parameter():
     """Test array_apply with process that uses index parameter."""
 
@@ -358,10 +316,10 @@ def test_array_apply_with_context():
 def test_array_apply_with_float_array():
     """Test array_apply with floating point array."""
 
-    # Define a process that computes square root
+    # Define a vectorized process that computes square root (nan for negatives)
     def sqrt_process(x, positional_parameters=None, named_parameters=None):
         """Process that computes square root."""
-        return np.sqrt(x) if x >= 0 else np.nan
+        return np.sqrt(np.where(x >= 0, x, np.nan))
 
     # Test with float array
     data = np.array([1.0, 4.0, 9.0, 16.0, 25.0])
@@ -443,30 +401,25 @@ def test_array_apply_label_parameter_none():
     result = array_apply(data, label_check_process)
 
     assert isinstance(result, np.ndarray)
-    # All labels should be None for regular arrays
-    assert all(label is None for label in labels_received)
-    assert len(labels_received) == 3
+    # The callback is evaluated once (vectorized) and label is None for plain arrays
+    assert labels_received == [None]
 
 
-def test_array_apply_reshape_handling():
-    """Test array_apply with processes that return object types."""
+def test_array_apply_index_broadcasts_over_leading_axis():
+    """index is the position along the leading axis, broadcast over each element."""
 
-    # Define a process that returns the sum of each element
-    def sum_process(x, positional_parameters=None, named_parameters=None):
-        """Process that returns sum of array element."""
-        if isinstance(x, np.ndarray):
-            return np.sum(x)
-        return x
+    # Add each element's index to the element (element = a row here)
+    def add_index(x, positional_parameters=None, named_parameters=None):
+        return x + named_parameters["index"]
 
-    # Test with 2D array - each row is summed
+    # 2D array: 2 elements along axis 0
     data = np.array([[1, 2], [3, 4]])
-    result = array_apply(data, sum_process)
+    result = array_apply(data, add_index)
 
     assert isinstance(result, np.ndarray)
-    # Result should have 2 elements (one sum per row)
     assert len(result) == 2
-    # Sums: [1+2=3, 3+4=7]
-    np.testing.assert_array_equal(result, np.array([3, 7]))
+    # row 0 += 0, row 1 += 1
+    np.testing.assert_array_equal(result, np.array([[1, 2], [4, 5]]))
 
 
 def test_array_apply_with_empty_dict():
@@ -477,15 +430,12 @@ def test_array_apply_with_empty_dict():
         """Process that records label."""
         return named_parameters.get("label")
 
-    # Test with empty dict
+    # Test with empty dict (degenerate input; array_apply is array-only)
     data = {}
     result = array_apply(data, record_label_process)
 
-    # Empty dict becomes single-element array
-    assert isinstance(result, np.ndarray)
-    assert len(result) == 1
-    # Label should be None (dicts are not supported, always None)
-    assert result[0] is None
+    # The callback is evaluated once and label is None for non-labeled input.
+    assert np.asarray(result).item() is None
 
 
 def test_array_apply_preserves_element_type():
@@ -568,7 +518,7 @@ def test_lazy_temporal_array_defers_realization():
     """The temporal callback receives a lazy array view that does not realize
     pixels until it is actually consumed, and then yields one timestamp at a time.
     """
-    from titiler.openeo.processes.implementations.apply import _LazyTemporalArray
+    from titiler.openeo.processes.implementations.apply import _LazyStackedArray
 
     realized = []
 
@@ -591,7 +541,7 @@ def test_lazy_temporal_array_defers_realization():
         def __len__(self):
             return 3
 
-    lazy = _LazyTemporalArray(_Stack())
+    lazy = _LazyStackedArray(_Stack())
 
     # Construction and len must not realize anything.
     assert len(lazy) == 3

--- a/titiler/openeo/processes/implementations/apply.py
+++ b/titiler/openeo/processes/implementations/apply.py
@@ -1,4 +1,35 @@
-"""titiler.openeo.processes Apply."""
+"""titiler.openeo.processes Apply.
+
+CRITICAL DEVELOPER WARNING - CALLBACK INVOCATION PATTERN
+========================================================
+
+The ``process``/callback passed to ``apply``, ``apply_dimension`` and ``array_apply``
+is an openEO process graph compiled by openeo_pg_parser_networkx. Its ``node_callable``
+memoizes each node's result in a **shared** ``results_cache`` (and mutates the graph's
+``resolved_kwargs`` on every call). Therefore you MUST call each callback EXACTLY ONCE
+per operation.
+
+KEY REQUIREMENTS:
+-----------------
+1. **NEVER iterate and call the callback per element/image**
+   ❌ BAD:  results = [process(x=item) for item in data]
+   ✅ GOOD: stacked = stack_all(data); result = process(x=stacked)
+
+   Calling the callback more than once returns the FIRST call's cached result for
+   every subsequent call (and, run concurrently, corrupts argument resolution —
+   e.g. a child ``max`` ends up with no ``data``). Rely on numpy broadcasting to map
+   a vectorized callback over every element in a single call instead.
+
+2. **Why this matters:** this is the same caching pitfall documented in reduce.py;
+   it has caused production issues (silent wrong results) more than once.
+
+3. **Testing requirements:** cover these processes with *process-graph* integration
+   tests (build an ``OpenEOProcessGraph`` and run it via ``to_callable``), not only
+   plain-Python callbacks — the latter have no shared cache and hide the bug.
+
+NOTE: ``_apply_spectral_dimension_stack`` still iterates per image; it is only correct
+for single-image stacks and must be reworked to a single stacked call (see issue).
+"""
 
 from typing import Any, Callable, Dict, Optional
 
@@ -11,19 +42,18 @@ from .data_model import ImageData, RasterStack
 __all__ = ["apply", "apply_dimension", "xyz_to_bbox", "xyz_to_tileinfo"]
 
 
-class _LazyTemporalArray:
-    """Lazy array view over the temporal dimension of a :class:`RasterStack`.
+class _LazyStackedArray(numpy.lib.mixins.NDArrayOperatorsMixin):
+    """Lazy ``(n, bands, height, width)`` array view over a :class:`RasterStack`.
 
-    Presents an ``array`` interface so that array processes such as ``array_apply``
-    accept it (per the openEO ``apply_dimension`` spec the callback receives a
-    labeled array, not a datacube), while deferring pixel realization until a
-    consumer actually accesses the values. Iterating yields one timestamp's array
-    at a time; ``numpy.asarray`` stacks them into ``(n_times, bands, height, width)``
-    on demand.
+    Behaves like a numpy array (via :class:`~numpy.lib.mixins.NDArrayOperatorsMixin`
+    and ``__array_ufunc__``) so it can be passed straight into an openEO callback —
+    including leaf processes that operate on it directly (e.g. ``multiply`` does
+    ``x * y``) and ``array_apply`` (which calls ``numpy.asarray``) — while deferring
+    pixel realization until the first operation/access.
 
-    This keeps ``_apply_temporal_dimension`` itself lazy — it never forces the whole
-    stack into memory; the consumer decides what to realize, mirroring how
-    ``reduce_dimension`` hands the RasterStack to its reducer.
+    This lets callers stack-and-call-the-callback-once (see module warning) without
+    eagerly forcing the whole stack into memory: realization is driven by the
+    consumer, mirroring how ``reduce_dimension`` hands the RasterStack to its reducer.
     """
 
     def __init__(self, data: RasterStack):
@@ -33,14 +63,30 @@ class _LazyTemporalArray:
         return len(self._data)
 
     def __iter__(self) -> Any:
-        # Realize one timestamp at a time, in temporal order, instead of
-        # ``values()`` which executes every task up front.
+        # Realize one image at a time, in key order, instead of ``values()`` which
+        # executes every task up front.
         for key in self._data.keys():
             yield self._data[key].array
 
     def __array__(self, dtype: Optional[Any] = None) -> numpy.ndarray:
         stacked = numpy.ma.stack(list(self))
         return stacked.astype(dtype) if dtype is not None else stacked
+
+    def __array_ufunc__(self, ufunc: Any, method: str, *inputs: Any, **kwargs: Any):
+        # Realize any lazy operands, then delegate to numpy. This makes the view
+        # usable directly by leaf processes (``x * y``) while deferring realization
+        # until the first ufunc is applied.
+        resolved = tuple(
+            numpy.asanyarray(i) if isinstance(i, _LazyStackedArray) else i
+            for i in inputs
+        )
+        out = kwargs.get("out")
+        if out:
+            kwargs["out"] = tuple(
+                numpy.asanyarray(o) if isinstance(o, _LazyStackedArray) else o
+                for o in out
+            )
+        return getattr(ufunc, method)(*resolved, **kwargs)
 
 
 class DimensionNotAvailable(Exception):
@@ -58,25 +104,42 @@ def apply(
     process: Callable,
     context: Optional[Any] = None,
 ) -> RasterStack:
-    """Apply process on RasterStack."""
-    positional_parameters = {"x": 0}
-    named_parameters = {"context": context}
+    """Apply a unary process to every value in a RasterStack.
 
-    def _process_img(img: ImageData):
-        return ImageData(
-            process(
-                img.array,
-                positional_parameters=positional_parameters,
-                named_parameters=named_parameters,
-            ),
-            assets=img.assets,
-            crs=img.crs,
-            bounds=img.bounds,
+    The callback is evaluated ONCE on the stacked array (see the module-level
+    warning): images are stacked to ``(n, bands, height, width)``, the vectorized
+    callback maps over every value, then the result is split back per timestamp.
+    Calling the callback per image (the previous design) returned the first image's
+    cached result for every subsequent image.
+    """
+    keys = list(data.keys())
+    if not keys:
+        return data
+
+    # Realize per-image metadata without loading pixels (lazy refs).
+    refs = dict(data.get_image_refs())
+
+    # Lazy (n, bands, h, w) view; the callback realizes it once via numpy.asarray.
+    stacked = _LazyStackedArray(data)
+    result = numpy.asanyarray(
+        process(
+            stacked,
+            positional_parameters={"x": 0},
+            named_parameters={"x": stacked, "context": context},
         )
+    )
 
-    # Apply process to each item in the stack
-    result = {k: _process_img(img) for k, img in data.items()}
-    return RasterStack.from_images(result)
+    out: Dict[Any, ImageData] = {}
+    for i, key in enumerate(keys):
+        ref = refs.get(key)
+        out[key] = ImageData(
+            result[i],
+            assets=[key],
+            crs=ref.crs if ref else None,
+            bounds=ref.bounds if ref else None,
+            band_descriptions=ref.band_names if ref and ref.band_names else [],
+        )
+    return RasterStack.from_images(out)
 
 
 def apply_dimension(
@@ -176,7 +239,7 @@ def _apply_temporal_dimension(
     # Pass a lazy array view so this function does not realize the whole stack;
     # the consumer (e.g. ``array_apply`` via ``numpy.asarray``) drives realization,
     # keeping the temporal path as lazy as the spectral path and ``reduce_dimension``.
-    stacked = _LazyTemporalArray(data)
+    stacked = _LazyStackedArray(data)
 
     # Apply the process to the temporal dimension
     result_array = process(

--- a/titiler/openeo/processes/implementations/apply.py
+++ b/titiler/openeo/processes/implementations/apply.py
@@ -116,9 +116,6 @@ def apply(
     if not keys:
         return data
 
-    # Realize per-image metadata without loading pixels (lazy refs).
-    refs = dict(data.get_image_refs())
-
     # Lazy (n, bands, h, w) view; the callback realizes it once via numpy.asarray.
     stacked = _LazyStackedArray(data)
     result = numpy.asanyarray(
@@ -129,15 +126,17 @@ def apply(
         )
     )
 
+    # Preserve each image's metadata. Realizing the stack above already cached the
+    # ImageData instances, so ``data[key]`` is a cache hit (no extra I/O).
     out: Dict[Any, ImageData] = {}
     for i, key in enumerate(keys):
-        ref = refs.get(key)
+        img = data[key]
         out[key] = ImageData(
             result[i],
-            assets=[key],
-            crs=ref.crs if ref else None,
-            bounds=ref.bounds if ref else None,
-            band_descriptions=ref.band_names if ref and ref.band_names else [],
+            assets=img.assets,
+            crs=img.crs,
+            bounds=img.bounds,
+            band_descriptions=img.band_descriptions,
         )
     return RasterStack.from_images(out)
 

--- a/titiler/openeo/processes/implementations/arrays.py
+++ b/titiler/openeo/processes/implementations/arrays.py
@@ -451,11 +451,13 @@ def array_apply(
 
     Args:
         data: An array to process
-        process: A process that accepts and returns a single value. The process
-                 receives the following parameters:
-                 - x: The value of the current element (any data type)
-                 - index: The zero-based index of the element (integer)
-                 - label: The label of the element (only for labeled arrays, optional)
+        process: A vectorized process applied to all elements at once (NOT once per
+                 element — see the apply.py callback warning). It must operate on
+                 whole numpy arrays rather than Python scalars. It receives:
+                 - x: The whole array of element values (numpy array)
+                 - index: The zero-based element index along the leading axis, shaped
+                          to broadcast over each element's dimensions
+                 - label: The element label (only for labeled arrays, ``None`` here)
                  - context: Additional data passed by the user (optional)
         context: Additional data to be passed to the process
 

--- a/titiler/openeo/processes/implementations/arrays.py
+++ b/titiler/openeo/processes/implementations/arrays.py
@@ -1,13 +1,11 @@
 """titiler.processes.implementations arrays."""
 
 import logging
-from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import numpy
 from numpy.typing import ArrayLike
-from rio_tiler.constants import MAX_THREADS
 from rio_tiler.models import ImageData
 
 from ...errors import OpenEOException
@@ -429,19 +427,27 @@ def array_apply(
     data: ArrayLike,
     process: Callable,
     context: Optional[Any] = None,
-    max_workers: int = MAX_THREADS,
 ) -> ArrayLike:
     """Apply a process to each element in an array.
 
     Applies a process to each individual value in the array. This is basically
     what other languages call either a `for each` loop or a `map` function.
 
-    Elements are processed concurrently with a thread pool: the per-element calls
-    are independent and numpy releases the GIL during array operations, so the
-    per-element work can overlap. Note that ``data`` is materialized up front via
-    ``numpy.asarray`` (a lazy view such as ``_LazyTemporalArray`` is realized at
-    that point), so the speedup comes from the concurrent ``process`` calls, not
-    from the realization. Result order is preserved.
+    The callback is a vectorized openEO process graph, so it is evaluated **once**
+    on the whole array and numpy broadcasting maps it over every element. This is
+    both correct and efficient:
+
+    - Correct: the openEO graph executor (openeo_pg_parser_networkx) memoizes each
+      callback node by id in a shared ``results_cache``. Invoking the callback once
+      per element — as a Python loop would — returns the first element's cached
+      result for every subsequent element (and, run concurrently, corrupts the
+      shared argument resolution). Evaluating it once sidesteps this entirely.
+    - Efficient: no Python-level per-element loop; the work happens in numpy.
+
+    Elements are taken along the leading axis. ``index`` is supplied as the
+    zero-based position along that axis, shaped to broadcast over the remaining
+    axes so callbacks may use it. ``label`` is only populated for labeled arrays
+    and is ``None`` here.
 
     Args:
         data: An array to process
@@ -452,47 +458,34 @@ def array_apply(
                  - label: The label of the element (only for labeled arrays, optional)
                  - context: Additional data passed by the user (optional)
         context: Additional data to be passed to the process
-        max_workers: Maximum number of threads used to process elements concurrently
 
     Returns:
         An array with the newly computed values. The number of elements is the
         same as for the original array.
     """
-    # Convert input to numpy array if needed
-    arr = numpy.asarray(data)
+    # Convert input to numpy array if needed, preserving masks
+    arr = numpy.asanyarray(data)
 
-    # Handle scalar case
+    # Handle scalar case (treat as a single-element array)
     if arr.ndim == 0:
-        arr = numpy.array([arr.item()])
+        arr = arr.reshape(1)
 
-    def _apply_one(index: int, value: Any) -> Any:
-        # Set up parameters for the process
-        # Only 'x' is passed as positional parameter (position 0)
-        positional_parameters = {"x": 0}
-        named_parameters = {
-            "x": value,
+    # Zero-based index per leading-axis element, shaped to broadcast over the
+    # element's own dimensions (so ``x * index`` works element-wise).
+    n = arr.shape[0]
+    index = numpy.arange(n).reshape((n,) + (1,) * (arr.ndim - 1))
+
+    # Evaluate the callback once on the whole array; broadcasting maps it over
+    # every element.
+    result = process(
+        arr,
+        positional_parameters={"x": 0},
+        named_parameters={
+            "x": arr,
             "index": index,
             "label": None,
             "context": context,
-        }
-        return process(
-            value,
-            positional_parameters=positional_parameters,
-            named_parameters=named_parameters,
-        )
+        },
+    )
 
-    # Process each element along the first dimension
-    n = len(arr)
-    if n <= 1 or max_workers <= 1:
-        # Avoid thread-pool overhead for trivial cases
-        result_list: List[Any] = [_apply_one(i, v) for i, v in enumerate(arr)]
-    else:
-        # ``executor.map`` preserves input order, so results stay aligned with
-        # the original elements.
-        with ThreadPoolExecutor(max_workers=min(max_workers, n)) as executor:
-            result_list = list(executor.map(_apply_one, range(n), arr))
-
-    # Convert result back to array
-    result_arr = numpy.array(result_list)
-
-    return result_arr
+    return numpy.asanyarray(result)


### PR DESCRIPTION
## The bug

The openEO callback compiled by `openeo_pg_parser_networkx` (`node_callable`) memoizes each node's result in a **shared `results_cache`**. So calling a callback **more than once** returns the *first* call's cached result for every subsequent call — and, run concurrently, corrupts argument resolution.

`array_apply` and `apply` both invoked the callback **per element / per image**, so with a *real* process graph they returned wrong results:

```
apply(multiply x10) over [img=1, img=5]  ->  {ts1: 10, ts2: 10}   # ts2 should be 50
array_apply(multiply x10) over [1,2,3,4] ->  [10, 10, 10, 10]      # should be [10,20,30,40]
```

The thread pool merged in #315 turned this latent bug into a hard crash:
`TypeError: max() missing 1 required positional argument: 'data'`.

This is the **same caching pitfall already documented in `reduce.py`** ("has caused production issues… more than once"). It was never caught because the unit tests use plain-Python callbacks, which have no shared cache.

## The fix — call each callback exactly once

- **`array_apply`**: evaluate the vectorized callback **once** on the whole array; numpy broadcasting maps it over every element. `index` is provided broadcast along the leading axis. Removes the per-element loop and the unsafe thread pool.
- **`apply`**: stack the RasterStack and call the callback **once**, then split results back per timestamp (was a per-image loop).
- **`_LazyStackedArray`**: now a numpy duck-array (`NDArrayOperatorsMixin` + `__array_ufunc__`) so it can be passed straight into leaf callbacks like `multiply` (which do `x * y`) **and** `array_apply` (which calls `numpy.asarray`), while still deferring realization until first use. Shared by `apply` and the temporal `apply_dimension` path.
- **Disclaimer**: module-level `CRITICAL DEVELOPER WARNING` in `apply.py`, mirroring `reduce.py`.

## Closing the test gap

New `tests/test_apply_graph_integration.py` runs `array_apply` / `apply` / `apply_dimension(t)+array_apply` through the real `OpenEOProcessGraph.to_callable` executor — the `node_callable` path the plain-Python unit tests bypass. Each test fails on the old implementations and passes now.

Existing `array_apply`/`apply` unit tests updated to vectorized semantics.

Full suite: **692 passed, 12 skipped**.

## Known follow-up

`_apply_spectral_dimension_stack` still iterates per image (flagged in the warning); it's only correct for single-image stacks and should be reworked to a single stacked call in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)