### PR TITLE
fix: forward enclosing scope to array_apply callbacks + realized arrays

### DIFF
--- a/tests/test_apply_graph_integration.py
+++ b/tests/test_apply_graph_integration.py
@@ -29,6 +29,23 @@ def _run(pg: dict, **named_parameters):
     return callable_(named_parameters=named_parameters)
 
 
+def _three_image_stack() -> RasterStack:
+    """A 3-timestamp single-band stack with values 3, 7, 5 (temporal max is 7)."""
+    return RasterStack.from_images(
+        {
+            datetime(2024, 6, 1): ImageData(
+                np.ma.array(np.full((1, 2, 2), 3, np.float32))
+            ),
+            datetime(2024, 6, 2): ImageData(
+                np.ma.array(np.full((1, 2, 2), 7, np.float32))
+            ),
+            datetime(2024, 6, 3): ImageData(
+                np.ma.array(np.full((1, 2, 2), 5, np.float32))
+            ),
+        }
+    )
+
+
 def _two_image_stack() -> RasterStack:
     """A 2-timestamp stack with distinct constant values (1 and 5)."""
     return RasterStack.from_images(
@@ -149,3 +166,60 @@ def test_apply_dimension_temporal_array_apply_via_graph():
     by_ts = {k: v.array.data.ravel().tolist() for k, v in result.items()}
     assert by_ts[datetime(2021, 1, 1)] == [2, 2, 2, 2]
     assert by_ts[datetime(2021, 1, 2)] == [10, 10, 10, 10]
+
+
+def test_array_apply_callback_references_enclosing_scope():
+    """array_apply callbacks may reference an outer-scope parameter (`data`).
+
+    Real-world pattern: apply_dimension(t) -> array_apply(neq(x, max(data))), where
+    `max(data)` refers to the enclosing apply_dimension array (the whole temporal
+    series), not array_apply's element `x`. array_apply must forward the enclosing
+    `named_parameters` so the nested `from_parameter: data` resolves; otherwise the
+    child `max` is called with no `data`. The callback input must also be a realized
+    array, since `max` type-checks with isinstance(numpy.ndarray).
+    """
+    pg = {
+        "ad": {
+            "process_id": "apply_dimension",
+            "arguments": {
+                "data": {"from_parameter": "data"},
+                "dimension": "t",
+                "process": {
+                    "process_graph": {
+                        "arrayapply1": {
+                            "process_id": "array_apply",
+                            "arguments": {
+                                "data": {"from_parameter": "data"},
+                                "process": {
+                                    "process_graph": {
+                                        "max1": {
+                                            "process_id": "max",
+                                            "arguments": {
+                                                "data": {"from_parameter": "data"}
+                                            },
+                                        },
+                                        "neq1": {
+                                            "process_id": "neq",
+                                            "arguments": {
+                                                "x": {"from_parameter": "x"},
+                                                "y": {"from_node": "max1"},
+                                            },
+                                            "result": True,
+                                        },
+                                    }
+                                },
+                            },
+                            "result": True,
+                        }
+                    }
+                },
+            },
+            "result": True,
+        }
+    }
+    result = _run(pg, data=_three_image_stack())
+    by_ts = {k: v.array.data.ravel().tolist() for k, v in result.items()}
+    # Each timestamp is flagged where it is NOT the temporal maximum (7 @ 06-02).
+    assert by_ts[datetime(2024, 6, 1)] == [True, True, True, True]
+    assert by_ts[datetime(2024, 6, 2)] == [False, False, False, False]
+    assert by_ts[datetime(2024, 6, 3)] == [True, True, True, True]

--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -514,51 +514,6 @@ def test_add_dimension():
         add_dimension(data=result, name="x", label="1", type="spatial")
 
 
-def test_lazy_temporal_array_defers_realization():
-    """The temporal callback receives a lazy array view that does not realize
-    pixels until it is actually consumed, and then yields one timestamp at a time.
-    """
-    from titiler.openeo.processes.implementations.apply import _LazyStackedArray
-
-    realized = []
-
-    class _Img:
-        def __init__(self, key):
-            self._key = key
-
-        @property
-        def array(self):
-            realized.append(self._key)
-            return np.ma.array(np.full((1, 2, 2), self._key, np.uint8))
-
-    class _Stack(dict):
-        def keys(self):  # temporal order
-            return ["a", "b", "c"]
-
-        def __getitem__(self, k):
-            return _Img({"a": 1, "b": 2, "c": 3}[k])
-
-        def __len__(self):
-            return 3
-
-    lazy = _LazyStackedArray(_Stack())
-
-    # Construction and len must not realize anything.
-    assert len(lazy) == 3
-    assert realized == []
-
-    # Iteration realizes lazily, one timestamp at a time, in order.
-    first = next(iter(lazy))
-    assert realized == [1]
-    assert first.shape == (1, 2, 2)
-
-    # numpy.asarray realizes the whole stack via the __array__ protocol.
-    realized.clear()
-    arr = np.asarray(lazy)
-    assert arr.shape == (3, 1, 2, 2)
-    assert realized == [1, 2, 3]
-
-
 def test_apply_dimension_temporal(sample_raster_stack):
     """Test apply_dimension on temporal dimension."""
 

--- a/titiler/openeo/processes/implementations/apply.py
+++ b/titiler/openeo/processes/implementations/apply.py
@@ -20,10 +20,21 @@ KEY REQUIREMENTS:
    e.g. a child ``max`` ends up with no ``data``). Rely on numpy broadcasting to map
    a vectorized callback over every element in a single call instead.
 
-2. **Why this matters:** this is the same caching pitfall documented in reduce.py;
-   it has caused production issues (silent wrong results) more than once.
+2. **Pass the callback a REALIZED numpy array, not a lazy/duck-array view.**
+   Many processes type-check their input with ``isinstance(x, numpy.ndarray)``
+   (e.g. ``max``, ``array_element``), so a lazy view is rejected. Realize the stack
+   before calling the callback.
 
-3. **Testing requirements:** cover these processes with *process-graph* integration
+3. **Forward the enclosing ``named_parameters``.** A callback may reference an
+   outer-scope parameter via ``from_parameter`` — e.g. ``array_apply`` running
+   ``neq(x, max(data))`` where ``data`` is the enclosing ``apply_dimension`` array.
+   When a process invokes a child callback it must merge its own parameters on top
+   of the inherited ones, never replace them.
+
+4. **Why this matters:** the single-call rule is the same caching pitfall documented
+   in reduce.py; it has caused production issues (silent wrong results) more than once.
+
+5. **Testing requirements:** cover these processes with *process-graph* integration
    tests (build an ``OpenEOProcessGraph`` and run it via ``to_callable``), not only
    plain-Python callbacks — the latter have no shared cache and hide the bug.
 
@@ -42,51 +53,16 @@ from .data_model import ImageData, RasterStack
 __all__ = ["apply", "apply_dimension", "xyz_to_bbox", "xyz_to_tileinfo"]
 
 
-class _LazyStackedArray(numpy.lib.mixins.NDArrayOperatorsMixin):
-    """Lazy ``(n, bands, height, width)`` array view over a :class:`RasterStack`.
+def _stack_rasterstack(data: RasterStack) -> numpy.ma.MaskedArray:
+    """Realize a RasterStack into a ``(n, bands, height, width)`` masked array.
 
-    Behaves like a numpy array (via :class:`~numpy.lib.mixins.NDArrayOperatorsMixin`
-    and ``__array_ufunc__``) so it can be passed straight into an openEO callback —
-    including leaf processes that operate on it directly (e.g. ``multiply`` does
-    ``x * y``) and ``array_apply`` (which calls ``numpy.asarray``) — while deferring
-    pixel realization until the first operation/access.
-
-    This lets callers stack-and-call-the-callback-once (see module warning) without
-    eagerly forcing the whole stack into memory: realization is driven by the
-    consumer, mirroring how ``reduce_dimension`` hands the RasterStack to its reducer.
+    Callbacks must receive a **real** numpy array, not a lazy view: many openEO
+    processes type-check their input with ``isinstance(x, numpy.ndarray)``
+    (e.g. ``max``, ``array_element``), which any lazy/duck-array fails. Stacking
+    here realizes each image exactly once (cached on the RasterStack), which is
+    unavoidable for a temporal/whole-cube operation anyway.
     """
-
-    def __init__(self, data: RasterStack):
-        self._data = data
-
-    def __len__(self) -> int:
-        return len(self._data)
-
-    def __iter__(self) -> Any:
-        # Realize one image at a time, in key order, instead of ``values()`` which
-        # executes every task up front.
-        for key in self._data.keys():
-            yield self._data[key].array
-
-    def __array__(self, dtype: Optional[Any] = None) -> numpy.ndarray:
-        stacked = numpy.ma.stack(list(self))
-        return stacked.astype(dtype) if dtype is not None else stacked
-
-    def __array_ufunc__(self, ufunc: Any, method: str, *inputs: Any, **kwargs: Any):
-        # Realize any lazy operands, then delegate to numpy. This makes the view
-        # usable directly by leaf processes (``x * y``) while deferring realization
-        # until the first ufunc is applied.
-        resolved = tuple(
-            numpy.asanyarray(i) if isinstance(i, _LazyStackedArray) else i
-            for i in inputs
-        )
-        out = kwargs.get("out")
-        if out:
-            kwargs["out"] = tuple(
-                numpy.asanyarray(o) if isinstance(o, _LazyStackedArray) else o
-                for o in out
-            )
-        return getattr(ufunc, method)(*resolved, **kwargs)
+    return numpy.ma.stack([data[key].array for key in data.keys()])
 
 
 class DimensionNotAvailable(Exception):
@@ -116,8 +92,8 @@ def apply(
     if not keys:
         return data
 
-    # Lazy (n, bands, h, w) view; the callback realizes it once via numpy.asarray.
-    stacked = _LazyStackedArray(data)
+    # Stack to a realized (n, bands, h, w) array and call the callback ONCE.
+    stacked = _stack_rasterstack(data)
     result = numpy.asanyarray(
         process(
             stacked,
@@ -235,14 +211,13 @@ def _apply_temporal_dimension(
 
     # Per the openEO ``apply_dimension`` spec the callback receives the values
     # along the dimension as an array (a labeled array), not the datacube itself.
-    # Pass a lazy array view so this function does not realize the whole stack;
-    # the consumer (e.g. ``array_apply`` via ``numpy.asarray``) drives realization,
-    # keeping the temporal path as lazy as the spectral path and ``reduce_dimension``.
-    stacked = _LazyStackedArray(data)
+    # It must be a realized numpy array: callbacks include processes that type-check
+    # with ``isinstance(x, numpy.ndarray)`` (e.g. ``max``).
+    stacked = _stack_rasterstack(data)
 
-    # Apply the process to the temporal dimension
+    # Apply the process to the temporal dimension (call the callback ONCE)
     result_array = process(
-        stacked,  # Pass as positional argument (a lazy (n_times, ...) array view)
+        stacked,  # Pass as positional argument: (n_times, bands, height, width)
         positional_parameters=positional_parameters,
         named_parameters=named_parameters,
     )

--- a/titiler/openeo/processes/implementations/arrays.py
+++ b/titiler/openeo/processes/implementations/arrays.py
@@ -427,6 +427,7 @@ def array_apply(
     data: ArrayLike,
     process: Callable,
     context: Optional[Any] = None,
+    named_parameters: Optional[Dict[str, Any]] = None,
 ) -> ArrayLike:
     """Apply a process to each element in an array.
 
@@ -449,6 +450,12 @@ def array_apply(
     axes so callbacks may use it. ``label`` is only populated for labeled arrays
     and is ``None`` here.
 
+    The callback's enclosing parameters (``named_parameters``) are forwarded so that
+    nested ``from_parameter`` references to an outer scope resolve — e.g. a callback
+    computing ``neq(x, max(data))`` where ``data`` is the enclosing
+    ``apply_dimension`` array. The element parameters (``x``/``index``/``label``/
+    ``context``) take precedence over any inherited ones.
+
     Args:
         data: An array to process
         process: A vectorized process applied to all elements at once (NOT once per
@@ -460,6 +467,9 @@ def array_apply(
                  - label: The element label (only for labeled arrays, ``None`` here)
                  - context: Additional data passed by the user (optional)
         context: Additional data to be passed to the process
+        named_parameters: Enclosing-scope parameters injected by the process
+                          executor; forwarded to the callback so outer references
+                          resolve.
 
     Returns:
         An array with the newly computed values. The number of elements is the
@@ -477,17 +487,22 @@ def array_apply(
     n = arr.shape[0]
     index = numpy.arange(n).reshape((n,) + (1,) * (arr.ndim - 1))
 
+    # Inherit the enclosing scope, then override with this callback's element
+    # parameters so nested ``from_parameter`` references (e.g. ``data``) still resolve.
+    child_named_parameters = {
+        **(named_parameters or {}),
+        "x": arr,
+        "index": index,
+        "label": None,
+        "context": context,
+    }
+
     # Evaluate the callback once on the whole array; broadcasting maps it over
     # every element.
     result = process(
         arr,
         positional_parameters={"x": 0},
-        named_parameters={
-            "x": arr,
-            "index": index,
-            "label": None,
-            "context": context,
-        },
+        named_parameters=child_named_parameters,
     )
 
     return numpy.asanyarray(result)


### PR DESCRIPTION
## The failure

A nested-callback graph (real masking pipeline) still crashed even after the single-call fix:

```
apply_dimension(dimension="t", process = array_apply( neq(x, max(data)) ))
```
```
TypeError: max() missing 1 required positional argument: 'data'
```

The integration test reproduced it and exposed **two distinct bugs**, both only reachable through a real *nested* process graph:

### 1. `array_apply` dropped the enclosing scope
The inner `max(data)` references `from_parameter: data` — that's the **outer `apply_dimension` array** (the whole temporal series), not `array_apply`'s element `x`. `array_apply` built a *fresh* `named_parameters` with only `x`/`index`/`label`/`context`, so the nested reference resolved to nothing and `max` was called with no `data`.

**Fix:** `array_apply` now inherits the enclosing `named_parameters` and overrides only its own element params, so nested `from_parameter` references resolve.

### 2. The lazy view broke `isinstance`-based processes
The callback received the `_LazyStackedArray` duck-array. It works for ufuncs (`multiply` → `x * y`), but `max` (and `array_element`, etc.) type-check with `isinstance(x, numpy.ndarray)`, which the view fails.

**Fix:** callbacks now receive a **realized** masked array (`_stack_rasterstack`). The lazy view is removed — realization is unavoidable for these whole-cube operations and the view never actually reduced peak memory (callbacks materialize immediately).

## Result

The reported pipeline now computes correctly — e.g. `apply_dimension(t) → array_apply(neq(x, max(data)))` over values `[3, 7, 5]` flags every timestamp that is **not** the temporal max:

```
2024-06-01 (3) -> [1,1,1,1]
2024-06-02 (7) -> [0,0,0,0]   # == temporal max
2024-06-03 (5) -> [1,1,1,1]
```

## Tests & docs

- `tests/test_apply_graph_integration.py`: added the nested-scope case (`apply_dimension(t) → array_apply(neq(x, max(data)))`) that reproduces the crash; removed the obsolete lazy-view unit test.
- Extended the `apply.py` CRITICAL DEVELOPER WARNING with the two new requirements (realized arrays; forward enclosing scope).

Full suite: **692 passed, 12 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)