### PR TITLE
fix: drop stale band labels so single-band cubes merge

### DIFF
--- a/tests/test_apply_graph_integration.py
+++ b/tests/test_apply_graph_integration.py
@@ -1012,3 +1012,134 @@ def test_ndvi_via_graph_with_target_band():
     np.testing.assert_array_equal(img.array[0], 100.0)
     np.testing.assert_array_equal(img.array[1], 200.0)
     np.testing.assert_allclose(img.array[2], 1.0 / 3.0, rtol=1e-6)
+
+
+def _labelled_vv_stack(dates, value) -> RasterStack:
+    """Single-band stack carrying the collection's band label ("vv")."""
+    return RasterStack.from_images(
+        {
+            d: ImageData(
+                np.ma.array(np.full((1, 2, 2), value, np.float32)),
+                band_descriptions=["vv"],
+            )
+            for d in dates
+        }
+    )
+
+
+def _before_after_pg(param: str, label: str, n: int) -> dict:
+    """reduce_dimension(t) → reduce_dimension(spectral) → add_dimension(label)."""
+    return {
+        f"rt{n}": {
+            "process_id": "reduce_dimension",
+            "arguments": {
+                "data": {"from_parameter": param},
+                "dimension": "t",
+                "reducer": {
+                    "process_graph": {
+                        f"mean{n}": {
+                            "process_id": "mean",
+                            "arguments": {"data": {"from_parameter": "data"}},
+                            "result": True,
+                        }
+                    }
+                },
+            },
+        },
+        f"rs{n}": {
+            "process_id": "reduce_dimension",
+            "arguments": {
+                "data": {"from_node": f"rt{n}"},
+                "dimension": "spectral",
+                "reducer": {
+                    "process_graph": {
+                        f"ae{n}": {
+                            "process_id": "array_element",
+                            "arguments": {
+                                "data": {"from_parameter": "data"},
+                                "index": 0,
+                            },
+                            "result": True,
+                        }
+                    }
+                },
+            },
+        },
+        f"ad{n}": {
+            "process_id": "add_dimension",
+            "arguments": {
+                "data": {"from_node": f"rs{n}"},
+                "name": "spectral",
+                "label": label,
+                "type": "bands",
+            },
+        },
+    }
+
+
+def test_spectral_reduce_of_single_band_cube_drops_band_label():
+    """reduce_dimension('spectral') eliminates the dimension → no band labels left.
+
+    A single-band cube is the tricky case: input and output band counts both equal
+    1, so a count-based check would wrongly keep the input label ("vv") on data
+    that no longer has a spectral dimension.
+    """
+    pg = _before_after_pg("data", "vv_before", 1)
+    pg["rs1"] = {**pg["rs1"], "result": True}
+
+    result = _run(pg, data=_labelled_vv_stack([datetime(2024, 1, 1)], 1.0))
+
+    assert result.first.band_descriptions == []
+
+
+def test_add_dimension_replaces_stale_band_label():
+    """add_dimension labels the single band; it never appends to stale labels.
+
+    Appending would leave 2 names on a 1-band image, and merge_cubes would then
+    treat the leftover name as a band shared by both cubes.
+    """
+    pg = _before_after_pg("data", "vv_before", 1)
+    pg["ad1"] = {**pg["ad1"], "result": True}
+
+    result = _run(pg, data=_labelled_vv_stack([datetime(2024, 1, 1)], 1.0))
+
+    assert result.first.band_descriptions == ["vv_before"]
+
+
+def test_before_after_merge_of_same_band_needs_no_resolver():
+    """Regression: two periods of the same band merge without an overlap resolver.
+
+    Real-world change-detection graph: load the same collection ("vv") over two
+    time ranges, reduce each to a single image, label them "vv_before"/"vv_during"
+    and merge.  The labels are disjoint, so no resolver is required — this raised
+    OverlapResolverMissing while the reduced cubes still carried the "vv" label.
+    """
+    pg = {
+        **_before_after_pg("cube_before", "vv_before", 1),
+        **_before_after_pg("cube_during", "vv_during", 2),
+        "merge": {
+            "process_id": "merge_cubes",
+            "arguments": {
+                "cube1": {"from_node": "ad1"},
+                "cube2": {"from_node": "ad2"},
+            },
+            "result": True,
+        },
+    }
+
+    result = _run(
+        pg,
+        cube_before=_labelled_vv_stack(
+            [datetime(2024, 1, 1), datetime(2024, 1, 5)], 1.0
+        ),
+        cube_during=_labelled_vv_stack(
+            [datetime(2024, 3, 1), datetime(2024, 3, 5)], 2.0
+        ),
+    )
+
+    # Both branches reduce to the sentinel key → one slice holding both bands
+    assert len(result) == 1
+    img = result.first
+    assert img.band_descriptions == ["vv_before", "vv_during"]
+    np.testing.assert_array_equal(img.array[0], 1.0)
+    np.testing.assert_array_equal(img.array[1], 2.0)

--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -12,6 +12,7 @@ from titiler.openeo.processes.implementations.apply import (
     apply_dimension,
 )
 from titiler.openeo.processes.implementations.arrays import (
+    DimensionExists,
     add_dimension,
     array_apply,
     array_create,
@@ -569,12 +570,21 @@ def test_add_dimension():
     img = result.first
     assert img.band_descriptions == ["red"]
 
-    # Adding a second band label appends to existing descriptions
+    # Re-adding the dimension relabels the single band – it must never append, or
+    # the image would carry more band names than the array has bands and merge_cubes
+    # would see a phantom overlapping band (OverlapResolverMissing).
     result2 = add_dimension(
         data=result, name="spectral", label="green", type="spectral"
     )
     assert len(result2) == 1
-    assert result2.first.band_descriptions == ["red", "green"]
+    assert result2.first.band_descriptions == ["green"]
+
+    # A multi-band cube already has a spectral dimension – adding one is an error
+    multiband = RasterStack.from_images(
+        {datetime(2021, 1, 1): ImageData(np.ma.ones((3, 4, 4), np.float32))}
+    )
+    with pytest.raises(DimensionExists):
+        add_dimension(data=multiband, name="spectral", label="red", type="bands")
 
     # type="temporal" / "other" still adds a new temporal entry
     result3 = add_dimension(

--- a/titiler/openeo/processes/implementations/arrays.py
+++ b/titiler/openeo/processes/implementations/arrays.py
@@ -177,6 +177,7 @@ def add_dimension(
 
     Raises:
         ValueError: If trying to add a spatial dimension (not supported).
+        DimensionExists: If a band dimension is added to a multi-band cube.
     """
     if type == "spatial":
         raise ValueError(
@@ -197,15 +198,23 @@ def add_dimension(
 
     if type in ("bands", "spectral"):
         # For spectral/band dimensions: label the band_descriptions of every image.
-        # After reduce_dimension("spectral"), images have band_descriptions=[] (the
-        # spectral dimension was eliminated). add_dimension re-introduces it with
-        # `label` as the single band name, which is what merge_cubes uses to detect
-        # overlap — without this the two cubes appear identical and OverlapResolverMissing
-        # is raised even when the bands are logically distinct.
+        # The added dimension has a single label, so the images must end up with
+        # exactly one band name — that name is what merge_cubes uses to detect
+        # overlap. Appending instead of setting would leave more labels than the
+        # array has bands (e.g. ["vv", "vv_before"] on a 1-band image after
+        # reduce_dimension("spectral")), and merge_cubes would then see a phantom
+        # shared band and raise OverlapResolverMissing for logically distinct cubes.
         result: Dict[datetime, ImageData] = {}
         for key in data.keys():
             img = data[key]
-            new_bands = list(img.band_descriptions or []) + [str(label)]
+            band_count = img.array.shape[0] if img.array.ndim == 3 else 1
+            if band_count > 1:
+                raise DimensionExists(
+                    f"A dimension with the name '{name}' already exists: the data cube "
+                    f"has {band_count} bands, so a new single-label band dimension "
+                    "cannot be added. Reduce the spectral dimension first."
+                )
+            new_bands = [str(label)]
             result[key] = ImageData(
                 img.array,
                 assets=img.assets,
@@ -233,6 +242,13 @@ def add_dimension(
         bounds=first_ref.bounds,
     )
     return RasterStack.from_images(new_data)
+
+
+class DimensionExists(OpenEOException):
+    """Raised when adding a dimension the data cube already has."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message=message, code="DimensionExists", status_code=400)
 
 
 class LabelMismatch(OpenEOException):

--- a/titiler/openeo/processes/implementations/reduce.py
+++ b/titiler/openeo/processes/implementations/reduce.py
@@ -541,6 +541,14 @@ def _reduce_spectral_dimension_stack(
                 f"Expected array-like data with reduced spectral bands."
             ) from e
 
+    # A reducer that eliminates the spectral dimension returns (time, height, width):
+    # no band axis is left. A 4-D output keeps a (smaller) spectral dimension, i.e. a
+    # partial reduction. The distinction matters for band names: when the dimension is
+    # gone the input labels no longer describe the output, even if the band count
+    # happens to match (single-band cube reduced with array_element). Keeping them
+    # would let merge_cubes see a shared band and raise OverlapResolverMissing.
+    spectral_dimension_eliminated = reduced_data.ndim < 4
+
     # Transform the result back to (time, ...) format for splitting into time slices
     final_data = _reshape_reduced_spectral_data(reduced_data, len(images))
 
@@ -560,7 +568,8 @@ def _reduce_spectral_dimension_stack(
         # If band count changed, clear band_names to avoid mismatches
         output_band_names = []
         if (
-            num_output_bands > 0
+            not spectral_dimension_eliminated
+            and num_output_bands > 0
             and meta["band_descriptions"]
             and len(meta["band_descriptions"]) == num_output_bands
         ):


### PR DESCRIPTION
## Problem

A change-detection graph — load the same band (`vv`) over two time ranges, reduce each to one image, label them `vv_before` / `vv_during`, merge — failed with:

```
OpenEoApiError: [400] OverlapResolverMissing: Overlapping data cubes, but no overlap resolver has been specified.
```

even though the two cubes carry distinct band labels and are logically disjoint.

## Root cause

Two defects combine to leave an image with **more band names than its array has bands**, which `merge_cubes` reads as a shared band:

1. **`reduce_dimension("spectral")` kept the input band label.** The decision to keep band names compared input and output band counts. For a single-band cube reduced with `array_element`, both are 1, so `"vv"` survived a reduction that eliminated the spectral dimension entirely.
2. **`add_dimension(type="bands")` appended.** `["vv"]` + `vv_before` → `["vv", "vv_before"]` on a 1-band array.

`merge_cubes` then sees `"vv"` in both cubes → phantom overlap → error.

Traced through the real executor (`OpenEOProcessGraph.to_callable`), before the fix:

```
after reduce(t)          band_descriptions=['vv']
after reduce(spectral)   band_descriptions=['vv']              <- should be []
after add_dimension      band_descriptions=['vv','vv_before']  <- 2 names, 1 band
MERGE FAILED: OverlapResolverMissing
```

## Fix

- `_reduce_spectral_dimension_stack` uses the **reducer output rank** rather than a band count match: a 3-D output `(time, height, width)` has no band axis, so the dimension is gone and the labels no longer describe the data. A 4-D output is a partial reduction and keeps its labels.
- `add_dimension(type="bands")` **sets** the single band name instead of appending, so labels can never outnumber the array's bands. Adding a band dimension to a genuinely multi-band cube now raises `DimensionExists` (400) instead of silently producing one label for N bands.

This is the same family as #328 / #329, two steps further down the chain.

## Tests

Three graph-level regressions in `tests/test_apply_graph_integration.py`, each failing before this change:

- spectral reduce of a single-band cube drops the band label
- `add_dimension` replaces a stale label rather than appending
- the full before/after merge needs no overlap resolver

Plus the `DimensionExists` case in `tests/test_processes.py`. One existing assertion in `test_add_dimension` encoded the old append behaviour (`["red", "green"]` on a 1-band image) and was updated — that state is exactly what caused the bug.

Full suite: 803 passed, 12 skipped.

## Note

Unrelated and pre-existing: `apply_dimension` producing more bands than it consumed (e.g. `array_create` of 3 elements from a 2-band cube) leaves the old 2 band descriptions in place. Pixels are correct; only the naming is inconsistent. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)