### PR TITLE
fix: validate ignore_nodata as boolean (clear error, not numpy crash)

### DIFF
--- a/tests/test_apply_graph_integration.py
+++ b/tests/test_apply_graph_integration.py
@@ -14,6 +14,7 @@ below would fail on the previous per-element / per-image implementations.
 from datetime import datetime
 
 import numpy as np
+import pytest
 from openeo_pg_parser_networkx.graph import OpenEOProcessGraph
 from rio_tiler.models import ImageData
 
@@ -120,6 +121,49 @@ def test_apply_via_graph_maps_each_image():
     by_ts = {k: v.array.data.ravel().tolist() for k, v in result.items()}
     assert by_ts[datetime(2021, 1, 1)] == [10, 10, 10, 10]
     assert by_ts[datetime(2021, 1, 2)] == [50, 50, 50, 50]
+
+
+def test_max_rejects_non_boolean_ignore_nodata():
+    """max/min must reject a non-boolean ``ignore_nodata`` with a clear validation
+    error, not a cryptic numpy "truth value of an array is ambiguous" crash.
+
+    This is the common misuse ``oe_max(a, b)``: openEO ``max`` is an array
+    aggregator ``max(data, ignore_nodata)``, so the second positional ``b`` binds
+    to ``ignore_nodata`` (which must be boolean). Element-wise max of two bands is
+    ``max(array_create([a, b]))``.
+    """
+    band = ImageData(
+        np.ma.array(np.full((1, 2, 2), 2.0), mask=[[[False, True], [False, False]]])
+    )
+    stack = RasterStack.from_images({datetime(2024, 6, 1): band})
+    pg = {
+        "m": {
+            "process_id": "max",
+            "arguments": {
+                "data": {"from_parameter": "data"},
+                "ignore_nodata": {"from_parameter": "data"},  # an array, not a bool
+            },
+            "result": True,
+        }
+    }
+    with pytest.raises(TypeError, match="ignore_nodata.*expected 'boolean'"):
+        _run(pg, data=stack)
+
+
+def test_max_accepts_boolean_ignore_nodata():
+    """A valid boolean ``ignore_nodata`` (and the default) still works."""
+    band = ImageData(np.ma.array(np.full((2, 1, 2), 3.0)))
+    stack = RasterStack.from_images({datetime(2024, 6, 1): band})
+    pg = {
+        "m": {
+            "process_id": "max",
+            "arguments": {"data": {"from_parameter": "data"}, "ignore_nodata": False},
+            "result": True,
+        }
+    }
+    out = np.asarray(_run(pg, data=stack))
+    assert out.shape == (2, 1, 2)
+    assert (out == 3.0).all()
 
 
 def test_apply_dimension_bands_maps_each_image_via_graph():

--- a/titiler/openeo/processes/implementations/math.py
+++ b/titiler/openeo/processes/implementations/math.py
@@ -433,8 +433,16 @@ def last(data):
         raise TypeError("Unsupported data type for last function.")
 
 
-def max(data, ignore_nodata=True):
-    """Return the maximum value of the array."""
+def max(data, ignore_nodata: bool = True):
+    """Return the maximum value of the array.
+
+    ``ignore_nodata`` is a boolean flag, annotated so the @process validator
+    rejects a non-boolean (e.g. an array) with a clear error instead of a cryptic
+    numpy "truth value of an array is ambiguous". This catches the common misuse
+    ``max(a, b)`` — openEO ``max`` is an array aggregator, so the second
+    positional ``b`` binds to ``ignore_nodata``; element-wise max of two bands is
+    ``max(array_create([a, b]))``.
+    """
     # Handle RasterStack
     if isinstance(data, RasterStack):
         # Return a single array with the maximum value for each array items in the stack.
@@ -454,8 +462,13 @@ def max(data, ignore_nodata=True):
         raise TypeError("Unsupported data type for max function.")
 
 
-def min(data, ignore_nodata=True):
-    """Return the minimum value of the array."""
+def min(data, ignore_nodata: bool = True):
+    """Return the minimum value of the array.
+
+    ``ignore_nodata`` is annotated as a boolean so the @process validator rejects
+    a non-boolean (e.g. an array) with a clear error rather than a cryptic numpy
+    crash — see the note in max().
+    """
     # Handle RasterStack
     if isinstance(data, RasterStack):
         # Return a single array with the minimum value for each array items in the stack.


### PR DESCRIPTION
## Problem

A graph using `oe_max(B03, B02)` (a common attempt at an element-wise band maximum in a chlorophyll band-ratio formula) crashed with a cryptic, deep numpy error:

```
File ".../math.py", line 288, in _max
    if not ignore_nodata:
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

openEO `max` is an **array aggregator** — `max(data, ignore_nodata)`. Two positional arrays bind `B03→data` and **`B02→ignore_nodata`** (which must be a boolean). When `data` is a `MaskedArray` (real masked rasters), `_max` evaluates `if not <B02 array>:` → the ambiguous-truth-value crash.

## Why validation didn't catch it

The `@process` validator (`_validate_parameter_types`) already rejects type mismatches, but it **skips parameters whose Python annotation is empty**:

```python
if param_type is None or param_type is inspect.Parameter.empty or param_type is Any:
    continue
```

`max`/`min` left `ignore_nodata` un-annotated, so the array slipped straight through to numpy.

## Fix

Annotate `ignore_nodata: bool` on `max`/`min`. The validator's pydantic check now rejects a non-boolean cleanly:

```
Parameter 'ignore_nodata' in process 'max': expected 'boolean' but got 'array'.
```

Valid calls (`ignore_nodata: false`, or the default) are unaffected.

**For graph authors:** element-wise max of two bands is `max(array_create([a, b]))`, not `max(a, b)`.

## Scope — are other signatures affected?

Audited all registered processes for un-annotated, spec-scalar parameters (45 hits). The vast majority are openEO **`number`** operands (`add`, `multiply`, `divide`, `log`, …) which in titiler's vectorized cube model **intentionally receive arrays** (raster math) — annotating those as scalars would wrongly reject normal usage, so they are deliberately left unenforced. `count.condition` is `boolean`-typed but is legitimately a per-pixel array. The only graph-exposed scalar **flag** with this gap was `ignore_nodata` on `max`/`min` (the other aggregators' `axis`/`keepdims` are internal control params, not openEO-spec parameters, so graphs never bind them). Hence this PR is scoped to `max`/`min`.

## Tests

`tests/test_apply_graph_integration.py` (real-executor path):
- `max` with an array `ignore_nodata` raises a clear `TypeError` (not the numpy crash).
- `max` with a boolean / default `ignore_nodata` still works.

Full suite: 744 passed, 12 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)