### PR TITLE
fix: recompute reducer per interval (fixes identical/grayscale periods)

### DIFF
--- a/tests/test_apply_graph_integration.py
+++ b/tests/test_apply_graph_integration.py
@@ -538,3 +538,59 @@ def test_apply_dimension_temporal_to_spectral_collapses_via_graph():
     assert img.array.shape == (3, 2, 2)  # 3 timestamps -> 3 spectral bands (renderable)
     # band values are the per-timestamp inputs * 10
     np.testing.assert_allclose([img.array[b].mean() for b in range(3)], [2.0, 5.0, 8.0])
+
+
+def test_aggregate_temporal_distinct_per_interval_via_graph():
+    """aggregate_temporal must compute EACH interval from its own slices.
+
+    The reducer is invoked once per interval, but the executor memoizes callback
+    nodes in a shared results_cache, so without resetting it every interval
+    returned the FIRST interval's result. In the real graph that made every
+    aggregated period identical (e.g. a 3-band temporal composite came out
+    grayscale because all bands were equal).
+    """
+
+    def _img(v):
+        return ImageData(
+            np.ma.array(np.full((1, 2, 2), v, np.float32)),
+            band_descriptions=["ndvi"],
+        )
+
+    # Distinct value per month -> per-interval means must be 0.2 / 0.5 / 0.8.
+    stack = RasterStack.from_images(
+        {
+            datetime(2024, 4, 10): _img(0.2),
+            datetime(2024, 4, 20): _img(0.2),
+            datetime(2024, 5, 10): _img(0.5),
+            datetime(2024, 6, 10): _img(0.8),
+        }
+    )
+    pg = {
+        "aggt": {
+            "process_id": "aggregate_temporal",
+            "arguments": {
+                "data": {"from_parameter": "data"},
+                "intervals": [
+                    ["2024-04-01", "2024-05-01"],
+                    ["2024-05-01", "2024-06-01"],
+                    ["2024-06-01", "2024-07-01"],
+                ],
+                "labels": ["2024-04-01", "2024-05-01", "2024-06-01"],
+                "reducer": {
+                    "process_graph": {
+                        "mean1": {
+                            "process_id": "mean",
+                            "arguments": {"data": {"from_parameter": "data"}},
+                            "result": True,
+                        }
+                    }
+                },
+            },
+            "result": True,
+        }
+    }
+    result = _run(pg, data=stack)
+    means = sorted(
+        round(float(np.ma.asarray(v.array).mean()), 3) for v in result.values()
+    )
+    assert means == [0.2, 0.5, 0.8]

--- a/titiler/openeo/processes/implementations/reduce.py
+++ b/titiler/openeo/processes/implementations/reduce.py
@@ -868,6 +868,41 @@ def _normalize_intervals(intervals: Any) -> List[List[Optional[str]]]:
     return [_interval_to_pair(iv) for iv in items]
 
 
+def _callback_results_cache(callback: Callable) -> Optional[Dict[Any, Any]]:
+    """Return the openEO executor's shared ``results_cache`` backing a callback.
+
+    The reducer/callback compiled by openeo_pg_parser_networkx is a
+    ``functools.partial(node_callable, ...)`` whose closure holds the
+    ``results_cache`` dict shared across the whole graph. We reach it so a process
+    that must invoke the callback more than once (e.g. ``aggregate_temporal``, once
+    per interval) can reset the callback's subgraph cache between calls — otherwise
+    the executor memoizes each node by id and every call returns the FIRST call's
+    result. Returns ``None`` if the structure can't be introspected (degrade
+    gracefully).
+    """
+    func = getattr(callback, "func", callback)  # unwrap functools.partial
+    freevars = getattr(getattr(func, "__code__", None), "co_freevars", ()) or ()
+    closure = getattr(func, "__closure__", None) or ()
+    for name, cell in zip(freevars, closure):
+        if name == "results_cache" and isinstance(cell.cell_contents, dict):
+            return cell.cell_contents
+    return None
+
+
+def _reset_results_cache(
+    cache: Optional[Dict[Any, Any]], baseline: Dict[Any, Any]
+) -> None:
+    """Reset a callback's shared results_cache to ``baseline`` (no-op if None).
+
+    Used to force a per-call recompute (e.g. ``aggregate_temporal`` per interval)
+    while preserving upstream cache entries captured in ``baseline``.
+    """
+    if cache is None:
+        return
+    cache.clear()
+    cache.update(baseline)
+
+
 def aggregate_temporal(
     data: RasterStack,
     intervals: Union[TemporalIntervals, List[List[Optional[str]]]],
@@ -934,6 +969,16 @@ def aggregate_temporal(
     if union_keys:
         data.prefetch(union_keys)
 
+    # The reducer is invoked once PER interval, but the executor memoizes each
+    # callback node in a results_cache SHARED across those calls. Without
+    # intervention every interval after the first returns the first interval's
+    # result (identical labels -> e.g. a grayscale composite instead of distinct
+    # per-period values). Snapshot the cache before any reduction and reset it to
+    # that state before each interval, so each recomputes on its own sub-stack
+    # while upstream entries are preserved (no re-reads).
+    reducer_cache = _callback_results_cache(reducer)
+    cache_baseline = dict(reducer_cache or {})
+
     result_images: Dict[datetime, ImageData] = {}
 
     for idx in range(len(parsed_intervals)):
@@ -960,6 +1005,10 @@ def aggregate_temporal(
         reducer_kwargs: Dict[str, Any] = {"data": sub_stack}
         if context is not None:
             reducer_kwargs["context"] = context
+
+        # Force this interval's reducer to recompute (see snapshot above).
+        _reset_results_cache(reducer_cache, cache_baseline)
+
         reduced_array = _coerce_reduced_array(reducer(**reducer_kwargs))
 
         first_img = next(iter(sub_images.values()))


### PR DESCRIPTION
## Symptom
A temporal-composite graph completed but came out **grayscale instead of RGB** — the 3 monthly NDVI bands were identical.

## Root cause
`aggregate_temporal` invokes the reducer **once per interval**, but the openEO executor (`openeo_pg_parser_networkx`) memoizes each callback node in a `results_cache` **shared across those calls**. The executor only bypasses that cache for parents `aggregate_temporal_period`/`aggregate_spatial` — **not** plain `aggregate_temporal`. So intervals 2..N returned interval 1's cached result:

```
aggregate_temporal(mean) over months with NDVI 0.2 / 0.5 / 0.8
  -> 0.2 / 0.2 / 0.2   (all the first interval)  ❌
```

Reproduced in-process with `scripts/debug_graph.py`.

This is the same callback-cache pitfall already documented in `apply.py`/`reduce.py`. Unlike `array_apply`, it **can't** be solved by "call once" — each interval is a distinct group that legitimately needs its own reduction.

## Fix
Snapshot the reducer's shared `results_cache` before any reduction and reset it to that baseline before each interval, so each interval recomputes on its own sub-stack **while preserving upstream cache entries** (no re-reads, compatible with the #311 eviction work). Degrades to current behavior if the callback's cache can't be introspected.

```
-> 0.2 / 0.5 / 0.8   ✅   (distinct bands -> RGB)
```

## Tests
`test_aggregate_temporal_distinct_per_interval_via_graph` runs `aggregate_temporal` through the real `OpenEOProcessGraph` executor and asserts distinct per-interval means. Full suite: 760 passed, 12 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)