### PR TITLE
fix: resolve band names against rio-tiler _b<n> suffix

### DIFF
--- a/tests/test_apply_graph_integration.py
+++ b/tests/test_apply_graph_integration.py
@@ -949,6 +949,46 @@ def test_ndvi_via_graph_with_band_names():
     np.testing.assert_allclose(img.array[0], 1.0 / 3.0, rtol=1e-6)
 
 
+def test_ndvi_via_graph_resolves_rio_tiler_band_names():
+    """ndvi resolves a requested band name against the reader's ``_b<n>`` names.
+
+    The reader (SimpleSTACReader) labels a single-band asset ``B04_10m`` as
+    ``B04_10m_b1`` in the cube. A graph that requests ``B04_10m`` must still
+    resolve. The earlier complete-graph tests used hand-built cubes with clean
+    band names, so they exercised the executor + process but NOT the reader's
+    naming — this fills that gap.
+    """
+    arr = np.ma.stack(
+        [
+            np.ma.array(np.full((2, 2), 100.0, np.float32)),  # B04_10m_b1 (red)
+            np.ma.array(np.full((2, 2), 200.0, np.float32)),  # B08_10m_b1 (nir)
+        ]
+    )
+    stack = RasterStack.from_images(
+        {
+            datetime(2026, 2, 1): ImageData(
+                arr, band_descriptions=["B04_10m_b1", "B08_10m_b1"]
+            )
+        }
+    )
+    pg = {
+        "ndvi1": {
+            "process_id": "ndvi",
+            "arguments": {
+                "data": {"from_parameter": "data"},
+                "nir": "B08_10m",
+                "red": "B04_10m",
+            },
+            "result": True,
+        }
+    }
+    result = _run(pg, data=stack)
+
+    img = result[datetime(2026, 2, 1)]
+    assert img.band_descriptions == ["ndvi"]
+    np.testing.assert_allclose(img.array[0], 1.0 / 3.0, rtol=1e-6)
+
+
 def test_ndvi_via_graph_with_target_band():
     """ndvi with `target_band` keeps the bands dimension and appends the index."""
     pg = {

--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -140,7 +140,42 @@ def test_ndvi_band_names(sample_raster_stack):
 def test_ndvi_unknown_band(sample_raster_stack):
     """NDVI raises a clear error when a band name can't be resolved."""
     with pytest.raises(ValueError, match="not found"):
-        ndvi(sample_raster_stack, "B08_10m", "red")
+        ndvi(sample_raster_stack, "purple", "red")
+
+
+def test_ndvi_band_names_with_rio_tiler_suffix():
+    """NDVI resolves openEO band names against rio-tiler ``<asset>_b<n>`` names.
+
+    The reader labels a single-band asset ``B04_10m`` as ``B04_10m_b1`` in the
+    cube, so a graph referencing ``B04_10m`` must still resolve.
+    """
+    arr = np.ma.stack(
+        [
+            np.ma.array(np.full((4, 4), 100.0, np.float32)),  # B04_10m_b1 (red)
+            np.ma.array(np.full((4, 4), 200.0, np.float32)),  # B08_10m_b1 (nir)
+        ]
+    )
+    stack = RasterStack.from_images(
+        {
+            datetime(2026, 2, 1): ImageData(
+                arr, band_descriptions=["B04_10m_b1", "B08_10m_b1"]
+            )
+        }
+    )
+    result = ndvi(stack, "B08_10m", "B04_10m")
+    for _key, img_data in result.items():
+        assert img_data.band_descriptions == ["ndvi"]
+        np.testing.assert_allclose(img_data.array[0], 1.0 / 3.0, rtol=1e-6)
+
+
+def test_ndvi_band_names_ambiguous_suffix():
+    """A base name matching several ``_b<n>`` bands is rejected as ambiguous."""
+    arr = np.ma.array(np.random.rand(2, 4, 4).astype(np.float32))
+    stack = RasterStack.from_images(
+        {datetime(2026, 2, 1): ImageData(arr, band_descriptions=["RGB_b1", "RGB_b2"])}
+    )
+    with pytest.raises(ValueError, match="ambiguous"):
+        ndvi(stack, "RGB", "RGB")
 
 
 def test_ndvi_target_band(sample_raster_stack):

--- a/titiler/openeo/processes/implementations/indices.py
+++ b/titiler/openeo/processes/implementations/indices.py
@@ -1,5 +1,6 @@
 """titiler.openeo.processes indices."""
 
+import re
 from datetime import datetime
 from typing import Dict, List, Optional, Union
 
@@ -12,6 +13,12 @@ __all__ = ["ndvi", "ndwi"]
 
 BandIdentifier = Union[int, str]
 
+# rio-tiler labels each band read from an asset as ``<asset>_b<n>`` (see
+# reader.SimpleSTACReader). For the common one-band-per-asset case that turns a
+# requested band ``B08_10m`` into a cube band ``B08_10m_b1``, so band-name
+# lookups must tolerate that trailing ``_b<n>`` suffix.
+_BAND_SUFFIX_RE = re.compile(r"_b\d+$")
+
 
 def _resolve_band_index(data: ImageData, band: BandIdentifier) -> int:
     """Resolve a band identifier to a 1-based band index.
@@ -20,6 +27,11 @@ def _resolve_band_index(data: ImageData, band: BandIdentifier) -> int:
     name that is matched against ``data.band_descriptions``. The openEO spec for
     ``ndvi`` expects band *names* (e.g. ``"B08_10m"``), while the historic
     implementation took integer indices; both are supported here.
+
+    Matching is progressive: exact name, then case-insensitive, then against the
+    band name with a rio-tiler ``_b<n>`` suffix stripped (so ``B08_10m`` matches
+    the read band ``B08_10m_b1``). A suffix match is only accepted when it is
+    unambiguous.
     """
     # Integer (or digit string) => already a 1-based index.
     if isinstance(band, bool):  # bool is a subclass of int; reject it explicitly
@@ -30,12 +42,28 @@ def _resolve_band_index(data: ImageData, band: BandIdentifier) -> int:
         return int(band)
 
     names = data.band_descriptions or []
-    # Exact match first, then case-insensitive as a convenience.
+
+    # Exact match, then case-insensitive.
     if band in names:
         return names.index(band) + 1
     lowered = [n.lower() for n in names]
-    if isinstance(band, str) and band.lower() in lowered:
+    if band.lower() in lowered:
         return lowered.index(band.lower()) + 1
+
+    # Suffix-tolerant match: compare against band names with the rio-tiler
+    # ``_b<n>`` suffix removed. Only accept when exactly one band matches.
+    target = band.lower()
+    matches = [
+        i for i, n in enumerate(names) if _BAND_SUFFIX_RE.sub("", n).lower() == target
+    ]
+    if len(matches) == 1:
+        return matches[0] + 1
+    if len(matches) > 1:
+        ambiguous = [names[i] for i in matches]
+        raise ValueError(
+            f"Band '{band}' is ambiguous; candidates: {ambiguous}. "
+            "Specify the full band name."
+        )
 
     raise ValueError(f"Band '{band}' not found. Available bands: {names or 'unknown'}")
 


### PR DESCRIPTION
Follow-up to #332.

## Problem

Running the ndvi graph against real data failed:

```
ValueError: Band 'B08_10m' not found. Available bands: ['B04_10m_b1', 'B08_10m_b1']
```

The reader (`SimpleSTACReader._reader`) labels each band read from an asset as `<asset>_b<n>` ([reader.py:296](titiler/openeo/reader.py#L296)). For the common one-band-per-asset case, the requested band `B08_10m` lands in the cube as `B08_10m_b1`, so the exact-name lookup added in #332 missed.

## Change

`_resolve_band_index` is now progressive: exact name → case-insensitive → **base-name** (band name with a trailing `_b<n>` stripped). The suffix match is only accepted when it's unambiguous; a multi-band asset like `RGB_b1`/`RGB_b2` referenced as `RGB` raises a clear ambiguity error.

## Tests

- Unit: `_b1`-suffixed resolution + ambiguous-suffix rejection.
- **Complete-graph** integration test using the reader's `_b<n>` band names. The #332 graph tests used hand-built cubes with clean names, so they exercised the executor + process but never the reader↔process naming boundary — which is exactly why they didn't catch this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)