### PR TITLE
fix: normalize RasterStack timestamps to naive UTC at creation

### DIFF
--- a/tests/test_lazy_raster_stack.py
+++ b/tests/test_lazy_raster_stack.py
@@ -22,7 +22,7 @@ def mock_task():
 
 def test_lazy_raster_stack():
     # Create a mock asset with datetime
-    dt = datetime(2021, 1, 1, tzinfo=timezone.utc)
+    dt = datetime(2021, 1, 1)
     mock_asset = {"datetime": dt}
 
     # Create a list of tasks
@@ -53,7 +53,7 @@ def test_lazy_raster_stack_same_timestamp():
     Since keys are now datetime objects directly, items with the same
     timestamp will have the same key (last one wins in the mapping).
     """
-    dt = datetime(2021, 1, 1, tzinfo=timezone.utc)
+    dt = datetime(2021, 1, 1)
     mock_asset_1 = {"datetime": dt}
     mock_asset_2 = {"datetime": dt}
 
@@ -123,9 +123,9 @@ def test_truly_lazy_execution():
         return ImageData(array)
 
     # Create multiple mock assets with different timestamps
-    dt1 = datetime(2021, 1, 1, tzinfo=timezone.utc)
-    dt2 = datetime(2021, 1, 2, tzinfo=timezone.utc)
-    dt3 = datetime(2021, 1, 3, tzinfo=timezone.utc)
+    dt1 = datetime(2021, 1, 1)
+    dt2 = datetime(2021, 1, 2)
+    dt3 = datetime(2021, 1, 3)
 
     assets = [
         {"datetime": dt1},
@@ -180,9 +180,9 @@ def test_truly_lazy_execution():
 
 def test_lazy_raster_stack_first_last_properties():
     """Test the first and last properties for efficient RasterStack access."""
-    dt1 = datetime(2021, 1, 1, tzinfo=timezone.utc)
-    dt2 = datetime(2021, 1, 2, tzinfo=timezone.utc)
-    dt3 = datetime(2021, 1, 3, tzinfo=timezone.utc)
+    dt1 = datetime(2021, 1, 1)
+    dt2 = datetime(2021, 1, 2)
+    dt3 = datetime(2021, 1, 3)
 
     assets = [
         {"datetime": dt1},
@@ -230,8 +230,8 @@ def test_lazy_raster_stack_error_handling():
     def success_task():
         return mock_task()
 
-    dt1 = datetime(2021, 1, 1, tzinfo=timezone.utc)
-    dt2 = datetime(2021, 1, 2, tzinfo=timezone.utc)
+    dt1 = datetime(2021, 1, 1)
+    dt2 = datetime(2021, 1, 2)
 
     assets = [
         {"datetime": dt1},  # failing
@@ -275,10 +275,10 @@ def test_lazy_raster_stack_selective_execution():
 
         return task
 
-    dt1 = datetime(2021, 1, 1, tzinfo=timezone.utc)
-    dt2 = datetime(2021, 1, 2, tzinfo=timezone.utc)
-    dt3 = datetime(2021, 1, 3, tzinfo=timezone.utc)
-    dt4 = datetime(2021, 1, 4, tzinfo=timezone.utc)
+    dt1 = datetime(2021, 1, 1)
+    dt2 = datetime(2021, 1, 2)
+    dt3 = datetime(2021, 1, 3)
+    dt4 = datetime(2021, 1, 4)
 
     assets = [
         {"datetime": dt1, "id": "item-001"},
@@ -309,9 +309,9 @@ def test_lazy_raster_stack_selective_execution():
 
 def test_lazy_raster_stack_timestamps():
     """Test timestamp-related functionality."""
-    dt1 = datetime(2021, 1, 1, tzinfo=timezone.utc)  # Earliest
-    dt2 = datetime(2021, 1, 2, tzinfo=timezone.utc)  # Middle
-    dt3 = datetime(2021, 1, 3, tzinfo=timezone.utc)  # Latest
+    dt1 = datetime(2021, 1, 1)  # Earliest
+    dt2 = datetime(2021, 1, 2)  # Middle
+    dt3 = datetime(2021, 1, 3)  # Latest
 
     # Insert in non-chronological order
     assets = [
@@ -404,8 +404,8 @@ def test_lazy_raster_stack_future_tasks():
 
 def test_lazy_raster_stack_iteration_methods():
     """Test iteration methods of RasterStack."""
-    dt1 = datetime(2021, 1, 1, tzinfo=timezone.utc)
-    dt2 = datetime(2021, 1, 2, tzinfo=timezone.utc)
+    dt1 = datetime(2021, 1, 1)
+    dt2 = datetime(2021, 1, 2)
 
     assets = [
         {"datetime": dt1},
@@ -524,9 +524,9 @@ def test_first_property_with_failing_tasks():
 
         return task
 
-    dt1 = datetime(2021, 1, 1, tzinfo=timezone.utc)
-    dt2 = datetime(2021, 1, 2, tzinfo=timezone.utc)
-    dt3 = datetime(2021, 1, 3, tzinfo=timezone.utc)
+    dt1 = datetime(2021, 1, 1)
+    dt2 = datetime(2021, 1, 2)
+    dt3 = datetime(2021, 1, 3)
 
     # Create tasks where first 2 fail and 3rd succeeds
     assets = [
@@ -654,9 +654,9 @@ def test_apply_pixel_selection_with_failing_tasks():
 
         return task
 
-    dt1 = datetime(2021, 1, 1, tzinfo=timezone.utc)
-    dt2 = datetime(2021, 1, 2, tzinfo=timezone.utc)
-    dt3 = datetime(2021, 1, 3, tzinfo=timezone.utc)
+    dt1 = datetime(2021, 1, 1)
+    dt2 = datetime(2021, 1, 2)
+    dt3 = datetime(2021, 1, 3)
 
     # Create tasks where first 2 fail and 3rd succeeds
     assets = [
@@ -707,3 +707,31 @@ def test_empty_lazy_raster_stack():
     # apply_pixel_selection should also fail gracefully
     with pytest.raises(ValueError, match="Method returned an empty array"):
         apply_pixel_selection(lazy_stack, pixel_selection="first")
+
+
+def test_keys_normalized_to_naive_utc():
+    """tz-aware inputs are normalized to naive UTC at the source so a stack never
+    mixes tz-aware and tz-naive keys (which can't be compared when sorting)."""
+    aware = datetime(2021, 1, 1, 12, tzinfo=timezone.utc)
+    naive = datetime(2021, 1, 2)  # already naive
+    tasks = [
+        (mock_task, {"datetime": naive}),
+        (mock_task, {"datetime": aware}),
+    ]
+    stack = RasterStack(tasks=tasks, timestamp_fn=lambda a: a["datetime"])
+
+    keys = list(stack.keys())
+    assert all(k.tzinfo is None for k in keys)  # all naive
+    # sorted chronologically, aware converted to naive UTC
+    assert keys == [datetime(2021, 1, 1, 12), datetime(2021, 1, 2)]
+
+
+def test_from_images_normalizes_mixed_awareness():
+    """RasterStack.from_images normalizes keys so mixed awareness doesn't crash."""
+    img = ImageData(np.ma.array(np.zeros((1, 2, 2), "float32")))
+    aware = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    naive = datetime(2024, 2, 1)
+    stack = RasterStack.from_images({aware: img, naive: img})
+    keys = list(stack.keys())
+    assert all(k.tzinfo is None for k in keys)
+    assert keys == [datetime(2024, 1, 1), datetime(2024, 2, 1)]

--- a/titiler/openeo/processes/implementations/data_model.py
+++ b/titiler/openeo/processes/implementations/data_model.py
@@ -4,7 +4,7 @@ import logging
 import threading
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import (
     Any,
     Callable,
@@ -37,6 +37,21 @@ from rio_tiler.types import BBox
 # NOTE: RasterStack is now a class, not a type alias. The class is defined below.
 
 T = TypeVar("T")
+
+
+def _normalize_to_naive_utc(dt: datetime) -> datetime:
+    """Convert a datetime to naive UTC.
+
+    If the datetime is tz-aware, convert to UTC and strip tzinfo.
+    If naive, treat as UTC (return as-is).
+
+    RasterStack keys are normalized through this so a single stack never mixes
+    tz-aware and tz-naive datetimes (which can't be compared/sorted). This is the
+    one source of truth — other modules import it from here.
+    """
+    if dt.tzinfo is not None:
+        return dt.astimezone(timezone.utc).replace(tzinfo=None)
+    return dt
 
 
 def compute_cutline_mask(
@@ -392,10 +407,11 @@ class RasterStack(Dict[datetime, ImageData]):
 
         Keys are datetime objects directly, ensuring natural temporal ordering.
         """
-        # First pass: extract timestamps
+        # First pass: extract timestamps, normalized to naive UTC so a stack never
+        # mixes tz-aware and tz-naive keys (which can't be compared when sorting).
         timestamp_task_pairs: List[Tuple[datetime, int, Dict[str, Any]]] = []
         for i, (_task_fn, asset) in enumerate(self._tasks):
-            timestamp = self._timestamp_fn(asset)
+            timestamp = _normalize_to_naive_utc(self._timestamp_fn(asset))
             timestamp_task_pairs.append((timestamp, i, asset))
 
         # Sort by timestamp to ensure temporal ordering
@@ -776,6 +792,11 @@ class RasterStack(Dict[datetime, ImageData]):
         """
         if not images:
             raise ValueError("Cannot create RasterStack from empty images dict")
+
+        # Normalize keys to naive UTC up front so the cache/ImageRefs/keys stay in
+        # sync and a stack never mixes tz-aware and tz-naive datetimes (e.g. an
+        # aware load_collection key combined with a naive datetime.now()).
+        images = {_normalize_to_naive_utc(dt): img for dt, img in images.items()}
 
         # Get first image for dimension parameters
         first_key = next(iter(images))

--- a/titiler/openeo/processes/implementations/reduce.py
+++ b/titiler/openeo/processes/implementations/reduce.py
@@ -50,7 +50,7 @@ from rio_tiler.mosaic.methods import PixelSelectionMethod
 from rio_tiler.types import BBox
 from rio_tiler.utils import resize_array
 
-from .data_model import ImageRef, RasterStack
+from .data_model import ImageRef, RasterStack, _normalize_to_naive_utc
 
 logger = logging.getLogger(__name__)
 
@@ -733,17 +733,6 @@ def _resolve_output_keys(
     if len(set(starts)) < len(starts):
         raise DistinctDimensionLabelsRequired()
     return [s if s is not None else datetime.min for s in starts]
-
-
-def _normalize_to_naive_utc(dt: datetime) -> datetime:
-    """Convert a datetime to naive UTC.
-
-    If the datetime is tz-aware, convert to UTC and strip tzinfo.
-    If naive, treat as UTC (return as-is).
-    """
-    if dt.tzinfo is not None:
-        return dt.astimezone(timezone.utc).replace(tzinfo=None)
-    return dt
 
 
 def _timestamp_in_interval(


### PR DESCRIPTION
## The crash
```
add_dimension -> RasterStack.from_images -> _compute_metadata
    timestamp_task_pairs.sort(key=lambda x: x[0])
TypeError: can't compare offset-naive and offset-aware datetimes
```
A stack mixed tz-aware and tz-naive keys — e.g. an **aware** `load_collection` timestamp combined with a **naive** `datetime.now()` added by `add_dimension` — and sorting the keys blew up.

## Fix it at the source
Rather than patch each process, normalize timestamps to **naive UTC where the RasterStack is built**, so no process can reintroduce the mix:
- `_compute_metadata` → normalizes the `timestamp_fn` output (covers the `__init__`/`load_collection` path).
- `from_images` → normalizes the provided keys up front, so `_data_cache` / `_image_refs` / `_keys` stay in sync (normalizing only in `_compute_metadata` would have desynced the cache `from_images` sets separately).

This is the same `_normalize_to_naive_utc` already used by `aggregate_temporal`; it now lives in **`data_model` as the single source of truth**. `reduce.py` imports it from there (duplicate removed), and `arrays.py`'s `from .reduce import _normalize_to_naive_utc` keeps working via re-export (`a is r is d` → True).

## Tests
- The existing `test_lazy_raster_stack.py` cases now use naive datetimes (they exercise ordering/caching/laziness, not tz).
- Two new tests assert keys are normalized to naive UTC from both `RasterStack(...)` and `from_images(...)`, including the mixed-awareness case that used to crash.

Full suite: 783 passed, 12 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)