### PR TITLE
feat: add resample_cube_spatial; unify spatial resampling

### DIFF
--- a/tests/test_resample_cube_spatial.py
+++ b/tests/test_resample_cube_spatial.py
@@ -1,0 +1,115 @@
+"""Tests for the resample_cube_spatial process."""
+
+from datetime import datetime
+
+import numpy as np
+import pytest
+from openeo_pg_parser_networkx.graph import OpenEOProcessGraph
+from rio_tiler.models import ImageData
+
+from titiler.openeo.processes import process_registry
+from titiler.openeo.processes.implementations.data_model import RasterStack
+from titiler.openeo.processes.implementations.spatial import resample_cube_spatial
+
+
+def _img(arr, bounds=(0, 0, 4, 4), crs="EPSG:4326", bands=None):
+    return ImageData(
+        np.ma.asanyarray(arr).astype("float32"),
+        bounds=bounds,
+        crs=crs,
+        band_descriptions=bands,
+    )
+
+
+def _stack(img, key=datetime(2024, 1, 1)):
+    return RasterStack.from_images({key: img})
+
+
+def test_registered_in_process_registry():
+    assert "resample_cube_spatial" in process_registry[None]
+
+
+def test_downscale_same_crs_average():
+    src = _stack(_img(np.arange(16).reshape(1, 4, 4), bands=["b"]))
+    target = _stack(_img(np.zeros((1, 2, 2)), bounds=(0, 0, 4, 4)))
+
+    out = resample_cube_spatial(src, target, method="average")
+    img = out.first
+    assert img.array.shape == (1, 2, 2)
+    assert tuple(img.bounds) == (0, 0, 4, 4)
+    assert img.band_descriptions == ["b"]  # bands preserved
+    # block means of the 4x4 grid
+    np.testing.assert_allclose(img.array[0], [[2.5, 4.5], [10.5, 12.5]])
+
+
+def test_already_aligned_is_identity():
+    src = _stack(_img(np.arange(16).reshape(1, 4, 4)))
+    # target IS the source grid -> no work, same image returned
+    out = resample_cube_spatial(src, src, method="near")
+    assert out.first is src.first
+
+
+def test_reproject_to_target_crs():
+    src = _stack(_img(np.arange(16).reshape(1, 4, 4), crs="EPSG:4326"))
+    target = _stack(
+        _img(np.zeros((1, 8, 8)), bounds=(0, 0, 445277.96, 445640.1), crs="EPSG:3857")
+    )
+    out = resample_cube_spatial(src, target, method="near")
+    assert out.first.array.shape == (1, 8, 8)
+    from rasterio.crs import CRS as RioCRS
+
+    assert RioCRS.from_user_input(out.first.crs).to_epsg() == 3857
+
+
+def test_preserves_temporal_dimension():
+    src = RasterStack.from_images(
+        {
+            datetime(2024, 1, 1): _img(np.ones((1, 4, 4))),
+            datetime(2024, 1, 2): _img(np.full((1, 4, 4), 2.0)),
+        }
+    )
+    target = _stack(_img(np.zeros((1, 2, 2))))
+    out = resample_cube_spatial(src, target, method="near")
+    assert sorted(out.keys()) == [datetime(2024, 1, 1), datetime(2024, 1, 2)]
+    assert all(v.array.shape == (1, 2, 2) for v in out.values())
+
+
+def test_nodata_mask_preserved():
+    arr = np.ma.array(
+        np.arange(16, dtype="float32").reshape(1, 4, 4),
+        mask=np.zeros((1, 4, 4), dtype=bool),
+    )
+    arr.mask[0, :2, :2] = True  # mask the top-left quadrant
+    src = _stack(_img(arr))
+    target = _stack(_img(np.zeros((1, 2, 2))))
+    out = resample_cube_spatial(src, target, method="near")
+    # top-left output pixel comes from masked source -> stays masked
+    assert bool(np.ma.getmaskarray(out.first.array)[0, 0, 0]) is True
+    assert bool(np.ma.getmaskarray(out.first.array)[0, 1, 1]) is False
+
+
+def test_unsupported_method():
+    src = _stack(_img(np.zeros((1, 4, 4))))
+    with pytest.raises(ValueError, match="Unsupported resampling method"):
+        resample_cube_spatial(src, src, method="bogus")
+
+
+def test_via_process_graph():
+    src = _stack(_img(np.arange(16).reshape(1, 4, 4)))
+    target = _stack(_img(np.zeros((1, 2, 2))))
+    pg = {
+        "process_graph": {
+            "r": {
+                "process_id": "resample_cube_spatial",
+                "arguments": {
+                    "data": {"from_parameter": "data"},
+                    "target": {"from_parameter": "target"},
+                    "method": "bilinear",
+                },
+                "result": True,
+            }
+        }
+    }
+    fn = OpenEOProcessGraph(pg_data=pg).to_callable(process_registry=process_registry)
+    out = fn(named_parameters={"data": src, "target": target})
+    assert out.first.array.shape == (1, 2, 2)

--- a/titiler/openeo/processes/data/resample_cube_spatial.json
+++ b/titiler/openeo/processes/data/resample_cube_spatial.json
@@ -1,0 +1,93 @@
+{
+  "id": "resample_cube_spatial",
+  "summary": "Resample the spatial dimensions to match a target data cube",
+  "description": "Resamples the spatial dimensions (x,y) from a source data cube to align with the corresponding dimensions of the given target data cube. Returns a new data cube with the resampled dimensions.\n\nTo resample a data cube to a specific resolution or projection regardless of an existing target data cube, refer to ``resample_spatial()``.",
+  "categories": [
+    "cubes",
+    "reproject"
+  ],
+  "parameters": [
+    {
+      "name": "data",
+      "description": "A raster data cube.",
+      "schema": {
+        "type": "object",
+        "subtype": "datacube",
+        "dimensions": [
+          {
+            "type": "spatial",
+            "axis": [
+              "x",
+              "y"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "target",
+      "description": "A raster data cube that describes the spatial target resolution.",
+      "schema": {
+        "type": "object",
+        "subtype": "datacube",
+        "dimensions": [
+          {
+            "type": "spatial",
+            "axis": [
+              "x",
+              "y"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "method",
+      "description": "Resampling method to use. The following options are available and are meant to align with [`gdalwarp`](https://gdal.org/programs/gdalwarp.html#cmdoption-gdalwarp-r):\n\n* `average`: average (mean) resampling, computes the weighted average of all valid pixels\n* `bilinear`: bilinear resampling\n* `cubic`: cubic resampling\n* `cubicspline`: cubic spline resampling\n* `lanczos`: Lanczos windowed sinc resampling\n* `max`: maximum resampling, selects the maximum value from all valid pixels\n* `med`: median resampling, selects the median value of all valid pixels\n* `min`: minimum resampling, selects the minimum value from all valid pixels\n* `mode`: mode resampling, selects the value which appears most often of all the sampled points\n* `near`: nearest neighbour resampling (default)\n* `q1`: first quartile resampling, selects the first quartile value of all valid pixels\n* `q3`: third quartile resampling, selects the third quartile value of all valid pixels\n* `rms` root mean square (quadratic mean) of all valid pixels\n* `sum`: compute the weighted sum of all valid pixels\n\nValid pixels are determined based on the function ``is_valid()``.",
+      "schema": {
+        "type": "string",
+        "enum": [
+          "average",
+          "bilinear",
+          "cubic",
+          "cubicspline",
+          "lanczos",
+          "max",
+          "med",
+          "min",
+          "mode",
+          "near",
+          "q1",
+          "q3",
+          "rms",
+          "sum"
+        ]
+      },
+      "default": "near",
+      "optional": true
+    }
+  ],
+  "returns": {
+    "description": "A raster data cube with the same dimensions. The dimension properties (name, type, labels, reference system and resolution) remain unchanged, except for the resolution and dimension labels of the spatial dimensions.",
+    "schema": {
+      "type": "object",
+      "subtype": "datacube",
+      "dimensions": [
+        {
+          "type": "spatial",
+          "axis": [
+            "x",
+            "y"
+          ]
+        }
+      ]
+    }
+  },
+  "links": [
+    {
+      "href": "https://openeo.org/documentation/1.0/datacubes.html#resample",
+      "rel": "about",
+      "title": "Resampling explained in the openEO documentation"
+    }
+  ]
+}

--- a/titiler/openeo/processes/implementations/spatial.py
+++ b/titiler/openeo/processes/implementations/spatial.py
@@ -1,15 +1,111 @@
 """titiler.openeo.processes Spatial."""
 
-import logging
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy
 from pyproj import CRS
+from rasterio.crs import CRS as RioCRS
+from rasterio.enums import Resampling
+from rasterio.transform import array_bounds
+from rasterio.transform import from_bounds as transform_from_bounds
+from rasterio.warp import calculate_default_transform
+from rasterio.warp import reproject as rio_reproject
 from rio_tiler.utils import resize_array
 
 from .data_model import ImageData, RasterStack, compute_cutline_mask
 
-__all__ = ["resample_spatial", "aggregate_spatial", "mask_polygon", "mask"]
+__all__ = [
+    "resample_spatial",
+    "resample_cube_spatial",
+    "aggregate_spatial",
+    "mask_polygon",
+    "mask",
+]
+
+# openEO resampling method names -> rasterio.enums.Resampling members.
+_RESAMPLING_METHODS = {
+    "near": "nearest",
+    "nearest": "nearest",
+    "bilinear": "bilinear",
+    "cubic": "cubic",
+    "cubicspline": "cubic_spline",
+    "lanczos": "lanczos",
+    "average": "average",
+    "mode": "mode",
+    "max": "max",
+    "min": "min",
+    "med": "med",
+    "q1": "q1",
+    "q3": "q3",
+    "rms": "rms",
+    "sum": "sum",
+}
+
+
+def _resolve_resampling(method: str) -> Resampling:
+    """Map an openEO resampling method name to a rasterio Resampling member."""
+    if method not in _RESAMPLING_METHODS:
+        raise ValueError(f"Unsupported resampling method: {method}")
+    return Resampling[_RESAMPLING_METHODS[method]]
+
+
+def _warp_image_to_grid(
+    img: ImageData,
+    dst_crs: Any,
+    dst_transform: Any,
+    dst_width: int,
+    dst_height: int,
+    resampling: Resampling,
+) -> ImageData:
+    """Warp one image onto an explicit destination grid (crs + transform + size).
+
+    Shared by ``resample_spatial`` (grid from CRS+resolution) and
+    ``resample_cube_spatial`` (grid from a target cube). The data is warped with the
+    requested method and the nodata mask is warped with nearest neighbour so
+    valid/nodata regions follow the data and uncovered pixels stay masked.
+    """
+    src = img.array
+    bands = src.shape[0]
+    dtype = src.dtype
+    src_crs = RioCRS.from_user_input(img.crs)
+    out_crs = RioCRS.from_user_input(dst_crs)
+    src_transform = transform_from_bounds(*img.bounds, img.width, img.height)
+
+    dst_data = numpy.zeros((bands, dst_height, dst_width), dtype=dtype)
+    rio_reproject(
+        numpy.ascontiguousarray(src.data),
+        dst_data,
+        src_transform=src_transform,
+        src_crs=src_crs,
+        dst_transform=dst_transform,
+        dst_crs=out_crs,
+        resampling=resampling,
+    )
+
+    src_mask = numpy.ma.getmaskarray(src).astype("uint8")
+    dst_mask = numpy.ones((bands, dst_height, dst_width), dtype="uint8")
+    rio_reproject(
+        numpy.ascontiguousarray(src_mask),
+        dst_mask,
+        src_transform=src_transform,
+        src_crs=src_crs,
+        dst_transform=dst_transform,
+        dst_crs=out_crs,
+        resampling=Resampling.nearest,
+        src_nodata=1,
+        dst_nodata=1,
+    )
+
+    out = numpy.ma.masked_array(dst_data, mask=dst_mask.astype(bool))
+    west, south, east, north = array_bounds(dst_height, dst_width, dst_transform)
+    return ImageData(
+        out,
+        assets=img.assets,
+        crs=out_crs,
+        bounds=(west, south, east, north),
+        band_descriptions=img.band_descriptions,
+        metadata=img.metadata,
+    )
 
 
 class IncompatibleDataCubes(Exception):
@@ -279,35 +375,13 @@ def resample_spatial(
         # align parameter is accepted but not yet implemented
         # We silently ignore it for now (uses GDAL defaults)
 
-        logging.info(
-            f"resample_spatial: input crs={img.crs}, dst_crs={dst_crs}, "
-            f"resolution={resolution}, size={img.width}x{img.height}, bounds={img.bounds}"
-        )
-
         # If no projection change requested and no resolution change, return as-is
         if dst_crs is None and (resolution is None or resolution == 0):
             return img
 
+        resampling = _resolve_resampling(method)
         # Use the image's existing CRS if no new projection specified
         target_crs = dst_crs if dst_crs is not None else img.crs
-        # Map the string resampling method to the matching enum name
-        resampling_method_map = {
-            "nearest": "nearest",
-            "near": "nearest",  # OpenEO alias for nearest
-            "bilinear": "bilinear",
-            "cubic": "cubic",
-            "cubicspline": "cubic_spline",
-            "lanczos": "lanczos",
-            "average": "average",
-            "mode": "mode",
-            "sum": "sum",
-            "rms": "rms",
-        }
-
-        if method not in resampling_method_map:
-            raise ValueError(f"Unsupported resampling method: {method}")
-
-        resampling_method = resampling_method_map[method]
 
         if (
             resolution is not None
@@ -315,19 +389,21 @@ def resample_spatial(
             and not isinstance(resolution, (list, tuple))
         ):
             resolution = (resolution, resolution)
-
-        # Handle resolution of 0 as no resolution change
         actual_resolution = None if resolution == 0 else resolution
 
-        # Reproject the image with the string method name
-        result = img.reproject(
-            target_crs, resolution=actual_resolution, reproject_method=resampling_method
+        # Derive the destination grid for this CRS/resolution (GDAL default extent),
+        # then warp onto it via the shared helper used by resample_cube_spatial.
+        dst_transform, dst_width, dst_height = calculate_default_transform(
+            RioCRS.from_user_input(img.crs),
+            RioCRS.from_user_input(target_crs),
+            img.width,
+            img.height,
+            *img.bounds,
+            resolution=actual_resolution,
         )
-        logging.info(
-            f"resample_spatial: output crs={result.crs}, "
-            f"size={result.width}x{result.height}, bounds={result.bounds}"
+        return _warp_image_to_grid(
+            img, target_crs, dst_transform, dst_width, dst_height, resampling
         )
-        return result
 
     # Get destination CRS from parameters (None if not specified)
     dst_crs: Optional[CRS] = None
@@ -340,6 +416,103 @@ def resample_spatial(
     # Reproject each image in the stack
     return RasterStack.from_images(
         {k: _reproject_img(v, dst_crs, resolution, method) for k, v in data.items()}
+    )
+
+
+def _target_spatial_grid(
+    target: RasterStack,
+) -> Tuple[Optional[CRS], Tuple[float, float, float, float], int, int]:
+    """Return (crs, bounds, width, height) of the target cube's spatial grid.
+
+    Reads ImageRef metadata first (no pixel load); falls back to realizing the
+    first image when the refs don't carry spatial dimensions.
+    """
+    refs = target.get_image_refs()
+    if refs:
+        _, ref = refs[0]
+        if ref.crs is not None and ref.bounds and ref.width and ref.height:
+            return ref.crs, tuple(ref.bounds), ref.width, ref.height  # type: ignore[return-value]
+    img = target.first
+    return img.crs, tuple(img.bounds), img.width, img.height  # type: ignore[return-value]
+
+
+def _resample_image_to_grid(
+    img: ImageData,
+    dst_crs: Optional[CRS],
+    dst_bounds: Tuple[float, float, float, float],
+    dst_width: int,
+    dst_height: int,
+    resampling: Resampling,
+) -> ImageData:
+    """Resample a single image onto the target (crs, bounds, width, height) grid."""
+    # Already aligned: nothing to do.
+    if (
+        img.crs == dst_crs
+        and img.width == dst_width
+        and img.height == dst_height
+        and img.bounds is not None
+        and numpy.allclose(img.bounds, dst_bounds)
+    ):
+        return img
+
+    # Without georeferencing we can only resize to the target size.
+    if img.crs is None or img.bounds is None:
+        src = img.array
+        resized = resize_array(src.data, dst_height, dst_width)
+        resized_mask = resize_array(
+            numpy.ma.getmaskarray(src).astype("uint8"), dst_height, dst_width
+        ).astype(bool)
+        return ImageData(
+            numpy.ma.masked_array(resized, mask=resized_mask),
+            assets=img.assets,
+            crs=dst_crs,
+            bounds=dst_bounds,
+            band_descriptions=img.band_descriptions,
+            metadata=img.metadata,
+        )
+
+    # Warp onto the exact target grid via the shared helper.
+    dst_transform = transform_from_bounds(*dst_bounds, dst_width, dst_height)
+    return _warp_image_to_grid(
+        img, dst_crs, dst_transform, dst_width, dst_height, resampling
+    )
+
+
+def resample_cube_spatial(
+    data: RasterStack,
+    target: RasterStack,
+    method: str = "near",
+) -> RasterStack:
+    """Resample the spatial dimensions of ``data`` to match the ``target`` cube.
+
+    Each image in ``data`` is warped onto the target cube's spatial grid (CRS,
+    bounds and width/height). Non-spatial dimensions (time, bands) are preserved.
+
+    Args:
+        data: The source raster data cube.
+        target: A raster data cube describing the target spatial grid.
+        method: Resampling method (gdalwarp names, e.g. ``near`` (default),
+            ``bilinear``, ``cubic``, ``average``, ``min``, ``max``, ``med`` ...).
+
+    Returns:
+        The source cube resampled onto the target's spatial grid.
+    """
+    if not data:
+        raise ValueError("Expected a non-empty data cube")
+    if not target:
+        raise ValueError("Expected a non-empty target data cube")
+
+    resampling = _resolve_resampling(method)
+
+    dst_crs, dst_bounds, dst_width, dst_height = _target_spatial_grid(target)
+
+    return RasterStack.from_images(
+        {
+            key: _resample_image_to_grid(
+                img, dst_crs, dst_bounds, dst_width, dst_height, resampling
+            )
+            for key, img in data.items()
+        }
     )
 
 


### PR DESCRIPTION
Adds the openEO [`resample_cube_spatial`](https://openeo.org/documentation/1.0/processes.html#resample_cube_spatial) process and rationalizes the spatial resampling code so it shares one implementation with `resample_spatial`.

## resample_cube_spatial
Warps each image of the source cube onto the **target cube's exact spatial grid** (CRS + bounds + width/height) via `rasterio.warp.reproject`, preserving the temporal/band dimensions and the nodata mask.
- Already-aligned inputs are returned unchanged (fast path).
- Ungeoreferenced inputs fall back to a plain resize.

## Rationalization (per review feedback — `_reproject_img` vs `_resample_image_to_grid` were doing the same thing)
- **One method map**: `_RESAMPLING_METHODS` (openEO → rasterio name). `resample_spatial` drops its smaller local map and now also supports `max/min/med/q1/q3/rms/sum`.
- **One warp helper**: `_warp_image_to_grid(img, dst_crs, dst_transform, w, h, resampling)` — data warped with the chosen method, nodata mask warped with nearest. Both processes call it; they differ only in **how the target grid is derived**:
  - `resample_spatial` → `calculate_default_transform` (CRS + resolution)
  - `resample_cube_spatial` → the target cube's grid

  `resample_spatial` no longer routes through rio_tiler `img.reproject`; behaviour is equivalent (existing `resample_spatial` tests still pass).

## Tests
`data/resample_cube_spatial.json` + `tests/test_resample_cube_spatial.py` (downscale block-means, exact-grid identity, cross-CRS reproject, temporal preservation, nodata mask preservation, bad method, real graph run). Full suite: 768 passed, 12 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)