### PR TITLE
feat: geocode and calibration for sar_backscatter (Phase 1, increment 2/4)

### DIFF
--- a/docs/adr/0001-sar-backscatter.md
+++ b/docs/adr/0001-sar-backscatter.md
@@ -1056,10 +1056,14 @@ correctness fix with no SAR dependency and should land first, on its own issue. 
 of #340 then reduces to what it should always have been: `calibration.py` plus a
 `geocode.py` that only builds the TPS inverse map for LUT coordinates.
 
-**Caveat to confirm.** (b)'s first client is motivated by `raster:scale/offset` being
-present on Sentinel-1 GRD assets. That has **not** been verified — if those fields are
-absent, `raw_values` is moot for SAR and (b) may have no first client yet, in which case
-it should be deferred rather than built speculatively.
+**Caveat, confirmed (2026-07-29).** (b)'s first client was motivated by `raster:scale`/
+`raster:offset` being present on Sentinel-1 GRD assets. Checked live against all three
+target catalogues' current GRD items (CDSE STAC, Earth Search, Planetary Computer): none
+declare `raster:scale`/`raster:offset` on the measurement assets, at the asset level or
+per-band. So `raw_values` is moot for SAR today, (b) has no first client, and it is
+deferred rather than built speculatively. Increment 2 proceeds unchanged: `calibration.py`
+plus a `geocode.py` that only builds the TPS inverse map for LUT coordinates, with no
+reader-requirement plumbing.
 
 ---
 

--- a/tests/test_sar_calibration.py
+++ b/tests/test_sar_calibration.py
@@ -1,0 +1,119 @@
+"""Tests for titiler.openeo.sar.calibration.
+
+Uses a Grid2D with a single constant value per LUT so the coefficient maths
+can be checked by hand, independent of Grid2D's own bilinear interpolation
+(covered separately in test_sar_annotation.py).
+"""
+
+import numpy as np
+import pytest
+
+from titiler.openeo.sar.annotation import CalibrationLUT, Grid2D, NoiseLUT
+from titiler.openeo.sar.calibration import calibrate
+from titiler.openeo.sar.geocode import InverseMap
+
+# Arbitrary, distinct constants -- not meant to satisfy the
+# gamma/sigma incidence-angle identity, since that's not calibrate()'s concern.
+SIGMA_NOUGHT = 2.0
+BETA_NOUGHT = 4.0
+GAMMA = 3.0
+
+
+@pytest.fixture
+def calibration_lut() -> CalibrationLUT:
+    grid = Grid2D(
+        lines=np.array([0.0, 10.0]),
+        pixels=np.array([0.0, 10.0]),
+        values={
+            "sigmaNought": np.full((2, 2), SIGMA_NOUGHT),
+            "betaNought": np.full((2, 2), BETA_NOUGHT),
+            "gamma": np.full((2, 2), GAMMA),
+        },
+    )
+    return CalibrationLUT(grid)
+
+
+@pytest.fixture
+def inverse() -> InverseMap:
+    """Two pixels; coordinates only need to fall inside the LUT's grid."""
+    return InverseMap(line=np.array([[1.0, 1.0]]), pixel=np.array([[1.0, 1.0]]))
+
+
+def test_calibrate_null_coefficient_returns_dn_squared_uncalibrated(
+    calibration_lut, inverse
+):
+    dn = np.array([[10.0, 0.0]])
+    result = calibrate(dn, inverse, calibration_lut, coefficient=None)
+
+    np.testing.assert_allclose(result.value, [[100.0, 0.0]])
+    np.testing.assert_array_equal(result.valid_mask, [[True, False]])
+    assert result.negative_count == 0
+
+
+@pytest.mark.parametrize(
+    "coefficient,expected_a",
+    [
+        ("beta0", BETA_NOUGHT),
+        ("sigma0-ellipsoid", SIGMA_NOUGHT),
+        ("gamma0-ellipsoid", GAMMA),
+    ],
+)
+def test_calibrate_hand_computed(calibration_lut, inverse, coefficient, expected_a):
+    dn = np.array([[10.0, 0.0]])
+    result = calibrate(dn, inverse, calibration_lut, coefficient=coefficient)
+
+    expected = np.array([[100.0 / expected_a**2, 0.0]])
+    np.testing.assert_allclose(result.value, expected)
+    np.testing.assert_array_equal(result.valid_mask, [[True, False]])
+
+
+def test_calibrate_unsupported_coefficient_raises(calibration_lut, inverse):
+    dn = np.array([[10.0]])
+    inverse = InverseMap(line=np.array([[1.0]]), pixel=np.array([[1.0]]))
+    with pytest.raises(ValueError, match="Unsupported calibration coefficient"):
+        calibrate(dn, inverse, calibration_lut, coefficient="gamma0-terrain")
+
+
+def test_calibrate_noise_removal_clamps_negatives_and_counts_them(
+    calibration_lut, inverse
+):
+    # power = dn**2 = 50; noise = 80 (constant) -> power - eta = -30, clamped to 0.
+    noise = NoiseLUT(
+        range_grid=Grid2D(
+            lines=np.array([0.0, 10.0]),
+            pixels=np.array([0.0, 10.0]),
+            values={"noiseRangeLut": np.full((2, 2), 80.0)},
+        )
+    )
+    dn = np.array([[np.sqrt(50.0), 0.0]])
+    result = calibrate(dn, inverse, calibration_lut, coefficient=None, noise=noise)
+
+    np.testing.assert_allclose(result.value, [[0.0, 0.0]])
+    # Only the first pixel is both valid (dn > 0) and went negative.
+    assert result.negative_count == 1
+
+
+def test_calibrate_noise_removal_leaves_positive_values_unclamped(
+    calibration_lut, inverse
+):
+    # power = dn**2 = 200; noise = 80 -> 120, still positive.
+    noise = NoiseLUT(
+        range_grid=Grid2D(
+            lines=np.array([0.0, 10.0]),
+            pixels=np.array([0.0, 10.0]),
+            values={"noiseRangeLut": np.full((2, 2), 80.0)},
+        )
+    )
+    dn = np.array([[np.sqrt(200.0), 0.0]])
+    result = calibrate(dn, inverse, calibration_lut, coefficient=None, noise=noise)
+
+    np.testing.assert_allclose(result.value, [[120.0, 0.0]])
+    assert result.negative_count == 0
+
+
+def test_calibrate_without_noise_skips_subtraction(calibration_lut, inverse):
+    dn = np.array([[10.0, 0.0]])
+    result = calibrate(dn, inverse, calibration_lut, coefficient=None, noise=None)
+
+    np.testing.assert_allclose(result.value, [[100.0, 0.0]])
+    assert result.negative_count == 0

--- a/tests/test_sar_geocode.py
+++ b/tests/test_sar_geocode.py
@@ -1,0 +1,136 @@
+"""Tests for titiler.openeo.sar.geocode.
+
+geocode.py builds the destination-to-source inverse map only -- it does not read
+pixels (docs/adr/0001-sar-backscatter.md S7.3, S7.10). These tests cover the map
+itself: hand-computed values on a trivial affine-consistent GCP set (with and
+without a dst_crs -> gcp_crs reprojection), and the TPS round-trip accuracy
+acceptance criterion (ADR S7.8.4) on a real Sentinel-1 GCP grid.
+"""
+
+import json
+from pathlib import Path
+
+import numpy as np
+from rasterio.control import GroundControlPoint
+from rasterio.crs import CRS
+from rasterio.warp import transform as warp_transform
+
+from titiler.openeo.sar.geocode import build_inverse_map
+
+FIXTURE = Path(__file__).parent / "fixtures" / "sar" / "gcps_ew_grdm_polar.json"
+
+# Four corner GCPs consistent with the exact affine row = 10 - y, col = x, so
+# TPS (which reproduces any affine-consistent input exactly) gives hand-computable
+# results independent of the CRS path taken to get there.
+_AFFINE_GCPS = [
+    GroundControlPoint(row=0, col=0, x=0, y=10),
+    GroundControlPoint(row=0, col=10, x=10, y=10),
+    GroundControlPoint(row=10, col=0, x=0, y=0),
+    GroundControlPoint(row=10, col=10, x=10, y=0),
+]
+
+# Expected inverse map for a 2x2 destination grid over bounds (0, 0, 10, 10):
+# pixel centres sit at ground (2.5, 7.5) and (7.5, 2.5)/(7.5, 7.5) etc., and
+# row = 10 - y, col = x gives these directly.
+_EXPECTED_LINE = np.array([[2.5, 2.5], [7.5, 7.5]])
+_EXPECTED_PIXEL = np.array([[2.5, 7.5], [2.5, 7.5]])
+
+
+def test_build_inverse_map_hand_computed_identity_crs():
+    """No reprojection needed when dst_crs == gcp_crs."""
+    crs = CRS.from_epsg(4326)
+    inverse = build_inverse_map(
+        _AFFINE_GCPS, crs, width=2, height=2, bounds=(0, 0, 10, 10), dst_crs=crs
+    )
+
+    np.testing.assert_allclose(inverse.line, _EXPECTED_LINE)
+    np.testing.assert_allclose(inverse.pixel, _EXPECTED_PIXEL)
+
+
+def test_build_inverse_map_reprojects_dst_crs_to_gcp_crs():
+    """dst_crs != gcp_crs: destination pixel centres must be reprojected first.
+
+    Reuses the same affine-consistent GCPs and expected values as the identity
+    case, but places the tiny ground square at a real (lon, lat) location and
+    drives the destination grid in Web Mercator -- exercising the
+    dst_crs -> gcp_crs warp_transform branch. At this scale (~100 m) Mercator
+    distortion is negligible, so the recovered (line, pixel) should match the
+    identity-CRS case to a small fraction of a pixel; a bug that skipped
+    reprojection would instead feed raw Web Mercator meters into the GCP
+    transformer and produce wildly out-of-range results.
+    """
+    lon0, lat0, delta = 10.0, 45.0, 0.001
+    gcps = [
+        GroundControlPoint(row=0, col=0, x=lon0, y=lat0 + delta),
+        GroundControlPoint(row=0, col=10, x=lon0 + delta, y=lat0 + delta),
+        GroundControlPoint(row=10, col=0, x=lon0, y=lat0),
+        GroundControlPoint(row=10, col=10, x=lon0 + delta, y=lat0),
+    ]
+    gcp_crs = CRS.from_epsg(4326)
+    dst_crs = CRS.from_epsg(3857)
+
+    xs, ys = warp_transform(
+        gcp_crs, dst_crs, [lon0, lon0 + delta], [lat0, lat0 + delta]
+    )
+    bounds = (xs[0], ys[0], xs[1], ys[1])
+
+    inverse = build_inverse_map(
+        gcps, gcp_crs, width=2, height=2, bounds=bounds, dst_crs=dst_crs
+    )
+
+    np.testing.assert_allclose(inverse.line, _EXPECTED_LINE, atol=1e-2)
+    np.testing.assert_allclose(inverse.pixel, _EXPECTED_PIXEL, atol=1e-2)
+
+
+def test_tps_round_trip_on_real_polar_gcps_sub_metre():
+    """Acceptance criterion 4 (ADR S7.8): TPS round-trip residual < 1 m RMS.
+
+    Regression guard for "TPS really is in use" -- this is what would have
+    caught both an order-2 default and an ignored METHOD=GCP_TPS (ADR S1.6b).
+    Probes each GCP with its own 1x1 destination "pixel" centred exactly on
+    that GCP's ground coordinate, so the recovered (line, pixel) is TPS
+    evaluated at one of its own control points -- which a true TPS reproduces
+    to numerical precision.
+    """
+    raw = json.loads(FIXTURE.read_text())
+    gcp_crs = CRS.from_string(raw["gcp_crs"])
+    gcps = [
+        GroundControlPoint(row=g["row"], col=g["col"], x=g["x"], y=g["y"], z=0)
+        for g in raw["gcps"]
+    ]
+
+    # A subset is enough to characterise the residual and keeps the test fast
+    # (each probe rebuilds the TPS solver over the full GCP set).
+    probes = gcps[::7]
+    assert len(probes) > 20, "expected a representative sample of GCPs"
+
+    row_err_px = []
+    col_err_px = []
+    eps = 1e-4  # degrees; tiny enough that the 1x1 grid is effectively a point
+    for g in probes:
+        bounds = (g.x - eps / 2, g.y - eps / 2, g.x + eps / 2, g.y + eps / 2)
+        inverse = build_inverse_map(
+            gcps, gcp_crs, width=1, height=1, bounds=bounds, dst_crs=gcp_crs
+        )
+        row_err_px.append(inverse.line[0, 0] - g.row)
+        col_err_px.append(inverse.pixel[0, 0] - g.col)
+
+    row_err_px = np.array(row_err_px)
+    col_err_px = np.array(col_err_px)
+
+    # Local ground sampling distance (metres/pixel), estimated from two
+    # adjacent GCPs on the same range line via a planar Web Mercator
+    # approximation (fine at this scale), to convert the pixel residual above
+    # into a ground distance without hard-coding Sentinel-1's spec'd pixel
+    # spacing.
+    same_line = [g for g in raw["gcps"] if g["row"] == raw["gcps"][0]["row"]][:2]
+    lons = [g["x"] for g in same_line]
+    lats = [g["y"] for g in same_line]
+    col_step = same_line[1]["col"] - same_line[0]["col"]
+    xs, ys = warp_transform(gcp_crs, CRS.from_epsg(3857), lons, lats)
+    ground_step_m = float(np.hypot(xs[1] - xs[0], ys[1] - ys[0]))
+    metres_per_pixel = ground_step_m / col_step
+
+    residual_m = np.hypot(row_err_px, col_err_px) * metres_per_pixel
+    rms_m = float(np.sqrt((residual_m**2).mean()))
+    assert rms_m < 1.0, f"RMS residual {rms_m:.4f} m (>= 1 m)"

--- a/titiler/openeo/sar/__init__.py
+++ b/titiler/openeo/sar/__init__.py
@@ -11,7 +11,9 @@ from .annotation import (  # noqa
     parse_calibration,
     parse_noise,
 )
+from .calibration import CalibrationResult, calibrate  # noqa
 from .fetcher import AssetFetcher, ObstoreFetcher, get_default_fetcher  # noqa
+from .geocode import InverseMap, build_inverse_map  # noqa
 
 __all__ = [
     "AssetFetcher",
@@ -23,4 +25,8 @@ __all__ = [
     "parse_noise",
     "get_calibration",
     "get_noise",
+    "InverseMap",
+    "build_inverse_map",
+    "CalibrationResult",
+    "calibrate",
 ]

--- a/titiler/openeo/sar/calibration.py
+++ b/titiler/openeo/sar/calibration.py
@@ -1,0 +1,75 @@
+"""Sentinel-1 GRD radiometric calibration: DN -> physical backscatter.
+
+Combines the DN read by `RasterStack` through the normal `load_collection` path (the
+read itself is out of scope here -- see geocode.py and
+docs/adr/0001-sar-backscatter.md S7.3) with the calibration/noise LUTs (annotation.py),
+evaluated at the geocode.py inverse-mapped (line, pixel) coordinates, into the
+coefficient the caller asked for. See ADR S7.3 steps 4-8.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+
+from .annotation import COEFFICIENT_LUT, CalibrationLUT, NoiseLUT
+from .geocode import InverseMap
+
+__all__ = ["CalibrationResult", "calibrate"]
+
+
+@dataclass(frozen=True)
+class CalibrationResult:
+    """The calibrated backscatter value plus the diagnostics callers need."""
+
+    #: Linear-scale backscatter (or DN^2 if coefficient is None), float64, HxW.
+    value: np.ndarray
+    #: True where source DN > 0, i.e. not border/no-data, HxW.
+    valid_mask: np.ndarray
+    #: Count of valid pixels where noise subtraction went negative before clamping.
+    negative_count: int
+
+
+def calibrate(
+    dn: np.ndarray,
+    inverse: InverseMap,
+    calibration: CalibrationLUT,
+    coefficient: Optional[str],
+    noise: Optional[NoiseLUT] = None,
+) -> CalibrationResult:
+    """Compute `(DN^2 - noise) / A^2` for `coefficient`.
+
+    `coefficient=None` returns `DN^2` uncalibrated (openEO's `null`).
+    `noise=None` skips noise subtraction (`noise_removal=false`). `A` is
+    selected via `COEFFICIENT_LUT`, so `coefficient` must be one of openEO's
+    own names (`beta0`, `sigma0-ellipsoid`, `gamma0-ellipsoid`) or `None`.
+
+    Noise subtraction can drive values negative in low-backscatter areas;
+    those are clamped to 0 and counted (SNAP does the same) rather than
+    emitted as negative backscatter.
+    """
+    valid_mask = dn > 0
+    power = dn.astype("f8") ** 2
+
+    negative_count = 0
+    if noise is not None:
+        eta = noise.evaluate(inverse.line, inverse.pixel)
+        negative = (power - eta) < 0
+        power = np.maximum(power - eta, 0.0)
+        negative_count = int(np.count_nonzero(negative & valid_mask))
+
+    if coefficient is None:
+        value = power
+    else:
+        lut_name = COEFFICIENT_LUT.get(coefficient)
+        if lut_name is None:
+            raise ValueError(
+                f"Unsupported calibration coefficient: {coefficient!r}. "
+                f"Expected one of {sorted(COEFFICIENT_LUT)} or None."
+            )
+        a = calibration.grid.interp(lut_name, inverse.line, inverse.pixel)
+        value = power / (a**2)
+
+    return CalibrationResult(
+        value=value, valid_mask=valid_mask, negative_count=negative_count
+    )

--- a/titiler/openeo/sar/geocode.py
+++ b/titiler/openeo/sar/geocode.py
@@ -1,0 +1,88 @@
+"""Geocoding for Sentinel-1 GRD: destination grid -> source (line, pixel).
+
+Builds the inverse map from destination pixel centres to source (line,
+pixel) coordinates using a thin-plate spline over the measurement TIFF's
+ground control points. That map is what calibration.py evaluates the
+calibration/noise LUTs at -- it does not read pixels.
+
+**Reading is `RasterStack`'s job, not this module's** (docs/adr/0001-sar-backscatter.md
+S7.3, S7.10). Duplicating a windowed, decimated, resampled read here would fork
+overviews, CRS handling, masks, mosaicking, output-size limits and retries away from
+rio-tiler, and would inevitably drift from it. The DN pixels are read through the
+normal `load_collection` path (`OpenEOReader` already warps GCP-referenced datasets from
+their real GCPs -- issue #344), and this module only tells the caller where, in the
+source product, each destination pixel's radiometry LUTs live.
+
+`rasterio.warp.reproject` is deliberately not used here: it silently ignores
+`METHOD=GCP_TPS` and always runs an order-2 polynomial, which on IW GRDH is a
+~25 m RMS geolocation error that looks like it worked
+(docs/adr/0001-sar-backscatter.md S1.6b).
+"""
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import numpy as np
+from rasterio.control import GroundControlPoint
+from rasterio.crs import CRS
+from rasterio.transform import GCPTransformer, from_bounds, xy
+from rasterio.warp import transform as warp_transform
+from rio_tiler.types import BBox
+
+__all__ = ["InverseMap", "build_inverse_map"]
+
+
+@dataclass(frozen=True)
+class InverseMap:
+    """Maps destination pixel centres back to source (line, pixel).
+
+    Both arrays have shape (height, width) and hold fractional (sub-pixel)
+    coordinates, never rounded, since calibration.py bilinearly interpolates
+    the LUTs at them.
+    """
+
+    line: np.ndarray
+    pixel: np.ndarray
+
+
+def build_inverse_map(
+    gcps: Sequence[GroundControlPoint],
+    gcp_crs: CRS,
+    width: int,
+    height: int,
+    bounds: BBox,
+    dst_crs: CRS,
+) -> InverseMap:
+    """Build the destination-to-source inverse map, once.
+
+    `bounds`/`dst_crs`/`width`/`height` describe the destination grid, exactly as
+    `RasterStack` already carries them for the polarisation's `ImageData`. `gcps`/
+    `gcp_crs` must come from the measurement TIFF itself (`src.gcps`, a header-only
+    open), never from item/asset `proj:*` -- some catalogues advertise a bbox-derived
+    affine that is fiction for SAR geometry (ADR S1.7).
+
+    Destination pixel centres are computed in `dst_crs` (typically Web Mercator for a
+    tile server) and reprojected into `gcp_crs` (typically EPSG:4326) before the GCP
+    transform, since `GCPTransformer` expects coordinates in the GCPs' own CRS.
+    """
+    dst_transform = from_bounds(*bounds, width, height)
+    rows, cols = np.mgrid[0:height, 0:width]
+    xs, ys = xy(dst_transform, rows.ravel(), cols.ravel())
+    xs = np.asarray(xs, dtype="f8")
+    ys = np.asarray(ys, dtype="f8")
+
+    if dst_crs != gcp_crs:
+        xs, ys = warp_transform(dst_crs, gcp_crs, xs, ys)
+        xs = np.asarray(xs, dtype="f8")
+        ys = np.asarray(ys, dtype="f8")
+
+    with GCPTransformer(gcps, tps=True) as transformer:
+        # op=lambda v: v keeps fractional coordinates; the default (floor)
+        # would throw away exactly the sub-pixel precision bilinear LUT
+        # interpolation needs.
+        line, pixel = transformer.rowcol(xs, ys, op=lambda v: v)
+
+    return InverseMap(
+        line=np.asarray(line, dtype="f8").reshape(height, width),
+        pixel=np.asarray(pixel, dtype="f8").reshape(height, width),
+    )


### PR DESCRIPTION
## Summary

Increment 2/4 of #340 (ADR 0001 — SAR backscatter, Phase 1).

- `titiler/openeo/sar/geocode.py` — `build_inverse_map`: destination pixel centres -> source `(line, pixel)` via `GCPTransformer(gcps, tps=True)`, reprojecting `dst_crs` into `gcp_crs` first when they differ. No pixel reads.
- `titiler/openeo/sar/calibration.py` — `calibrate`: `(DN² − η·noise_removal) / A²`, `A` selected by `coefficient` (`null` → uncalibrated `DN²`), negative clamping with a count.
- **Deliberately no `reader.py`.** Per the ADR's revision (§7.3, §7.10), reading is `RasterStack`'s job — `OpenEOReader` already warps GCP-referenced datasets from their real GCPs (#344). Duplicating a windowed/decimated/resampled read here would fork overviews, CRS handling, masks, mosaicking, output-size limits and retries away from rio-tiler.
- Resolves the ADR §7.10(b) open caveat: checked live STAC items from CDSE, Earth Search and Planetary Computer — none declare `raster:scale`/`raster:offset` on Sentinel-1 GRD assets, so the graph-driven reader-requirement mechanism has no first client yet and stays deferred. Recorded in the ADR.

## Test plan

- [x] `tests/test_sar_geocode.py` — hand-computed inverse map on an affine-consistent GCP set (identity CRS and with a `dst_crs != gcp_crs` reprojection), plus the ADR §7.8 acceptance criterion 4: TPS round-trip residual **< 1 m RMS** on the real polar Sentinel-1 GCP fixture.
- [x] `tests/test_sar_calibration.py` — coefficient maths (`beta0`, `sigma0-ellipsoid`, `gamma0-ellipsoid`, `null`) against hand-computed values, noise-removal negative clamping/counting, unsupported-coefficient error.
- [x] Full suite passes: `uv run pytest tests/` (856 passed, 12 skipped).
- [x] `pre-commit run` (ruff, ruff-format, mypy, isort, markdownlint) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)