### PR TITLE
fix: sentinel key + band labels for multi-sensor feature fusion

### DIFF
--- a/tests/test_apply_graph_integration.py
+++ b/tests/test_apply_graph_integration.py
@@ -596,6 +596,68 @@ def test_aggregate_temporal_distinct_per_interval_via_graph():
     assert means == [0.2, 0.5, 0.8]
 
 
+def test_reduce_temporal_then_merge_produces_single_slice():
+    """reduce_dimension("t") on two cubes from DIFFERENT time ranges must yield
+    the same canonical temporal key so that merge_cubes combines them into a
+    single slice at the band level, not two separate temporal slices.
+
+    Regression: the old implementation kept the first acquisition's datetime as
+    the RasterStack key, so merging S2 (key 2019-09-07) with S1-p1 (key
+    2019-09-06) produced two temporal slices with mismatched band counts.
+    _apply_spectral_dimension_stack then failed with "all input arrays must
+    have the same shape" because it tried to stack (5,h,w) and (1,h,w) images.
+    """
+    # Simulate two temporally-reduced cubes at DIFFERENT original timestamps
+    # (as produced by load_collection→reduce_dimension("t") from different periods)
+    from titiler.openeo.processes.implementations.reduce import (
+        REDUCED_TEMPORAL_SENTINEL,
+    )
+
+    cube_s2 = RasterStack.from_images(
+        {
+            REDUCED_TEMPORAL_SENTINEL: ImageData(
+                np.ma.array(np.stack([np.full((2, 2), float(i)) for i in range(5)])),
+                band_descriptions=["B03", "B04", "B08", "B11", "B12"],
+            )
+        }
+    )
+    cube_s1 = RasterStack.from_images(
+        {
+            REDUCED_TEMPORAL_SENTINEL: ImageData(
+                np.ma.array(np.full((1, 2, 2), 0.5, np.float32)),
+                band_descriptions=[],
+            )
+        }
+    )
+
+    pg_add_and_merge = {
+        "ad": {
+            "process_id": "add_dimension",
+            "arguments": {
+                "data": {"from_parameter": "s1"},
+                "name": "spectral",
+                "label": "vh",
+                "type": "bands",
+            },
+        },
+        "merge": {
+            "process_id": "merge_cubes",
+            "arguments": {
+                "cube1": {"from_parameter": "s2"},
+                "cube2": {"from_node": "ad"},
+            },
+            "result": True,
+        },
+    }
+    result = _run(pg_add_and_merge, s2=cube_s2, s1=cube_s1)
+
+    # Must be a single temporal slice with 6 bands, not two slices
+    assert len(result) == 1
+    img = result.first
+    assert img.count == 6
+    assert img.band_descriptions == ["B03", "B04", "B08", "B11", "B12", "vh"]
+
+
 def test_add_dimension_bands_via_graph():
     """add_dimension(type='bands') must set band_descriptions, not add a temporal entry.
 

--- a/titiler/openeo/processes/implementations/reduce.py
+++ b/titiler/openeo/processes/implementations/reduce.py
@@ -67,6 +67,16 @@ __all__ = ["aggregate_temporal", "apply_pixel_selection", "reduce_dimension"]
 # Use 'firstpixel' reducer for pixel-wise first valid value behavior.
 # Note: rio_tiler doesn't have a 'last' PixelSelectionMethod, so 'lastpixel'
 # uses a fallback array-based implementation (not in this mapping).
+# Canonical key used as the RasterStack key for temporally-reduced cubes.
+# After reduce_dimension("t") the temporal dimension no longer exists per the
+# openEO spec. In our RasterStack model we still need *some* key, but it must
+# be the SAME for every reduced cube so that merge_cubes treats two reduced
+# cubes as having the same (single) temporal label and merges them at the band
+# level rather than keeping them as separate temporal slices.
+# A date from 1900 is safely before any real satellite acquisition and trivially
+# distinct from any user-supplied aggregate_temporal label.
+REDUCED_TEMPORAL_SENTINEL = datetime(1900, 1, 1)
+
 PIXEL_SELECTION_REDUCERS = {
     "firstpixel": "first",  # first available pixel (fills masked values)
     "mean": "mean",
@@ -145,9 +155,7 @@ def _create_pixel_selection_result(
         band_descriptions=band_names if band_names is not None else [],
         metadata={"pixel_selection_method": pixel_selection},
     )
-    # Use the first asset's datetime as the result key
-    result_datetime = assets_used[0] if assets_used else datetime.now()
-    return RasterStack.from_images({result_datetime: result_img})
+    return RasterStack.from_images({REDUCED_TEMPORAL_SENTINEL: result_img})
 
 
 def _collect_images_from_data(
@@ -358,7 +366,7 @@ def _reduce_temporal_dimension(
             "reduction_method": getattr(reducer, "__name__", "custom_reducer"),
         },
     )
-    return RasterStack.from_images({first_key: reduced_img})
+    return RasterStack.from_images({REDUCED_TEMPORAL_SENTINEL: reduced_img})
 
 
 def _reshape_reduced_spectral_data(


### PR DESCRIPTION
## Summary

Two related fixes that together make the multi-sensor feature-fusion graph work
(`load_collection → reduce_t → reduce_spectral → add_dimension → merge_cubes → apply_dimension(spectral)`):

### 1. `add_dimension(type="bands")` — set band_descriptions, not temporal entry

The old implementation added a new temporal `RasterStack` entry for every dimension type, so band labels were never propagated. `merge_cubes` saw images with empty `band_descriptions` at shared temporal keys and raised `OverlapResolverMissing` even when the bands were logically distinct.

**Fix:** for `type in ("bands", "spectral")`, update `band_descriptions` on each existing image instead of adding a temporal entry.

### 2. `reduce_dimension("t")` — canonical sentinel key

After temporal reduction the temporal dimension **no longer exists** (openEO spec: *"The dimension over which the reducer is applied is removed from the output data cube"*). The old implementation kept the first acquisition's datetime as the RasterStack key, so merging two temporally-reduced cubes from different time ranges produced separate temporal slices with mismatched band counts. `_apply_spectral_dimension_stack` then crashed with:
```
ValueError: all input arrays must have the same shape
```

**Fix:** emit `REDUCED_TEMPORAL_SENTINEL = datetime(1900, 1, 1)` from `_reduce_temporal_dimension` and `_create_pixel_selection_result` so every temporally-reduced cube shares the same canonical key. `merge_cubes` then sees them as having the same (single) temporal label and merges at the band level. The original acquisition datetime is still preserved in `assets=[first_key]` on the `ImageData`.

## Graph pattern that now works

```
load_collection(S2, 2019-09-06/09-08) ──> reduce_t ──> merge_cubes3 ─┐
load_collection(S1, 2019-09-06/09-08) ──> reduce_t ──> reduce_spectral(vh) ──> add_dimension("vh_t1") ─┐ merge_cubes1 ─┐
load_collection(S1, 2019-09-11/09-13) ──> reduce_t ──> reduce_spectral(vh) ──> add_dimension("vh_t2") ─┘              │ resample ─┘
                                                     └──> reduce_spectral(vv) ──> add_dimension("vv_t2") ──> merge_cubes2 ─┘
```

After the fix all reduced cubes share the sentinel key so merge_cubes produces one slice with 8 bands, then `apply_dimension(spectral)` works correctly.

## Test plan

- [x] `test_add_dimension_then_merge_spec_example_3a` — spec example 3a (same timestamp, disjoint labels)
- [x] `test_add_dimension_no_resolver_without_labeling_raises` — unlabeled bands still require resolver
- [x] `test_via_process_graph` — `merge_cubes` end-to-end through executor
- [x] `test_add_dimension_bands_via_graph` — `add_dimension(bands)` through executor
- [x] `test_reduce_add_dimension_merge_via_graph` — disjoint-timestamp pattern through executor
- [x] `test_reduce_add_dimension_merge_same_timestamp_via_graph` — same-timestamp through executor
- [x] `test_reduce_temporal_then_merge_produces_single_slice` — sentinel key regression test
- [x] Multi-timestamp unit test for `add_dimension`
- [x] All 789 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)