### PR TITLE
fix: preserve nodata masks when stacking arrays

### DIFF
--- a/tests/test_mask_preservation.py
+++ b/tests/test_mask_preservation.py
@@ -1,0 +1,153 @@
+"""Tests that nodata masks survive the stacking operations in the process graph.
+
+Regression coverage for the "satellite swath edge" artifact: pixels flagged as
+nodata at load time (e.g. Sentinel-2 nodata=0 at acquisition edges) must stay
+masked through every operation that recombines per-slice or per-band arrays.
+
+The root cause was the use of ``numpy.stack`` on lists of ``MaskedArray``, which
+silently drops the masks (returning an all-``False`` mask) instead of combining
+them. Every such site must use ``numpy.ma.stack``. These tests assert the masks
+are preserved end-to-end so the bug cannot regress.
+"""
+
+from datetime import datetime
+
+import numpy as np
+import pytest
+from rio_tiler.models import ImageData
+
+from titiler.openeo.processes.implementations.arrays import array_create, array_element
+from titiler.openeo.processes.implementations.data_model import RasterStack
+from titiler.openeo.processes.implementations.math import max as max_
+from titiler.openeo.processes.implementations.math import min as min_
+from titiler.openeo.processes.implementations.reduce import reduce_dimension
+
+
+def _masked_image(values, mask):
+    """Build a single-band ImageData from a 2D values/mask pair."""
+    arr = np.ma.MaskedArray(
+        np.asarray(values, dtype="float64")[np.newaxis, ...],
+        mask=np.asarray(mask, dtype=bool)[np.newaxis, ...],
+    )
+    return ImageData(arr, band_descriptions=["b"])
+
+
+def test_numpy_stack_drops_masks_baseline():
+    """Document the trap that motivates these tests: numpy.stack loses masks."""
+    a = np.ma.MaskedArray([1.0, 2.0], mask=[True, False])
+    b = np.ma.MaskedArray([3.0, 4.0], mask=[False, True])
+
+    # Plain numpy.stack silently drops the masks ...
+    assert not np.ma.getmaskarray(np.stack([a, b], axis=0)).any()
+    # ... while numpy.ma.stack preserves them.
+    assert np.ma.getmaskarray(np.ma.stack([a, b], axis=0)).tolist() == [
+        [True, False],
+        [False, True],
+    ]
+
+
+def test_array_create_preserves_masks():
+    """array_create stacks band callbacks; masked nodata must survive."""
+    band0 = np.ma.MaskedArray([[1.0, 2.0]], mask=[[True, False]])
+    band1 = np.ma.MaskedArray([[3.0, 4.0]], mask=[[False, False]])
+
+    result = array_create(data=[band0, band1])
+
+    assert isinstance(result, np.ma.MaskedArray)
+    assert np.ma.getmaskarray(result).tolist() == [[[True, False]], [[False, False]]]
+
+
+def test_array_element_preserves_masks_over_stack():
+    """array_element over a RasterStack must keep each slice's nodata mask."""
+    stack = RasterStack.from_images(
+        {
+            datetime(2024, 6, 1): _masked_image([[1.0, 2.0]], [[True, False]]),
+            datetime(2024, 6, 2): _masked_image([[3.0, 4.0]], [[False, True]]),
+        }
+    )
+
+    result = array_element(stack, 0)
+
+    assert isinstance(result, np.ma.MaskedArray)
+    # Shape is (time, height, width) after taking band 0 from each slice.
+    assert np.ma.getmaskarray(result).tolist() == [[[True, False]], [[False, True]]]
+
+
+def test_array_element_preserves_mask_on_band_index():
+    """array_element selecting a band from a MaskedArray (the common callback case,
+    e.g. extracting SCL or a reflectance band inside a reducer) must keep the mask."""
+    arr = np.ma.MaskedArray(
+        np.array([[[1.0, 2.0]], [[3.0, 4.0]]]),
+        mask=np.array([[[True, False]], [[False, True]]]),
+    )
+
+    result = array_element(arr, index=0)
+
+    assert isinstance(result, np.ma.MaskedArray)
+    assert np.ma.getmaskarray(result).tolist() == [[True, False]]
+
+
+@pytest.mark.parametrize("reducer", [max_, min_])
+def test_max_min_over_rasterstack_preserve_masks(reducer):
+    """Temporal max/min must mask pixels that are nodata in every slice and keep
+    valid values where at least one slice has data."""
+    # Pixel (0,0): masked in both slices -> stays masked.
+    # Pixel (0,1): valid in both -> reducer picks across the two values.
+    stack = RasterStack.from_images(
+        {
+            datetime(2024, 6, 1): _masked_image([[10.0, 2.0]], [[True, False]]),
+            datetime(2024, 6, 2): _masked_image([[20.0, 5.0]], [[True, False]]),
+        }
+    )
+
+    result = reducer(stack)
+
+    assert isinstance(result, np.ma.MaskedArray)
+    mask = np.ma.getmaskarray(result)
+    assert bool(mask[..., 0]) is True
+    assert bool(mask[..., 1]) is False
+
+
+def test_max_over_rasterstack_keeps_value_when_one_slice_valid():
+    """A pixel that is nodata in one slice but valid in another must not be
+    contaminated by the masked underlying value."""
+    # Underlying masked value (999.0) is larger than the valid value; if the mask
+    # were dropped, max would wrongly return 999.0.
+    stack = RasterStack.from_images(
+        {
+            datetime(2024, 6, 1): _masked_image([[999.0]], [[True]]),
+            datetime(2024, 6, 2): _masked_image([[7.0]], [[False]]),
+        }
+    )
+
+    result = max_(stack)
+
+    assert not bool(np.ma.getmaskarray(result)[..., 0])
+    assert float(result[..., 0]) == 7.0
+
+
+def test_spectral_reduce_preserves_mask_through_stack():
+    """reduce_dimension over bands stacks per-image arrays; nodata must persist."""
+
+    def reducer(data):
+        # data shape: (bands, time, height, width) -> reduce over bands (axis 0).
+        return np.ma.max(data, axis=0)
+
+    stack = RasterStack.from_images(
+        {
+            datetime(2024, 6, 1): ImageData(
+                np.ma.MaskedArray(
+                    np.array([[[1.0, 2.0]], [[3.0, 4.0]]]),
+                    mask=np.array([[[True, False]], [[True, False]]]),
+                ),
+                band_descriptions=["b0", "b1"],
+            ),
+        }
+    )
+
+    result = reduce_dimension(data=stack, reducer=reducer, dimension="bands")
+    out = result.first.array
+
+    assert isinstance(out, np.ma.MaskedArray)
+    # Pixel (0,0) is nodata in both bands -> stays masked after band reduction.
+    assert bool(np.ma.getmaskarray(out)[..., 0, 0]) is True

--- a/titiler/openeo/processes/implementations/arrays.py
+++ b/titiler/openeo/processes/implementations/arrays.py
@@ -66,8 +66,10 @@ def array_element(
             array_dict = {k: v.array for k, v in data.items() if k == label}
         # return a multi-dimensional array
         # For RasterStack, this will execute all tasks when stacking is needed
-        # This is expected behavior for array operations
-        return numpy.stack(list(array_dict.values()), axis=0)
+        # This is expected behavior for array operations.
+        # Use numpy.ma.stack (not numpy.stack) so per-slice nodata masks are
+        # preserved; plain numpy.stack silently drops them.
+        return numpy.ma.stack(list(array_dict.values()), axis=0)
 
     # Handle regular arrays (index must be provided at this point)
     if index is None:
@@ -76,8 +78,10 @@ def array_element(
     # Get the array to work with
     array_data = data.array if isinstance(data, ImageData) else data
 
-    # Convert to numpy array to ensure we have a shape attribute
-    array_data = numpy.asarray(array_data)
+    # Convert to numpy array to ensure we have a shape attribute.
+    # Use numpy.ma.asanyarray (not numpy.asarray) so a MaskedArray keeps its
+    # nodata mask; numpy.asarray strips it, turning masked nodata into valid data.
+    array_data = numpy.ma.asanyarray(array_data)
 
     # Handle 0-dimensional arrays (scalars)
     # If index is 0, return the scalar value itself
@@ -123,8 +127,10 @@ def array_create(data: Optional[ArrayLike] = None, repeat: int = 1) -> ArrayLike
     if isinstance(data, (list, tuple)):
         # Convert each element to array and stack them
         arrays = [numpy.asanyarray(item) for item in data]
-        # Stack along first axis - this creates (n_elements, *spatial_dims)
-        return numpy.stack(arrays, axis=0)
+        # Stack along first axis - this creates (n_elements, *spatial_dims).
+        # Use numpy.ma.stack (not numpy.stack) so masked nodata in any element is
+        # preserved; plain numpy.stack silently drops the masks.
+        return numpy.ma.stack(arrays, axis=0)
 
     # Handle single array input
     arr = numpy.asanyarray(data)

--- a/titiler/openeo/processes/implementations/math.py
+++ b/titiler/openeo/processes/implementations/math.py
@@ -362,8 +362,10 @@ def max(data, ignore_nodata=True):
     """Return the maximum value of the array."""
     # Handle RasterStack
     if isinstance(data, RasterStack):
-        # Return a single array with the maximum value for each array items in the stack
-        stacked_arrays = numpy.stack([v.array for v in data.values()], axis=0)
+        # Return a single array with the maximum value for each array items in the stack.
+        # numpy.ma.stack (not numpy.stack) preserves the per-slice nodata masks; plain
+        # numpy.stack silently drops them, turning masked nodata into valid values.
+        stacked_arrays = numpy.ma.stack([v.array for v in data.values()], axis=0)
         return _max(stacked_arrays, ignore_nodata=ignore_nodata, axis=0)
     elif isinstance(data, numpy.ndarray):
         return _max(data, ignore_nodata=ignore_nodata)
@@ -377,8 +379,10 @@ def min(data, ignore_nodata=True):
     """Return the minimum value of the array."""
     # Handle RasterStack
     if isinstance(data, RasterStack):
-        # Return a single array with the minimum value for each array items in the stack
-        stacked_arrays = numpy.stack([v.array for v in data.values()], axis=0)
+        # Return a single array with the minimum value for each array items in the stack.
+        # numpy.ma.stack (not numpy.stack) preserves the per-slice nodata masks; plain
+        # numpy.stack silently drops them, turning masked nodata into valid values.
+        stacked_arrays = numpy.ma.stack([v.array for v in data.values()], axis=0)
         return _min(stacked_arrays, ignore_nodata=ignore_nodata, axis=0)
     elif isinstance(data, numpy.ndarray):
         return _min(data, ignore_nodata=ignore_nodata)

--- a/titiler/openeo/processes/implementations/reduce.py
+++ b/titiler/openeo/processes/implementations/reduce.py
@@ -494,8 +494,10 @@ def _reduce_spectral_dimension_stack(
     # CRITICAL: Stack all images FIRST, then call reducer ONCE
     # This is required for reducers with internal caching/state
     # Stack all images along a new temporal dimension (axis 0)
-    # Shape will be (time, bands, height, width)
-    stacked_data = numpy.stack(images, axis=0)
+    # Shape will be (time, bands, height, width).
+    # Use numpy.ma.stack (not numpy.stack) so per-image nodata masks are preserved;
+    # plain numpy.stack silently drops them, turning masked nodata into valid data.
+    stacked_data = numpy.ma.stack(images, axis=0)
 
     # To reduce the spectral dimension while maintaining time separation,
     # we move the bands axis to the front: (bands, time, height, width)


### PR DESCRIPTION
## Problem

A cloud-free monthly composite over West Corsica rendered with a hard **satellite swath-edge artifact** — a diagonal band of black pixels where the acquisition footprint ended — instead of being composited away across the month. The reference implementation produces a clean full-extent image.

Inspecting the output GeoTIFF: 888,554 / 1,048,576 pixels were written as literal `0.0` (not nodata/NaN), exactly along the swath edge. Sentinel-2 loads with `nodata=0` correctly masked at acquisition edges, so these pixels **should** stay masked and be filled by other acquisitions in the temporal composite.

| Reference | titiler-openeo (before) |
|---|---|
| full extent, no edge | diagonal swath-edge mask |

## Root cause

`numpy.stack` on a list of `MaskedArray`s **silently drops the per-element masks** — it returns a `MaskedArray` with an all-`False` mask rather than combining the inputs' masks:

```python
a = np.ma.MaskedArray([1., 2.], mask=[True, False])
b = np.ma.MaskedArray([3., 4.], mask=[False, True])
np.ma.getmaskarray(np.stack([a, b]))      # [[False, False], [False, False]]  ← lost!
np.ma.getmaskarray(np.ma.stack([a, b]))   # [[True, False],  [False, True]]   ← correct
```

Several array-recombination sites used the lossy form, all in the hot path of this graph, so masked nodata was resurrected as valid `0.0` and the effects compounded. `numpy.asarray` in `array_element`'s single-array path strips masks the same way.

## Fix

Switch the affected sites to `numpy.ma.stack` / `numpy.ma.asanyarray`:

- `math.max` / `math.min` over a `RasterStack` (final temporal reduce)
- `arrays.array_create` (band-callback results, e.g. RGB build)
- `arrays.array_element` (RasterStack stacking **and** band-index `asarray` path)
- `reduce._reduce_spectral_dimension_stack` (SCL cloud mask, band ratios)

The remaining `asarray` calls (`merge_cubes`, `reduce_dimension` output validation) are already guarded by `isinstance(..., MaskedArray)` checks. `apply._stack_rasterstack` already used `numpy.ma.stack`.

## Tests

Adds `tests/test_mask_preservation.py` (8 tests) asserting masks survive each operation end-to-end, including the key case where a pixel is nodata in one slice but valid in another (must return the valid value, not the masked underlying one). Full suite: 713 passed, 12 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)