### PR TITLE
fix: aggregators reduce over the leading axis, not globally

### DIFF
--- a/tests/test_aggregator_axis.py
+++ b/tests/test_aggregator_axis.py
@@ -1,0 +1,59 @@
+"""The openEO aggregators reduce over the leading axis (axis 0), not globally.
+
+In titiler's vectorized cube model the leading axis is the dimension an openEO
+aggregator operates on: the time axis inside an ``apply_dimension(t)`` /
+``array_apply`` callback, and the band axis inside ``reduce_dimension(bands)``.
+Reducing globally (the old ``axis=None`` default on plain arrays) collapsed every
+spatial pixel into a single scalar and broke per-pixel temporal compositing.
+
+This mirrors the behaviour the RasterStack branch of each aggregator already has
+(it reduces the stacked time axis) and the ``count``/``first``/``last`` plain-array
+branches (which already index/reduce axis 0).
+"""
+
+import numpy as np
+import pytest
+
+from titiler.openeo.processes.implementations.math import max as max_
+from titiler.openeo.processes.implementations.math import mean, median
+from titiler.openeo.processes.implementations.math import min as min_
+from titiler.openeo.processes.implementations.math import sd, stdev, variance
+
+# A 2-element leading axis (e.g. 2 time slices or 2 bands) over a 1x3 strip, with
+# spatially varying values so a per-axis reduction differs from a global one.
+CUBE = np.array([[[1.0, 8.0, 3.0]], [[5.0, 2.0, 4.0]]])  # shape (2, 1, 3)
+
+
+@pytest.mark.parametrize(
+    "func, expected",
+    [
+        (max_, [[5.0, 8.0, 4.0]]),
+        (min_, [[1.0, 2.0, 3.0]]),
+        (mean, [[3.0, 5.0, 3.5]]),
+        (median, [[3.0, 5.0, 3.5]]),
+    ],
+)
+def test_aggregator_reduces_leading_axis(func, expected):
+    """max/min/mean/median collapse axis 0, preserving spatial shape (1, 3)."""
+    result = func(CUBE)
+    assert np.asarray(result).shape == (1, 3)
+    np.testing.assert_allclose(np.asarray(result), expected)
+
+
+@pytest.mark.parametrize("func", [sd, stdev, variance])
+def test_dispersion_aggregators_reduce_leading_axis(func):
+    """sd/stdev/variance also reduce axis 0 (shape (1, 3)), not to a scalar."""
+    result = func(CUBE)
+    assert np.asarray(result).shape == (1, 3)
+
+
+def test_aggregator_preserves_mask_over_leading_axis():
+    """A pixel masked in every slice stays masked; otherwise the valid value wins."""
+    arr = np.ma.MaskedArray(
+        [[[1.0, 9.0]], [[5.0, 9.0]]],
+        mask=[[[False, True]], [[False, True]]],  # col 1 masked in both slices
+    )
+    result = max_(arr)
+    assert np.asarray(result).shape == (1, 2)
+    assert bool(np.ma.getmaskarray(result)[0, 1]) is True
+    assert float(result[0, 0]) == 5.0

--- a/tests/test_apply_graph_integration.py
+++ b/tests/test_apply_graph_integration.py
@@ -223,3 +223,88 @@ def test_array_apply_callback_references_enclosing_scope():
     assert by_ts[datetime(2024, 6, 1)] == [True, True, True, True]
     assert by_ts[datetime(2024, 6, 2)] == [False, False, False, False]
     assert by_ts[datetime(2024, 6, 3)] == [True, True, True, True]
+
+
+def _selection_pg() -> dict:
+    """apply_dimension(t) -> array_apply(neq(x, max(data))): the 'best pixel over
+    time' selection. ``max(data)`` must be the per-pixel temporal max, not a
+    single global scalar."""
+    return {
+        "ad": {
+            "process_id": "apply_dimension",
+            "arguments": {
+                "data": {"from_parameter": "data"},
+                "dimension": "t",
+                "process": {
+                    "process_graph": {
+                        "arrayapply1": {
+                            "process_id": "array_apply",
+                            "arguments": {
+                                "data": {"from_parameter": "data"},
+                                "process": {
+                                    "process_graph": {
+                                        "max1": {
+                                            "process_id": "max",
+                                            "arguments": {
+                                                "data": {"from_parameter": "data"}
+                                            },
+                                        },
+                                        "neq1": {
+                                            "process_id": "neq",
+                                            "arguments": {
+                                                "x": {"from_parameter": "x"},
+                                                "y": {"from_node": "max1"},
+                                            },
+                                            "result": True,
+                                        },
+                                    }
+                                },
+                            },
+                            "result": True,
+                        }
+                    }
+                },
+            },
+            "result": True,
+        }
+    }
+
+
+def test_temporal_array_apply_max_is_per_pixel_not_global():
+    """Regression: max(data) inside a temporal array_apply must reduce over the
+    time axis PER PIXEL, not collapse the whole cube to one global scalar.
+
+    The earlier global-scalar behaviour broke the cloud-free "best pixel over
+    time" composite: with two complementary acquisitions (one valid on the left
+    half, one on the right), only the single globally-maximum pixel survived and
+    the rest of the scene was masked out instead of being filled by the other
+    acquisition. This test uses spatially VARYING values so global-max and
+    per-pixel-temporal-max differ (the uniform-valued test above cannot tell them
+    apart).
+    """
+
+    # 1x4 strip, single band. t0 valid on left (cols 0,1), t1 valid on right.
+    def _img(vals, mask):
+        return ImageData(
+            np.ma.MaskedArray(
+                np.array([[vals]], dtype=float), mask=np.array([[mask]], dtype=bool)
+            )
+        )
+
+    stack = RasterStack.from_images(
+        {
+            datetime(2024, 6, 1): _img(
+                [5.0, 6.0, 0.0, 0.0], [False, False, True, True]
+            ),
+            datetime(2024, 6, 2): _img(
+                [0.0, 0.0, 7.0, 8.0], [True, True, False, False]
+            ),
+        }
+    )
+
+    sel = _run(_selection_pg(), data=stack)
+    flagged = {k: v.array.data.ravel().tolist() for k, v in sel.items()}
+    # Per pixel, the single valid time is its own temporal max -> NOT flagged.
+    # Global-scalar max (8) would instead flag every pixel except the one 8.
+    assert flagged[datetime(2024, 6, 1)] == [False, False, True, True]
+    assert flagged[datetime(2024, 6, 2)] == [True, True, False, False]

--- a/titiler/openeo/processes/implementations/math.py
+++ b/titiler/openeo/processes/implementations/math.py
@@ -226,10 +226,12 @@ def _max(data, ignore_nodata=True, axis=None, keepdims=False):
     return numpy.max(data, axis=axis, keepdims=keepdims)
 
 
-def median(data, axis=None, keepdims=False):
+def median(data, axis=0, keepdims=False):
     """Calculate median across the data.
 
-    When used with RasterStack, it uses the efficient streaming approach.
+    Reduces over axis 0 (the leading "array" dimension) by default, consistent
+    with the other aggregators — see the note in max(). When used with
+    RasterStack, it uses the efficient streaming approach.
     """
     # Handle RasterStack - use apply_pixel_selection for efficiency
     if isinstance(data, RasterStack):
@@ -241,10 +243,12 @@ def median(data, axis=None, keepdims=False):
     return numpy.median(data, axis=axis, keepdims=keepdims)
 
 
-def mean(data, axis=None, keepdims=False):
+def mean(data, axis=0, keepdims=False):
     """Calculate mean across the data.
 
-    When used with RasterStack, it uses the efficient streaming approach.
+    Reduces over axis 0 (the leading "array" dimension) by default, consistent
+    with the other aggregators — see the note in max(). When used with
+    RasterStack, it uses the efficient streaming approach.
     """
     # Handle RasterStack - use apply_pixel_selection for efficiency
     if isinstance(data, RasterStack):
@@ -256,15 +260,17 @@ def mean(data, axis=None, keepdims=False):
     return numpy.mean(data, axis=axis, keepdims=keepdims)
 
 
-def sd(x, axis=None, keepdims=False):
+def sd(x, axis=0, keepdims=False):
     return numpy.std(x, axis=axis, keepdims=keepdims, ddof=1)
 
 
-def stdev(data, axis=None, keepdims=False):
+def stdev(data, axis=0, keepdims=False):
     """Calculate standard deviation across the data.
 
-    This is an alias for sd() that matches the PixelSelectionMethod naming.
-    When used with RasterStack, it uses the efficient streaming approach.
+    Reduces over axis 0 (the leading "array" dimension) by default, consistent
+    with the other aggregators — see the note in max(). This is an alias for
+    sd() that matches the PixelSelectionMethod naming. When used with
+    RasterStack, it uses the efficient streaming approach.
     """
     # Handle RasterStack - use apply_pixel_selection for efficiency
     if isinstance(data, RasterStack):
@@ -273,7 +279,7 @@ def stdev(data, axis=None, keepdims=False):
     return numpy.std(data, axis=axis, keepdims=keepdims, ddof=1)
 
 
-def variance(x, axis=None, keepdims=False):
+def variance(x, axis=0, keepdims=False):
     return numpy.var(x, axis=axis, keepdims=keepdims, ddof=1)
 
 
@@ -368,9 +374,13 @@ def max(data, ignore_nodata=True):
         stacked_arrays = numpy.ma.stack([v.array for v in data.values()], axis=0)
         return _max(stacked_arrays, ignore_nodata=ignore_nodata, axis=0)
     elif isinstance(data, numpy.ndarray):
-        return _max(data, ignore_nodata=ignore_nodata)
-    elif isinstance(data, numpy.ma.MaskedArray):
-        return _max(data, ignore_nodata=ignore_nodata)
+        # Reduce over axis 0 (the leading "array" dimension), NOT globally. In
+        # titiler's vectorized cube model the leading axis is the dimension an
+        # openEO aggregator operates on (the time axis in apply_dimension(t)
+        # callbacks, the band axis in reduce_dimension(bands)). This mirrors the
+        # RasterStack branch above and avoids collapsing every spatial pixel into
+        # a single scalar. (MaskedArray is an ndarray subclass, so it lands here.)
+        return _max(data, ignore_nodata=ignore_nodata, axis=0)
     else:
         raise TypeError("Unsupported data type for max function.")
 
@@ -385,9 +395,9 @@ def min(data, ignore_nodata=True):
         stacked_arrays = numpy.ma.stack([v.array for v in data.values()], axis=0)
         return _min(stacked_arrays, ignore_nodata=ignore_nodata, axis=0)
     elif isinstance(data, numpy.ndarray):
-        return _min(data, ignore_nodata=ignore_nodata)
-    elif isinstance(data, numpy.ma.MaskedArray):
-        return _min(data, ignore_nodata=ignore_nodata)
+        # Reduce over axis 0 (the leading "array" dimension), NOT globally — see
+        # the note in max(). (MaskedArray is an ndarray subclass, so it lands here.)
+        return _min(data, ignore_nodata=ignore_nodata, axis=0)
     else:
         raise TypeError("Unsupported data type for min function.")
 


### PR DESCRIPTION
## Problem

Follow-up to #318. With the nodata masks now preserved, the cloud-free monthly composite over West Corsica still does not fill the satellite swath edge — the area is transparent instead of being filled by the other orbit's acquisition, and the result looks like a single image rather than a month-long composite.

The STAC query for this bbox/month returns **12 acquisitions from 2 complementary orbits** (relative orbits 22 and 65, tile 32TMM) whose footprints together cover the full extent. So the data to fill the gap exists — the temporal compositing was dropping it.

## Root cause

The "best pixel over time" selection is expressed as:

```
apply_dimension(dimension="t", process = array_apply( neq(x, max(data)) ))
```

`max(data)` is meant to be the **per-pixel temporal maximum** so `neq` keeps each pixel's best date. But the openEO aggregators (`max`/`min`/`mean`/`median`/`sd`/`stdev`/`variance`) reduced a plain array over **all** axes (`axis=None` → a single global scalar), collapsing every spatial pixel into one number:

```python
max(plain 4D cube) == 7.0          # one global scalar
np.ma.max(cube, axis=0).shape == (1, 2, 2)   # what we actually want
```

End-to-end on two complementary-footprint slices, only the single globally-maximum pixel survived; everything the other orbit should have filled was masked out:

```
before: [masked, masked, masked, 8.0]
after : [5.0,    6.0,    7.0,    8.0]   # each column filled by whichever orbit covers it
```

This also silently broke `reduce_dimension(dimension="bands")` whenever a builtin aggregator was used directly as the reducer.

## Fix

Make `axis=0` the default for the plain-array branch of each aggregator. In titiler's vectorized cube model the leading axis **is** the dimension an openEO aggregator operates on (time in `apply_dimension(t)` callbacks, bands in `reduce_dimension(bands)`). This matches what was already true for:

- every aggregator's **RasterStack** branch (reduces the stacked time axis), and
- `count` / `first` / `last` on plain arrays (already index/reduce axis 0).

No axis context needs to be threaded through the executor or `array_apply` — the leading axis is the reduction dimension by construction. Also removes the now-dead `MaskedArray` `elif` in `max`/`min` (`MaskedArray` is an `ndarray` subclass, so it never reached it).

## Tests

- `test_apply_graph_integration`: a spatially-**varying** two-orbit selection graph run through the real executor. The pre-existing test used spatially-**uniform** values, where global-max == per-pixel-temporal-max, so it could not distinguish the two and missed this bug.
- `test_aggregator_axis`: the leading-axis contract for each aggregator, including mask preservation.

Full suite: 722 passed, 12 skipped.

## Validation note

Verified end-to-end against synthetic complementary-orbit data (composite now fills). Confirming against the real Corsica scene needs CDSE credentials / a local run of the graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)