### PR TITLE
feat: apply STAC raster:scale/offset (per band) on read

### DIFF
--- a/tests/test_scale_offset.py
+++ b/tests/test_scale_offset.py
@@ -1,0 +1,217 @@
+"""Tests for STAC raster:scale/raster:offset application in the reader.
+
+CDSE sentinel-2-l2a bands declare raster:scale=0.0001 / raster:offset=-0.1 (BOA
+offset, processing baseline >= 04.00). The reader applies them per band so bands
+are returned as physical reflectance (float32) instead of raw DN, while bands
+without scale/offset (e.g. SCL) are left untouched. See reader._apply_scale_offset.
+"""
+
+from datetime import datetime
+
+import numpy
+import pytest
+from rio_tiler.models import ImageData
+
+import titiler.openeo.reader as reader
+from titiler.openeo.reader import (
+    _apply_scale_offset,
+    _asset_extra_fields,
+    _band_scale_offset,
+)
+from titiler.openeo.settings import ProcessingSettings
+
+
+# --- _band_scale_offset -----------------------------------------------------
+def test_band_scale_offset_asset_level():
+    assert _band_scale_offset({"raster:scale": 0.0001, "raster:offset": -0.1}) == (
+        0.0001,
+        -0.1,
+    )
+
+
+def test_band_scale_offset_raster_bands_fallback():
+    assert _band_scale_offset(
+        {"raster:bands": [{"scale": 0.0001, "offset": -0.1}]}
+    ) == (
+        0.0001,
+        -0.1,
+    )
+    # newer "bands" with raster: prefixed keys
+    assert _band_scale_offset(
+        {"bands": [{"raster:scale": 2.0, "raster:offset": 1.0}]}
+    ) == (2.0, 1.0)
+
+
+def test_band_scale_offset_default_identity():
+    assert _band_scale_offset({}) == (1.0, 0.0)
+
+
+# --- _asset_extra_fields ----------------------------------------------------
+def test_asset_extra_fields_from_dict():
+    item = {"assets": {"B02_10m": {"raster:scale": 0.0001}}}
+    assert _asset_extra_fields(item, "B02_10m") == {"raster:scale": 0.0001}
+    assert _asset_extra_fields(item, "MISSING") == {}
+
+
+def test_asset_extra_fields_from_pystac_item():
+    import pystac
+
+    item = pystac.Item(
+        id="x",
+        geometry={"type": "Point", "coordinates": [0, 0]},
+        bbox=[0, 0, 0, 0],
+        datetime=datetime(2024, 6, 14),
+        properties={},
+    )
+    item.add_asset(
+        "B02_10m",
+        pystac.Asset(href="x.jp2", extra_fields={"raster:scale": 0.0001}),
+    )
+    assert _asset_extra_fields(item, "B02_10m")["raster:scale"] == 0.0001
+    assert _asset_extra_fields(item, "MISSING") == {}
+
+
+# --- _apply_scale_offset ----------------------------------------------------
+def _img(dn, mask=False, dtype="uint16"):
+    arr = numpy.ma.MaskedArray(numpy.asarray(dn, dtype=dtype), mask=mask)
+    return ImageData(arr, band_names=[f"b{i + 1}" for i in range(arr.shape[0])])
+
+
+def test_apply_scale_offset_per_band_float32_mask_preserved():
+    # band 0 = B02 (scale/offset), band 1 = SCL (none)
+    img = _img(
+        [[[2000, 1500]], [[4, 9]]],
+        mask=[[[False, True]], [[False, True]]],
+    )
+    item = {
+        "assets": {
+            "B02_10m": {"raster:scale": 0.0001, "raster:offset": -0.1},
+            "SCL_20m": {},
+        }
+    }
+    out = _apply_scale_offset(img, item, ["B02_10m", "SCL_20m"])
+
+    # float32, NOT float64
+    assert out.array.dtype == numpy.float32
+    # B02: DN*0.0001 - 0.1
+    numpy.testing.assert_allclose(out.array.data[0], [[0.1, 0.05]], rtol=1e-5)
+    # SCL untouched (identity scale/offset)
+    numpy.testing.assert_array_equal(out.array.data[1], [[4.0, 9.0]])
+    # mask preserved per band
+    assert numpy.ma.getmaskarray(out.array).tolist() == [
+        [[False, True]],
+        [[False, True]],
+    ]
+
+
+def test_apply_scale_offset_noop_when_all_identity_keeps_dtype():
+    img = _img([[[4, 9]]])  # SCL only, no scale/offset
+    out = _apply_scale_offset(img, {"assets": {"SCL_20m": {}}}, ["SCL_20m"])
+    assert out is img  # unchanged object
+    assert out.array.dtype == numpy.dtype("uint16")  # integer dtype preserved
+
+
+def test_apply_scale_offset_noop_on_band_asset_mismatch():
+    img = _img([[[2000, 1500]], [[4, 9]]])  # 2 bands
+    out = _apply_scale_offset(img, {"assets": {}}, ["only_one_asset"])
+    assert out is img
+
+
+def test_apply_scale_offset_noop_when_assets_missing():
+    img = _img([[[2000, 1500]]])
+    assert _apply_scale_offset(img, {"assets": {}}, None) is img
+
+
+# --- _reader integration (flag on/off), still lazy --------------------------
+class _FakeSrc:
+    """Stand-in for SimpleSTACReader as a context manager returning a fixed part."""
+
+    def __init__(self, img):
+        self._img = img
+        self.calls = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def part(self, bbox, **kwargs):
+        self.calls += 1
+        return self._img
+
+
+@pytest.fixture
+def s2_item():
+    return {
+        "id": "s2",
+        "properties": {"datetime": "2024-06-14T10:00:00Z"},
+        "assets": {
+            "B02_10m": {"raster:scale": 0.0001, "raster:offset": -0.1},
+            "SCL_20m": {},
+        },
+    }
+
+
+def test_reader_applies_scale_offset(monkeypatch, s2_item):
+    img = _img([[[2000, 0]], [[4, 0]]], mask=[[[False, True]], [[False, True]]])
+    fake = _FakeSrc(img)
+    monkeypatch.setattr(reader, "SimpleSTACReader", lambda item: fake)
+    monkeypatch.setattr(reader.processing_settings, "apply_scale_offset", True)
+
+    out = reader._reader(s2_item, (0, 0, 1, 1), assets=["B02_10m", "SCL_20m"])
+    assert out.array.dtype == numpy.float32
+    assert out.array.data[0][0, 0] == pytest.approx(0.1, rel=1e-5)  # B02 reflectance
+    assert out.array.data[1][0, 0] == 4.0  # SCL untouched
+
+
+def test_reader_flag_off_returns_raw_dn(monkeypatch, s2_item):
+    img = _img([[[2000, 0]], [[4, 0]]])
+    monkeypatch.setattr(reader, "SimpleSTACReader", lambda item: _FakeSrc(img))
+    monkeypatch.setattr(reader.processing_settings, "apply_scale_offset", False)
+
+    out = reader._reader(s2_item, (0, 0, 1, 1), assets=["B02_10m", "SCL_20m"])
+    assert out.array.dtype == numpy.dtype("uint16")
+    assert out.array.data[0][0, 0] == 2000  # raw DN, not scaled
+
+
+# --- laziness ---------------------------------------------------------------
+def test_scale_offset_is_lazy(monkeypatch, s2_item):
+    """Building a RasterStack must not read/scale anything; the scale/offset only
+    runs inside the task, on first access to a slice."""
+    from titiler.openeo.processes.implementations.data_model import RasterStack
+
+    img = _img([[[2000, 0]], [[4, 0]]], mask=[[[False, True]], [[False, True]]])
+    calls = {"n": 0}
+
+    def task():
+        calls["n"] += 1
+        monkeypatch.setattr(reader, "SimpleSTACReader", lambda item: _FakeSrc(img))
+        return reader._reader(s2_item, (0, 0, 1, 1), assets=["B02_10m", "SCL_20m"])
+
+    dt = datetime(2024, 6, 14)
+    stack = RasterStack(
+        tasks=[(task, {"id": "s2", "datetime": dt})],
+        timestamp_fn=lambda asset: asset["datetime"],
+    )
+
+    # Building + listing keys must not execute the task.
+    assert calls["n"] == 0
+    assert list(stack.keys()) == [dt]
+    assert calls["n"] == 0
+
+    # First access executes the task and applies scale/offset (float32 reflectance).
+    out = stack[dt]
+    assert calls["n"] == 1
+    assert out.array.dtype == numpy.float32
+    assert out.array.data[0][0, 0] == pytest.approx(0.1, rel=1e-5)
+
+
+# --- settings ---------------------------------------------------------------
+def test_setting_default_on():
+    assert ProcessingSettings().apply_scale_offset is True
+
+
+def test_setting_env_override(monkeypatch):
+    monkeypatch.setenv("TITILER_OPENEO_PROCESSING_APPLY_SCALE_OFFSET", "false")
+    assert ProcessingSettings().apply_scale_offset is False

--- a/titiler/openeo/reader.py
+++ b/titiler/openeo/reader.py
@@ -6,6 +6,7 @@ import warnings
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, Union
 
 import attr
+import numpy
 import pystac
 import rasterio
 from morecantile import TileMatrixSet
@@ -27,8 +28,11 @@ from rio_tiler.utils import cast_to_sequence, inherit_rasterio_env
 from typing_extensions import TypedDict
 
 from .errors import OutputLimitExceeded
+from .settings import ProcessingSettings
 
 logger = logging.getLogger(__name__)
+
+processing_settings = ProcessingSettings()
 
 
 class Dims(TypedDict):
@@ -768,6 +772,87 @@ def _estimate_output_dimensions(
     )
 
 
+def _asset_extra_fields(item: Any, band: str) -> Dict[str, Any]:
+    """Return the STAC extra fields for ``band`` from ``item`` (dict or pystac.Item)."""
+    if isinstance(item, dict):
+        return item.get("assets", {}).get(band, {}) or {}
+    assets = getattr(item, "assets", None)
+    if not assets or band not in assets:
+        return {}
+    return dict(getattr(assets[band], "extra_fields", {}) or {})
+
+
+def _band_scale_offset(asset: Dict[str, Any]) -> Tuple[float, float]:
+    """Extract (scale, offset) for a band from STAC asset metadata.
+
+    Looks at the asset level first (``raster:scale``/``raster:offset``), then the
+    raster-extension per-band variants. Defaults to ``(1.0, 0.0)`` (i.e. identity,
+    e.g. for Sentinel-2 SCL which carries no scale/offset).
+    """
+    scale = asset.get("raster:scale")
+    offset = asset.get("raster:offset")
+    if scale is None or offset is None:
+        bands = asset.get("raster:bands") or asset.get("bands")
+        if bands:
+            b0 = bands[0]
+            if scale is None:
+                scale = b0.get("scale", b0.get("raster:scale"))
+            if offset is None:
+                offset = b0.get("offset", b0.get("raster:offset"))
+    return (
+        float(scale) if scale is not None else 1.0,
+        float(offset) if offset is not None else 0.0,
+    )
+
+
+def _apply_scale_offset(
+    img: ImageData, item: Any, assets: Optional[Sequence[str]]
+) -> ImageData:
+    """Apply per-band STAC ``raster:scale``/``raster:offset`` to ``img``.
+
+    Returns physical values (e.g. reflectance) as ``float32``. Bands without
+    scale/offset metadata (default 1/0) are left unchanged, so e.g. Sentinel-2 SCL
+    keeps its integer class values. The nodata mask is preserved.
+
+    No-ops (returns ``img`` unchanged, keeping its dtype) when ``assets`` is missing,
+    its length does not match the band count, or every band is identity (1/0).
+    """
+    if not assets:
+        return img
+
+    nbands = img.array.shape[0]
+    if len(assets) != nbands:
+        logger.warning(
+            "Cannot apply scale/offset: %d band(s) but %d asset name(s); skipping.",
+            nbands,
+            len(assets),
+        )
+        return img
+
+    pairs = [_band_scale_offset(_asset_extra_fields(item, b)) for b in assets]
+    if all(scale == 1.0 and offset == 0.0 for scale, offset in pairs):
+        return img
+
+    # float32 operands so the result stays float32 (a float32 array times a Python
+    # float / float64 array would promote to float64).
+    scales = numpy.asarray([s for s, _ in pairs], dtype="float32").reshape(-1, 1, 1)
+    offsets = numpy.asarray([o for _, o in pairs], dtype="float32").reshape(-1, 1, 1)
+    # Rescale the underlying data (every pixel) and re-attach the original mask, so
+    # masked (nodata) pixels stay masked and no raw DN lingers under the mask.
+    data = numpy.ma.getdata(img.array).astype("float32") * scales + offsets
+    array = numpy.ma.MaskedArray(data, mask=numpy.ma.getmaskarray(img.array))
+
+    return ImageData(
+        array,
+        assets=img.assets,
+        crs=img.crs,
+        bounds=img.bounds,
+        band_names=img.band_names,
+        band_descriptions=img.band_descriptions,
+        metadata=img.metadata,
+    )
+
+
 def _reader(item: Dict[str, Any], bbox: BBox, **kwargs: Any) -> ImageData:
     """
     Read a STAC item and return an ImageData object.
@@ -802,6 +887,12 @@ def _reader(item: Dict[str, Any], bbox: BBox, **kwargs: Any) -> ImageData:
         try:
             with SimpleSTACReader(item) as src_dst:
                 img = src_dst.part(bbox, **kwargs)
+
+                # Apply STAC raster:scale/raster:offset (per band) so bands are
+                # returned as physical values (e.g. reflectance) instead of raw DN.
+                # Runs inside the lazy task — only when a slice is actually read.
+                if processing_settings.apply_scale_offset:
+                    img = _apply_scale_offset(img, item, kwargs.get("assets"))
 
                 # IMPORTANT: We intentionally do NOT set cutline_mask on individual tiles.
                 #

--- a/titiler/openeo/reader.py
+++ b/titiler/openeo/reader.py
@@ -3,7 +3,7 @@
 import logging
 import time
 import warnings
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, Union, cast
 
 import attr
 import numpy
@@ -833,17 +833,17 @@ def _apply_scale_offset(
     if all(scale == 1.0 and offset == 0.0 for scale, offset in pairs):
         return img
 
-    # float32 operands so the result stays float32 (a float32 array times a Python
-    # float / float64 array would promote to float64).
-    scales = numpy.asarray([s for s, _ in pairs], dtype="float32").reshape(-1, 1, 1)
-    offsets = numpy.asarray([o for _, o in pairs], dtype="float32").reshape(-1, 1, 1)
-    # Rescale the underlying data (every pixel) and re-attach the original mask, so
-    # masked (nodata) pixels stay masked and no raw DN lingers under the mask.
-    data = numpy.ma.getdata(img.array).astype("float32") * scales + offsets
-    array = numpy.ma.MaskedArray(data, mask=numpy.ma.getmaskarray(img.array))
+    scales = numpy.array([s for s, _ in pairs])
+    offsets = numpy.array([o for _, o in pairs])
+    # In-place unscale on a float32 copy, mirroring rio-tiler's Reader: casting the
+    # array to float32 (then ``out=`` float32) keeps the result float32 regardless
+    # of the scale/offset dtype, avoids extra allocations, and preserves the mask.
+    data = cast(numpy.ma.MaskedArray, img.array.astype("float32", casting="unsafe"))
+    numpy.multiply(data, scales.reshape((-1, 1, 1)), out=data, casting="unsafe")
+    numpy.add(data, offsets.reshape((-1, 1, 1)), out=data, casting="unsafe")
 
     return ImageData(
-        array,
+        data,
         assets=img.assets,
         crs=img.crs,
         bounds=img.bounds,

--- a/titiler/openeo/settings.py
+++ b/titiler/openeo/settings.py
@@ -218,6 +218,11 @@ class ProcessingSettings(BaseSettings):
     # memory to ~the working set. See titiler.openeo.results_cache.
     evict_intermediate_results: bool = True
 
+    # Apply STAC raster:scale / raster:offset (per band) when loading so bands are
+    # returned as physical values (e.g. Sentinel-2 BOA reflectance) instead of raw
+    # DN. Disable to keep raw DN (e.g. while migrating graphs that scale manually).
+    apply_scale_offset: bool = True
+
     model_config = SettingsConfigDict(
         env_prefix="TITILER_OPENEO_PROCESSING_",
         env_file=".env",


### PR DESCRIPTION
## Problem

CDSE `sentinel-2-l2a` (and any raster-extension collection) comes out **faded**. The assets declare
per-band `raster:scale: 0.0001` and `raster:offset: -0.1` (the Sentinel-2 processing-baseline ≥ 04.00
BOA offset), but the reader consumed only `nodata` and returned **raw uint16 DN**. Graphs that scale
manually by `/10000` apply the scale but miss the `-0.1` offset, lifting every value by +0.1
reflectance — dark areas (water) turn grey. True value: `DN*scale + offset = DN/10000 − 0.1`.

This is **not** a JPEG2000 / dtype-conversion issue (the original hypothesis); it's the missing
radiometric offset.

## Fix

Apply `raster:scale`/`raster:offset` **per band** inside the module-level `_reader` (the reader used
by `mosaic_reader` for `load_collection`/`load_stac`/`load_url`), right after `part()`, returning
physical values as **float32**.

Properties:
- **Per band** — reflectance bands (B0x) carry scale/offset; **SCL carries none**, so its class
  values are preserved and the cloud mask keeps working. Bands default to identity (1/0) when no
  metadata is present (helper is a no-op then, keeping integer dtype).
- **float32, never float64** — scale/offset operands are built as `float32` arrays so a `float32`
  image isn't promoted back to `float64` (a `float32` array × a Python float would upcast).
- **Lazy** — `_reader` only runs inside a `RasterStack` task (on first access to a slice); the
  scale/offset numbers come from the in-memory STAC item (no extra I/O). Building the stack triggers
  zero reads and zero scaling.
- **Mask preserved** — masked nodata stays masked.

### Config
New `ProcessingSettings.apply_scale_offset` (default **True**, env
`TITILER_OPENEO_PROCESSING_APPLY_SCALE_OFFSET`). Set `false` to keep the old raw-DN behavior while
migrating graphs.

### ⚠️ Behavior change
With the flag ON, bands are returned as reflectance, so graphs must **drop the manual `/10000`**
(and any offset workaround) — otherwise they double-scale to ~black. Operators can disable the flag
during migration.

## Verification (live CDSE)

| | flag ON (default) | flag OFF |
|---|---|---|
| dtype | `float32` | `uint16` |
| B02 median | **0.0586** reflectance (1586·0.0001−0.1) | 1586 (raw DN) |
| SCL | classes 1–12 preserved | 1–12 |

`1586 DN → 0.0586` (correct) vs the faded `0.1586` from `/10000` alone. No slice is read until accessed.

## Tests

`tests/test_scale_offset.py` (14 tests): `_band_scale_offset` variants + default; `_asset_extra_fields`
for dict and `pystac.Item`; per-band apply with **float32 assertion**, SCL untouched, mask preserved;
no-op cases (all-identity keeps integer dtype, band/asset mismatch, missing assets); `_reader`
integration with the flag on/off; a **laziness** test (RasterStack built with a counting task → 0
executions until access); settings default + env override.

Full suite: **756 passed**, 12 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)