### PR TITLE
feat: add rename_labels

### DIFF
--- a/tests/test_rename_labels.py
+++ b/tests/test_rename_labels.py
@@ -1,0 +1,118 @@
+"""Tests for the rename_labels process."""
+
+from datetime import datetime
+
+import numpy as np
+import pytest
+from openeo_pg_parser_networkx.graph import OpenEOProcessGraph
+from rio_tiler.models import ImageData
+
+from titiler.openeo.errors import OpenEOException
+from titiler.openeo.processes import process_registry
+from titiler.openeo.processes.implementations.arrays import rename_labels
+from titiler.openeo.processes.implementations.data_model import RasterStack
+
+
+def _stack(band_descriptions=None):
+    img = ImageData(
+        np.ma.array(np.arange(3 * 2 * 2, dtype="float32").reshape(3, 2, 2)),
+        band_descriptions=band_descriptions or ["b1", "b2", "b3"],
+    )
+    return RasterStack.from_images({datetime(2024, 4, 1): img})
+
+
+def test_registered_in_process_registry():
+    assert "rename_labels" in process_registry[None]
+
+
+def test_rename_bands_by_position():
+    out = rename_labels(_stack(), "bands", target=["B04", "B08", "SCL"])
+    assert out.first.band_descriptions == ["B04", "B08", "SCL"]
+    # data is unchanged
+    np.testing.assert_array_equal(out.first.array, _stack().first.array)
+
+
+def test_rename_bands_with_source_subset():
+    out = rename_labels(_stack(), "bands", target=["RED", "NIR"], source=["b1", "b3"])
+    assert out.first.band_descriptions == ["RED", "b2", "NIR"]
+
+
+def test_rename_spectral_alias():
+    out = rename_labels(_stack(), "spectral", target=["a", "b", "c"])
+    assert out.first.band_descriptions == ["a", "b", "c"]
+
+
+def test_rename_unnamed_bands_by_position():
+    # band_descriptions absent -> still renamable by position
+    img = ImageData(np.ma.array(np.zeros((2, 2, 2), "float32")), band_descriptions=[])
+    stack = RasterStack.from_images({datetime(2024, 4, 1): img})
+    out = rename_labels(stack, "bands", target=["x", "y"])
+    assert out.first.band_descriptions == ["x", "y"]
+
+
+def test_rename_temporal_by_position():
+    out = rename_labels(_stack(), "t", target=["2025-01-01"])
+    assert list(out.keys()) == [datetime(2025, 1, 1)]
+
+
+def test_rename_temporal_with_source():
+    s = RasterStack.from_images(
+        {
+            datetime(2024, 4, 1): ImageData(
+                np.ma.array(np.zeros((1, 2, 2), "float32"))
+            ),
+            datetime(2024, 5, 1): ImageData(np.ma.array(np.ones((1, 2, 2), "float32"))),
+        }
+    )
+    out = rename_labels(s, "t", target=["2030-01-01"], source=["2024-05-01"])
+    keys = sorted(out.keys())
+    assert keys == [datetime(2024, 4, 1), datetime(2030, 1, 1)]
+
+
+def test_label_mismatch():
+    with pytest.raises(OpenEOException) as exc:
+        rename_labels(_stack(), "bands", target=["a", "b"], source=["b1"])
+    assert exc.value.code == "LabelMismatch"
+
+
+def test_label_mismatch_by_position():
+    with pytest.raises(OpenEOException) as exc:
+        rename_labels(_stack(), "bands", target=["a", "b"])  # 2 != 3 bands
+    assert exc.value.code == "LabelMismatch"
+
+
+def test_labels_not_enumerated_missing_source():
+    with pytest.raises(OpenEOException) as exc:
+        rename_labels(_stack(), "bands", target=["x"], source=["does-not-exist"])
+    assert exc.value.code == "LabelsNotEnumerated"
+
+
+def test_label_exists_on_collision():
+    with pytest.raises(OpenEOException) as exc:
+        rename_labels(_stack(), "bands", target=["b2", "b2", "b3"])
+    assert exc.value.code == "LabelExists"
+
+
+def test_unknown_dimension():
+    with pytest.raises(OpenEOException) as exc:
+        rename_labels(_stack(), "x", target=["a"])
+    assert exc.value.code == "DimensionNotAvailable"
+
+
+def test_rename_labels_via_process_graph():
+    pg = {
+        "process_graph": {
+            "r": {
+                "process_id": "rename_labels",
+                "arguments": {
+                    "data": {"from_parameter": "data"},
+                    "dimension": "bands",
+                    "target": ["B04", "B08", "SCL"],
+                },
+                "result": True,
+            }
+        }
+    }
+    fn = OpenEOProcessGraph(pg_data=pg).to_callable(process_registry=process_registry)
+    out = fn(named_parameters={"data": _stack()})
+    assert out.first.band_descriptions == ["B04", "B08", "SCL"]

--- a/titiler/openeo/processes/data/rename_labels.json
+++ b/titiler/openeo/processes/data/rename_labels.json
@@ -1,0 +1,71 @@
+{
+  "id": "rename_labels",
+  "summary": "Rename dimension labels",
+  "description": "Renames the labels of the specified dimension in the data cube from `source` to `target`.\n\nIf the array for the parameter `source` is empty, the dimension labels are renamed to the labels specified in the parameter `target` based on their position in the data cube. Otherwise, the labels in `source` are renamed to the corresponding labels in `target` and the number of labels in `source` and `target` must be equal.\n\nThis process only renames the labels, it does not reorder or change the data in any other way.",
+  "categories": [
+    "cubes"
+  ],
+  "parameters": [
+    {
+      "name": "data",
+      "description": "The data cube.",
+      "schema": {
+        "type": "object",
+        "subtype": "datacube"
+      }
+    },
+    {
+      "name": "dimension",
+      "description": "The name of the dimension to rename the labels for.",
+      "schema": {
+        "type": "string"
+      }
+    },
+    {
+      "name": "target",
+      "description": "The new names for the labels. If a target dimension label already exists in the data cube, a `LabelExists` exception is thrown.",
+      "schema": {
+        "type": "array",
+        "items": {
+          "type": [
+            "number",
+            "string"
+          ]
+        }
+      }
+    },
+    {
+      "name": "source",
+      "description": "The original names of the labels to be renamed to corresponding labels specified in the parameter `target`. If this array is empty, the dimension labels are renamed by their position. The number of labels in the parameters `source` and `target` must be equal.",
+      "schema": {
+        "type": "array",
+        "items": {
+          "type": [
+            "number",
+            "string"
+          ]
+        }
+      },
+      "default": [],
+      "optional": true
+    }
+  ],
+  "returns": {
+    "description": "The data cube with the same dimensions. The only change is the names of the dimension labels.",
+    "schema": {
+      "type": "object",
+      "subtype": "datacube"
+    }
+  },
+  "exceptions": {
+    "LabelMismatch": {
+      "message": "The number of labels in the parameters `source` and `target` don't match."
+    },
+    "LabelsNotEnumerated": {
+      "message": "The dimension labels are not enumerated."
+    },
+    "LabelExists": {
+      "message": "A label with the specified name exists."
+    }
+  }
+}

--- a/titiler/openeo/processes/implementations/arrays.py
+++ b/titiler/openeo/processes/implementations/arrays.py
@@ -21,6 +21,7 @@ __all__ = [
     "create_data_cube",
     "add_dimension",
     "merge_cubes",
+    "rename_labels",
 ]
 
 
@@ -223,6 +224,164 @@ def add_dimension(
     )
 
     return RasterStack.from_images(new_data)
+
+
+class LabelMismatch(OpenEOException):
+    """Raised when the number of source and target labels don't match."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message=message, code="LabelMismatch", status_code=400)
+
+
+class LabelExists(OpenEOException):
+    """Raised when a renamed label collides with an existing label."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message=message, code="LabelExists", status_code=400)
+
+
+class LabelsNotEnumerated(OpenEOException):
+    """Raised when the dimension labels are not enumerated/available."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message=message, code="LabelsNotEnumerated", status_code=400)
+
+
+def _compute_renamed_labels(
+    current: List[Any], source: List[Any], target: List[Any]
+) -> List[Any]:
+    """Rename ``current`` per the source/target mapping (generic over hashables).
+
+    - source empty: ``target`` replaces all labels by position (lengths must match).
+    - source given: each ``source`` label is renamed to its ``target`` counterpart.
+
+    Enforces the openEO ``LabelMismatch``/``LabelsNotEnumerated``/``LabelExists``
+    exceptions.
+    """
+    if source:
+        if len(source) != len(target):
+            raise LabelMismatch(
+                f"The number of labels in 'source' ({len(source)}) and 'target' "
+                f"({len(target)}) don't match."
+            )
+        missing = [s for s in source if s not in current]
+        if missing:
+            raise LabelsNotEnumerated(
+                f"Source label(s) {missing} do not exist in the dimension."
+            )
+        mapping = dict(zip(source, target))
+        renamed = [mapping.get(label, label) for label in current]
+    else:
+        if len(target) != len(current):
+            raise LabelMismatch(
+                f"Renaming by position requires one 'target' label per existing "
+                f"label (expected {len(current)}, got {len(target)})."
+            )
+        renamed = list(target)
+
+    seen: set = set()
+    for label in renamed:
+        if label in seen:
+            raise LabelExists(f"A label with the name '{label}' already exists.")
+        seen.add(label)
+    return renamed
+
+
+def _rename_band_labels(
+    data: RasterStack, source: List[Any], target: List[Any]
+) -> RasterStack:
+    """Rename the spectral (band) labels of every image in the stack."""
+    result: Dict[datetime, ImageData] = {}
+    for key, img in data.items():
+        current = list(img.band_descriptions or [])
+        if not current:
+            # Bands are not named yet; positional placeholders of the right length.
+            current = [f"band{i + 1}" for i in range(img.count)]
+        renamed = _compute_renamed_labels(current, source, target)
+        result[key] = ImageData(
+            img.array,
+            assets=img.assets,
+            crs=img.crs,
+            bounds=img.bounds,
+            band_descriptions=renamed,
+            metadata=img.metadata,
+        )
+    return RasterStack.from_images(result)
+
+
+def _coerce_temporal_label(label: Any) -> datetime:
+    """Parse a temporal label into a naive-UTC datetime (stack keys are datetimes)."""
+    if isinstance(label, datetime):
+        return _normalize_to_naive_utc(label)
+    try:
+        return _normalize_to_naive_utc(datetime.fromisoformat(str(label)))
+    except (ValueError, TypeError) as err:
+        raise LabelsNotEnumerated(
+            f"Temporal label '{label}' is not a valid ISO datetime."
+        ) from err
+
+
+def _rename_temporal_labels(
+    data: RasterStack, source: List[Any], target: List[Any]
+) -> RasterStack:
+    """Rename temporal labels (the stack keys); targets are parsed to datetimes."""
+    current = list(data.keys())
+    src = [_coerce_temporal_label(s) for s in source]
+    tgt = [_coerce_temporal_label(t) for t in target]
+    renamed = _compute_renamed_labels(current, src, tgt)
+    result: Dict[datetime, ImageData] = {
+        new_key: data[old_key] for old_key, new_key in zip(current, renamed)
+    }
+    return RasterStack.from_images(result)
+
+
+@process
+def rename_labels(
+    data: RasterStack,
+    dimension: str,
+    target: List[Union[str, float]],
+    source: Optional[List[Union[str, float]]] = None,
+) -> RasterStack:
+    """Rename the labels of a dimension in the data cube.
+
+    Supports the spectral (``"bands"``/``"spectral"``) and temporal
+    (``"t"``/``"temporal"``/``"time"``) dimensions: for bands the band descriptions
+    are renamed; for the temporal dimension the stack keys are renamed (targets are
+    parsed to datetimes). The data itself is unchanged.
+
+    Args:
+        data: The data cube.
+        dimension: The name of the dimension to rename the labels for.
+        target: The new label names. If a target label already exists, a
+            ``LabelExists`` exception is raised.
+        source: The original label names to rename. When empty (default), labels
+            are renamed by position and ``target`` must have one entry per label.
+
+    Returns:
+        The data cube with renamed labels.
+
+    Raises:
+        LabelMismatch: If the number of source and target labels don't match.
+        LabelsNotEnumerated: If a source label does not exist.
+        LabelExists: If a renamed label collides with another label.
+    """
+    if not data:
+        raise ValueError("Expected a non-empty data cube")
+
+    source = list(source or [])
+    target = list(target)
+    dim = dimension.lower()
+
+    if dim in ("bands", "spectral"):
+        return _rename_band_labels(data, source, target)
+    if dim in ("t", "temporal", "time"):
+        return _rename_temporal_labels(data, source, target)
+
+    raise OpenEOException(
+        message=f"A dimension with the name '{dimension}' does not exist.",
+        code="DimensionNotAvailable",
+        status_code=400,
+    )
 
 
 class OverlapResolverMissing(OpenEOException):


### PR DESCRIPTION
Implements the openEO [`rename_labels`](https://openeo.org/documentation/1.0/processes.html#rename_labels) process — renames the labels of a dimension without changing the data.

## Behaviour
- **bands / spectral** → renames each image's band descriptions.
- **t / temporal** → renames the stack keys (targets parsed as ISO datetimes, since the RasterStack is datetime-keyed).
- `source` empty → rename **by position** (`target` must have one entry per label).
- `source` given → rename only the named labels to their `target` counterparts.

## Errors (per spec)
- `LabelMismatch` — `source`/`target` length differ (or position-rename length ≠ label count)
- `LabelsNotEnumerated` — a `source` label doesn't exist / a temporal target isn't a valid datetime
- `LabelExists` — a renamed label collides with another
- `DimensionNotAvailable` — unknown dimension

## Files
- `titiler/openeo/processes/data/rename_labels.json` — process spec (auto-registered by name).
- `titiler/openeo/processes/implementations/arrays.py` — `rename_labels` (+ small helpers/exceptions), added to `__all__`.
- `tests/test_rename_labels.py` — 13 tests: band & temporal renaming, positional vs source/target, unnamed bands, each error case, and execution through the real `OpenEOProcessGraph` executor.

Full suite: 773 passed, 12 skipped.

> Spec JSON is the official openEO 1.0 `rename_labels` definition. If you have a specific variant you wanted me to use, point me at it and I'll swap it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)