### PR TITLE
fix: accept band names and support target_band

### DIFF
--- a/tests/test_apply_graph_integration.py
+++ b/tests/test_apply_graph_integration.py
@@ -904,3 +904,71 @@ def test_reduce_add_dimension_merge_same_timestamp_via_graph():
     assert img.band_descriptions == ["scene1", "scene2"]
     np.testing.assert_array_equal(img.array[0], 10.0)
     np.testing.assert_array_equal(img.array[1], 20.0)
+
+
+def _two_band_named_stack() -> RasterStack:
+    """A single-timestamp cube with two named bands: B04_10m (red), B08_10m (nir).
+
+    red=100, nir=200 => NDVI = (200-100)/(200+100) = 1/3.
+    """
+    arr = np.ma.stack(
+        [
+            np.ma.array(np.full((2, 2), 100.0, np.float32)),  # B04_10m / red
+            np.ma.array(np.full((2, 2), 200.0, np.float32)),  # B08_10m / nir
+        ]
+    )
+    return RasterStack.from_images(
+        {datetime(2026, 2, 1): ImageData(arr, band_descriptions=["B04_10m", "B08_10m"])}
+    )
+
+
+def test_ndvi_via_graph_with_band_names():
+    """ndvi resolves openEO `band-name` string arguments through the real executor.
+
+    This is the graph shape that previously raised
+    ``expected 'integer' but got 'string'`` because the implementation took
+    integer indices while the process spec (and this graph) pass band names.
+    """
+    pg = {
+        "ndvi1": {
+            "process_id": "ndvi",
+            "arguments": {
+                "data": {"from_parameter": "data"},
+                "nir": "B08_10m",
+                "red": "B04_10m",
+            },
+            "result": True,
+        }
+    }
+    result = _run(pg, data=_two_band_named_stack())
+
+    assert len(result) == 1
+    img = result[datetime(2026, 2, 1)]
+    # Bands dimension dropped by default: a single computed band.
+    assert img.band_descriptions == ["ndvi"]
+    np.testing.assert_allclose(img.array[0], 1.0 / 3.0, rtol=1e-6)
+
+
+def test_ndvi_via_graph_with_target_band():
+    """ndvi with `target_band` keeps the bands dimension and appends the index."""
+    pg = {
+        "ndvi1": {
+            "process_id": "ndvi",
+            "arguments": {
+                "data": {"from_parameter": "data"},
+                "nir": "B08_10m",
+                "red": "B04_10m",
+                "target_band": "ndvi",
+            },
+            "result": True,
+        }
+    }
+    result = _run(pg, data=_two_band_named_stack())
+
+    assert len(result) == 1
+    img = result[datetime(2026, 2, 1)]
+    # Original bands preserved, computed band appended under `target_band`.
+    assert img.band_descriptions == ["B04_10m", "B08_10m", "ndvi"]
+    np.testing.assert_array_equal(img.array[0], 100.0)
+    np.testing.assert_array_equal(img.array[1], 200.0)
+    np.testing.assert_allclose(img.array[2], 1.0 / 3.0, rtol=1e-6)

--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -125,6 +125,39 @@ def test_ndvi(sample_raster_stack):
         assert img_data.band_descriptions == ["ndvi"]  # Should be named "ndvi"
 
 
+def test_ndvi_band_names(sample_raster_stack):
+    """NDVI accepts band names (openEO `band-name`), not just indices."""
+    by_index = ndvi(sample_raster_stack, 3, 1)
+    by_name = ndvi(sample_raster_stack, "blue", "red")
+
+    for key, img_data in by_name.items():
+        assert img_data.count == 1
+        assert img_data.band_descriptions == ["ndvi"]
+        # Same result whether bands are referenced by name or by index.
+        np.testing.assert_array_equal(img_data.array, by_index[key].array)
+
+
+def test_ndvi_unknown_band(sample_raster_stack):
+    """NDVI raises a clear error when a band name can't be resolved."""
+    with pytest.raises(ValueError, match="not found"):
+        ndvi(sample_raster_stack, "B08_10m", "red")
+
+
+def test_ndvi_target_band(sample_raster_stack):
+    """When target_band is set, the bands dimension is kept and the index appended."""
+    result = ndvi(sample_raster_stack, "blue", "red", target_band="ndvi")
+
+    for _key, img_data in result.items():
+        assert img_data.count == 4  # 3 original bands + ndvi
+        assert img_data.band_descriptions == ["red", "green", "blue", "ndvi"]
+
+
+def test_ndvi_target_band_conflict(sample_raster_stack):
+    """target_band that collides with an existing band raises."""
+    with pytest.raises(ValueError, match="already exists"):
+        ndvi(sample_raster_stack, "blue", "red", target_band="red")
+
+
 def test_ndwi(sample_raster_stack):
     """Test the ndwi function."""
     # NDWI uses nir and swir bands, but we only have 3 bands

--- a/titiler/openeo/processes/data/ndwi.json
+++ b/titiler/openeo/processes/data/ndwi.json
@@ -18,17 +18,34 @@
         },
         {
             "name": "nir",
-            "description": "The index of the NIR band.",
+            "description": "The name of the NIR band.\n\nEither the unique band name (metadata field `name` in bands) or one of the common band names (metadata field `common_name` in bands) can be specified. If the unique band name and the common name conflict, the unique band name has a higher priority.",
             "schema": {
-                "type": "number"
+                "type": "string",
+                "subtype": "band-name"
             }
         },
         {
             "name": "swir",
-            "description": "The index of the SWIR band",
+            "description": "The name of the SWIR band.\n\nEither the unique band name (metadata field `name` in bands) or one of the common band names (metadata field `common_name` in bands) can be specified. If the unique band name and the common name conflict, the unique band name has a higher priority.",
             "schema": {
-                "type": "number"
+                "type": "string",
+                "subtype": "band-name"
             }
+        },
+        {
+            "name": "target_band",
+            "description": "By default, the dimension of type `bands` is dropped. To keep the dimension specify a new band name in this parameter so that a new dimension label with the specified name will be added for the computed values.",
+            "schema": [
+                {
+                    "type": "string",
+                    "pattern": "^\\w+$"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "default": null,
+            "optional": true
         }
     ],
     "returns": {

--- a/titiler/openeo/processes/implementations/indices.py
+++ b/titiler/openeo/processes/implementations/indices.py
@@ -1,77 +1,136 @@
 """titiler.openeo.processes indices."""
 
 from datetime import datetime
-from typing import Dict
+from typing import Dict, List, Optional, Union
+
+import numpy
 
 from .data_model import ImageData, RasterStack
 from .math import normalized_difference
 
 __all__ = ["ndvi", "ndwi"]
 
+BandIdentifier = Union[int, str]
 
-def _apply_ndvi(data: ImageData, nir: int, red: int) -> ImageData:
-    """Apply NDVI to a single ImageData."""
-    nirb = data.array[int(nir) - 1]
-    redb = data.array[int(red) - 1]
 
+def _resolve_band_index(data: ImageData, band: BandIdentifier) -> int:
+    """Resolve a band identifier to a 1-based band index.
+
+    Accepts either a 1-based integer index (or its digit-string form) or a band
+    name that is matched against ``data.band_descriptions``. The openEO spec for
+    ``ndvi`` expects band *names* (e.g. ``"B08_10m"``), while the historic
+    implementation took integer indices; both are supported here.
+    """
+    # Integer (or digit string) => already a 1-based index.
+    if isinstance(band, bool):  # bool is a subclass of int; reject it explicitly
+        raise ValueError(f"Invalid band identifier: {band!r}")
+    if isinstance(band, int):
+        return band
+    if isinstance(band, str) and band.isdigit():
+        return int(band)
+
+    names = data.band_descriptions or []
+    # Exact match first, then case-insensitive as a convenience.
+    if band in names:
+        return names.index(band) + 1
+    lowered = [n.lower() for n in names]
+    if isinstance(band, str) and band.lower() in lowered:
+        return lowered.index(band.lower()) + 1
+
+    raise ValueError(f"Band '{band}' not found. Available bands: {names or 'unknown'}")
+
+
+def _normalized_difference_image(
+    data: ImageData,
+    first: BandIdentifier,
+    second: BandIdentifier,
+    name: str,
+    target_band: Optional[str],
+) -> ImageData:
+    """Compute a normalized difference index for a single ImageData.
+
+    When ``target_band`` is ``None`` the bands dimension is dropped and the
+    result is a single-band image named ``name``. When ``target_band`` is set,
+    the computed band is appended to the existing bands under that label.
+    """
+    first_idx = _resolve_band_index(data, first)
+    second_idx = _resolve_band_index(data, second)
+
+    firstb = data.array[first_idx - 1]
+    secondb = data.array[second_idx - 1]
+    nd = normalized_difference(firstb, secondb)
+
+    if target_band is None:
+        return ImageData(
+            nd,
+            assets=data.assets,
+            crs=data.crs,
+            bounds=data.bounds,
+            band_descriptions=[name],
+        )
+
+    existing = list(data.band_descriptions or [])
+    if target_band in existing:
+        raise ValueError(f"A band named '{target_band}' already exists.")
+
+    array = numpy.ma.concatenate([data.array, nd[numpy.newaxis, ...]], axis=0)
+    band_descriptions: List[str] = existing + [target_band]
     return ImageData(
-        normalized_difference(nirb, redb),
+        array,
         assets=data.assets,
         crs=data.crs,
         bounds=data.bounds,
-        band_descriptions=[
-            "ndvi",
-        ],
+        band_descriptions=band_descriptions,
     )
 
 
-def _apply_ndwi(data: ImageData, nir: int, swir: int) -> ImageData:
-    """Apply NDWI to a single ImageData."""
-    nirb = data.array[int(nir) - 1]
-    swirb = data.array[int(swir) - 1]
-
-    return ImageData(
-        normalized_difference(nirb, swirb),
-        assets=data.assets,
-        crs=data.crs,
-        bounds=data.bounds,
-        band_descriptions=[
-            "ndwi",
-        ],
-    )
-
-
-def ndwi(data: RasterStack, nir: int, swir: int) -> RasterStack:
+def ndwi(
+    data: RasterStack,
+    nir: BandIdentifier,
+    swir: BandIdentifier,
+    target_band: Optional[str] = None,
+) -> RasterStack:
     """Apply NDWI to RasterStack.
 
     Args:
         data: RasterStack to process
-        nir: Index of the NIR band (1-based)
-        swir: Index of the SWIR band (1-based)
+        nir: NIR band, as a 1-based index or a band name
+        swir: SWIR band, as a 1-based index or a band name
+        target_band: If set, keep the bands dimension and append the NDWI band
+            under this name; otherwise drop the bands dimension.
 
     Returns:
         RasterStack with NDWI results
     """
-    # Apply NDWI to each item in the stack
     result: Dict[datetime, ImageData] = {}
     for key, img_data in data.items():
-        result[key] = _apply_ndwi(img_data, nir, swir)
+        result[key] = _normalized_difference_image(
+            img_data, nir, swir, "ndwi", target_band
+        )
     return RasterStack.from_images(result)
 
 
-def ndvi(data: RasterStack, nir: int, red: int) -> RasterStack:
+def ndvi(
+    data: RasterStack,
+    nir: BandIdentifier,
+    red: BandIdentifier,
+    target_band: Optional[str] = None,
+) -> RasterStack:
     """Apply NDVI to RasterStack.
 
     Args:
         data: RasterStack to process
-        nir: Index of the NIR band (1-based)
-        red: Index of the red band (1-based)
+        nir: NIR band, as a 1-based index or a band name
+        red: Red band, as a 1-based index or a band name
+        target_band: If set, keep the bands dimension and append the NDVI band
+            under this name; otherwise drop the bands dimension.
 
     Returns:
         RasterStack (Dict[datetime, ImageData]) containing NDVI results
     """
-    # Apply NDVI to each item in the stack
     result: Dict[datetime, ImageData] = {}
     for key, img_data in data.items():
-        result[key] = _apply_ndvi(img_data, nir, red)
+        result[key] = _normalized_difference_image(
+            img_data, nir, red, "ndvi", target_band
+        )
     return RasterStack.from_images(result)


### PR DESCRIPTION
## Problem

Running a standard openEO graph that uses `ndvi` with band-name arguments fails with:

```
TypeError: Parameter 'nir' in process 'ndvi': expected 'integer' but got 'string'.
```

The process **spec** (`ndvi.json`) declares `nir`/`red` as `band-name` **strings** with an optional `target_band`, but the **implementation** (`ndvi(data, nir: int, red: int)`) took integer indices and had no `target_band`. So a spec-conformant graph passing band names (e.g. `"B08_10m"`) was rejected by the `@process` type validator, and `target_band` would have failed next as an unexpected argument.

This path never actually worked against this backend.

## Change

- `ndvi`/`ndwi` now resolve a band **name** against `band_descriptions` (exact, then case-insensitive). Integer indices are still accepted for internal/Python callers.
- Implement `target_band`:
  - `None` (default): drop the bands dimension → single computed band (unchanged behavior).
  - string: keep the bands dimension and **append** the computed band under that name; raise if the name already exists.
- Align `ndwi.json` (a custom, non-official process, unused by any in-repo graph) to the openEO `band-name` style + `target_band`. `ndvi.json` already matched the official spec and is unchanged.

## Tests

- Unit tests: band-name resolution, unknown-band error, `target_band` append, name collision.
- **Complete-graph** integration tests that compile and run through the real openEO executor (`OpenEOProcessGraph.to_callable`) with the reported graph shape — both the drop-dimension and `target_band` variants. These fail on the previous integer-index implementation.

All 69 tests in the affected suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)