### PR TITLE
docs: add SAR backscatter user docs and catalogue-contract test (increment 4/4)

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
       - Parameter Management: "parameter-management.md"
       - Service Authorization: "authorization.md"
       - Tile Assignment: "tile-assignment.md"
+      - SAR Backscatter: "sar-backscatter.md"
   - Administrator Guide:
     - Overview: "admin-guide.md"
     - OpenID Connect: "openid-connect.md"

--- a/docs/src/sar-backscatter.md
+++ b/docs/src/sar-backscatter.md
@@ -1,0 +1,201 @@
+# SAR Backscatter (Sentinel-1)
+
+`sar_backscatter` calibrates Sentinel-1 GRD digital numbers (DN) into physical radar
+backscatter. This is **Phase 1**: ellipsoid-referenced coefficients only. Terrain
+correction (DEM-based geometric orthorectification, radiometric terrain flattening) is
+not implemented and is tracked as later phases — see the
+[design reference](#design-reference) below for the full rationale and what is planned.
+
+## Supported collections
+
+`sentinel-1-grd` is served from CDSE, Earth Search and Planetary Computer. Any STAC
+catalogue configured for this backend works the same way, as long as its items expose
+the same asset shape those three do: one measurement asset per polarisation (`vv`,
+`vh`, `hh`, `hv`) plus its `schema-calibration-<pol>` and `schema-noise-<pol>` sibling
+annotation assets.
+
+Acceptance is **capability-gated, not identity-gated**: `sar_backscatter` does not
+require a specific `product:type` or `sar:product_type` value (these are inconsistent
+across catalogues), only that the assets it needs actually resolve. It does reject
+`sar:product_type` values positively known to be unsupported (`SLC`, `OCN`) — the
+process assumes detected GRD amplitude data.
+
+## Supported parameters
+
+| Parameter | Phase 1 support |
+| --- | --- |
+| `coefficient` | `beta0`, `sigma0-ellipsoid`, `gamma0-ellipsoid`, `null`. **Not** `sigma0-terrain` or `gamma0-terrain` (the openEO spec's own default) — callers must opt into an ellipsoid coefficient explicitly. |
+| `elevation_model` | Must be `null`. No DEM is used. |
+| `mask` | Supported. Adds a `mask` band: `1.0` valid, `0.0` invalid/no-data. |
+| `noise_removal` | Supported (default `true`). Subtracts ESA's thermal noise LUT before calibration; negative results are clamped to `0` and counted. |
+| `ellipsoid_incidence_angle` | Supported. Adds an `ellipsoid_incidence_angle` band, in degrees, recovered from the calibration LUTs alone (no orbit geometry needed). |
+| `contributing_area` | **Not supported** — requires a DEM. |
+| `local_incidence_angle` | **Not supported** — requires a DEM. |
+
+Every unsupported parameter raises a clear error rather than silently approximating:
+
+| Condition | Error |
+| --- | --- |
+| `coefficient` is `sigma0-terrain` or `gamma0-terrain` | `ProcessParameterInvalid` |
+| `contributing_area=true` or `local_incidence_angle=true` | `FeatureUnsupported` |
+| `elevation_model` is not `null` | `DigitalElevationModelInvalid` |
+| `data` is not a STAC-item-backed `load_collection`/`load_stac` stack, or a slice mosaics several source items | `ProcessParameterInvalid` |
+| A requested polarisation's measurement/calibration/noise asset does not resolve | `ProcessParameterInvalid`, naming the polarisation and asset kind |
+| `sar:product_type` is positively `SLC` or `OCN` | `ProcessParameterInvalid` |
+
+## Scientific accuracy statement
+
+Reproduced verbatim from the design ADR (§5), which governs Phase 1's radiometric and
+geometric accuracy claims:
+
+> **Radiometric accuracy — excellent.** The computation
+> `σ⁰ = (DN² − η) / A_σ²` is exactly the relation ESA specifies
+> ([ESA-EOPG-CSCOP-TN-0002](https://sentinels.copernicus.eu/documents/247904/685163/S1-Radiometric-Calibration-V1.0.pdf) §4), with the same supplied LUTs, and is what SNAP's
+> Calibration operator implements. The absolute calibration constant K is already folded
+> into the LUTs and must **not** be applied again. Agreement with SNAP is expected to
+> be limited only by resampling choice, well inside Sentinel-1's ~0.3–0.5 dB absolute
+> radiometric accuracy. Decimation bias is ≤ 0.06 dB, and ESA explicitly endorses
+> averaging in power — *"the average backscatter coefficient over an area of interest can be
+> used instead: σ⁰ = ⟨DN²⟩ / A_σ²"*.
+>
+> **A nuance on "ellipsoid".** The Earth model behind the LUTs is not the bare WGS84
+> ellipsoid: ESA defines it as *"the ellipsoid inflated with an average height"* for the
+> scene. So `sigma0-ellipsoid` is already referenced to a mean scene elevation, which
+> slightly reduces — but does not remove — the terrain error below. The openEO coefficient
+> name `sigma0-ellipsoid` is still the correct label; these docs should just not overstate it
+> as "sea-level referenced".
+>
+> **Geometric accuracy — terrain-dependent, but less so than first stated.** ESA computes
+> the geolocation grid against a terrain model — sampled 10 CDSE products across
+> 2015–2026 show GCP height is 0 m over ocean and sea ice, but 196–253 m and 251–351 m
+> over European land at 52–56°N, and 0–835 m over the tropics at 4–7°N. Geocoding
+> through these GCPs therefore already accounts for terrain **at grid resolution** — a
+> coarse ~10–25 km sampling. What remains uncorrected is local relief *relative to the
+> smoothly interpolated grid*, not the full terrain height. The figures below are
+> consequently an **upper bound**, pessimistic for large-scale topography while
+> remaining valid for local relief.
+>
+> This does not change the radiometry: `sigma0-ellipsoid`/`gamma0-ellipsoid` use the
+> ellipsoid incidence angle from the calibration LUTs regardless of what the
+> geolocation grid does. The geometric and radiometric senses of "ellipsoid" are
+> independent.
+>
+> Planimetric error, as an upper bound:
+>
+> ```
+> Δx  =  Δh / tan(θ)
+> ```
+>
+> For IW (θ ≈ 29°–46°) that is **1.0× to 1.8× the height above the grid's own
+> reference** — which is the terrain-sampled grid rather than the bare ellipsoid.
+> Concretely: 100 m of relief → 100–180 m of horizontal displacement; 500 m →
+> 0.5–0.9 km. Over flat coastal or agricultural terrain the error is metres. Over
+> mountains it is catastrophic for any per-pixel analysis.
+>
+> **Radiometric terrain effects — uncorrected.** On sloping terrain the illuminated area
+> per pixel departs from the ellipsoid assumption; `gamma0-ellipsoid` typically deviates
+> from `gamma0-terrain` by ±3 dB on moderate slopes and >6 dB on steep foreslopes. Layover
+> and shadow are neither detected nor masked.
+>
+> **Fit for purpose:** open water and flood mapping, agriculture, wetlands, sea ice, oil
+> spill and ship detection, urban change over low-relief terrain, and any application that
+> compares same-geometry acquisitions (same relative orbit) where the terrain bias largely
+> cancels.
+>
+> **Not fit for purpose:** mountainous terrain, cross-orbit (ascending vs descending)
+> comparison, biomass or soil-moisture retrieval, anything requiring CARD4L compliance.
+
+## Worked examples
+
+Ellipsoid sigma0, with a validity mask, over VV/VH:
+
+```json
+{
+  "process_graph": {
+    "load1": {
+      "process_id": "load_collection",
+      "arguments": {
+        "id": "sentinel-1-grd",
+        "spatial_extent": {"west": 139.5, "south": 35.2, "east": 140.2, "north": 35.8},
+        "temporal_extent": ["2026-07-08T20:42:00Z", "2026-07-08T20:44:00Z"],
+        "bands": ["vv", "vh"]
+      }
+    },
+    "sar1": {
+      "process_id": "sar_backscatter",
+      "arguments": {
+        "data": {"from_node": "load1"},
+        "coefficient": "sigma0-ellipsoid",
+        "noise_removal": true,
+        "mask": true
+      }
+    },
+    "save1": {
+      "process_id": "save_result",
+      "arguments": {
+        "data": {"from_node": "sar1"},
+        "format": "GTiff"
+      },
+      "result": true
+    }
+  }
+}
+```
+
+Gamma0, with the ellipsoid incidence angle also requested (e.g. to build a
+polarimetric or terrain-aware downstream index):
+
+```json
+{
+  "process_graph": {
+    "load1": {
+      "process_id": "load_collection",
+      "arguments": {
+        "id": "sentinel-1-grd",
+        "spatial_extent": {"west": 139.5, "south": 35.2, "east": 140.2, "north": 35.8},
+        "temporal_extent": ["2026-07-08T20:42:00Z", "2026-07-08T20:44:00Z"],
+        "bands": ["vv", "vh"]
+      }
+    },
+    "sar1": {
+      "process_id": "sar_backscatter",
+      "arguments": {
+        "data": {"from_node": "load1"},
+        "coefficient": "gamma0-ellipsoid",
+        "ellipsoid_incidence_angle": true
+      }
+    },
+    "save1": {
+      "process_id": "save_result",
+      "arguments": {
+        "data": {"from_node": "sar1"},
+        "format": "GTiff"
+      },
+      "result": true
+    }
+  }
+}
+```
+
+See the [Sentinel-1 SAR Backscatter RGB Composite](notebooks/sar_backscatter_rgb.ipynb)
+notebook for an end-to-end run producing a VH/VV/VH:VV false-colour composite, a useful
+visual sanity check of a real calibrated product (water dark, vegetation reddish, urban
+bright).
+
+## Need CARD4L or terrain-corrected gamma0?
+
+This backend does not produce terrain-corrected (`gamma0-terrain`/`sigma0-terrain`)
+or CARD4L-compliant output. If you need that today, use a pre-computed Radiometric
+Terrain Correction (RTC) collection instead — for example
+[OPERA RTC-S1](https://hyp3-docs.asf.alaska.edu/guides/opera_rtc_product_guide/), which
+ships CARD4L-compliant terrain-flattened gamma0 directly as a STAC collection you can
+`load_collection` like any other. `sar_backscatter`'s terrain correction (Phase 2:
+geometric orthorectification, then Phase 3: radiometric terrain flattening and
+registering `ard_normalized_radar_backscatter`) is on the roadmap but not built yet.
+
+## Design reference
+
+The full design rationale, empirical findings, and phased implementation plan live in
+[ADR 0001](https://github.com/sentinel-hub/titiler-openeo/blob/main/docs/adr/0001-sar-backscatter.md).
+ADRs are repo-only documentation (like `docs/audits/`) and are not published on this
+site — follow the link on GitHub.

--- a/tests/fixtures/sar/README.md
+++ b/tests/fixtures/sar/README.md
@@ -28,3 +28,20 @@ products, the affine and `MAX_GCP_ORDER=3` warp paths diverge by ≤ 30 m at
 affine a poor model of the grid. A mid-latitude grid cannot discriminate the
 two paths at all: the difference falls below the resampling quantisation
 floor. See `docs/adr/0001-sar-backscatter.md` §1.6i and issue #343.
+
+## STAC item fixtures (`items/`)
+
+Trimmed real STAC items — one per catalogue this project targets — fetched
+live 2026-07-30, used by `tests/test_sar_catalogue_contract.py` (ADR §7.9).
+Each keeps only `sar:*`/`proj:*`/`product:type` properties and the
+measurement + `schema-calibration-*`/`schema-noise-*` assets; thumbnails,
+manifests and other unrelated assets are dropped.
+
+| File | Source item | Notes |
+| --- | --- | --- |
+| `cdse.json` | `S1D_IW_GRDH_1SDV_20260730T185910_20260730T185937_003907_00710E_0863_COG` | No `proj:*` at all. `sar:product_type` absent (only `product:type`, a different field). |
+| `earth_search.json` | `S1D_IW_GRDH_1SDV_20260730T185910_20260730T185937_003907_00710E` | Same acquisition as the CDSE fixture, from a different catalogue. Publishes a bbox-derived `proj:transform` that is fiction for SAR geometry. |
+| `planetary_computer.json` | `S1C_EW_GRDM_1SDH_20260730T181143_20260730T181243_008776_01164E` | HH/HV (EW mode), not VV/VH — exercises a different polarisation pair. Also publishes a bbox-derived `proj:transform`. |
+
+Adding a catalogue means adding a row here and a fixture, per the ADR — this
+is what makes portability a verified claim rather than an assumption.

--- a/tests/fixtures/sar/items/cdse.json
+++ b/tests/fixtures/sar/items/cdse.json
@@ -1,0 +1,151 @@
+{
+  "type": "Feature",
+  "stac_version": "1.1.0",
+  "id": "S1D_IW_GRDH_1SDV_20260730T185910_20260730T185937_003907_00710E_0863_COG",
+  "properties": {
+    "datetime": "2026-07-30T18:59:10.437185Z",
+    "product:type": "IW_GRDH_1S",
+    "sar:polarizations": [
+      "VV",
+      "VH"
+    ],
+    "sar:frequency_band": "C",
+    "sar:instrument_mode": "IW",
+    "sar:center_frequency": 5.405,
+    "sar:pixel_spacing_range": 10.0,
+    "sar:observation_direction": "right",
+    "sar:pixel_spacing_azimuth": 10.0
+  },
+  "assets": {
+    "vh": {
+      "href": "s3://eodata/Sentinel-1/SAR/IW_GRDH_1S-COG/2026/07/30/S1D_IW_GRDH_1SDV_20260730T185910_20260730T185937_003907_00710E_0863_COG.SAFE/measurement/s1d-iw-grd-vh-20260730t185910-20260730t185937-003907-00710e-002-cog.tiff",
+      "alternate": {
+        "https": {
+          "href": "https://download.dataspace.copernicus.eu/odata/v1/Products(276a2da2-4ae2-482c-b7cc-32fc944c5253)/Nodes(S1D_IW_GRDH_1SDV_20260730T185910_20260730T185937_003907_00710E_0863_COG.SAFE)/Nodes(measurement)/Nodes(s1d-iw-grd-vh-20260730t185910-20260730t185937-003907-00710e-002-cog.tiff)/$value",
+          "auth:refs": [
+            "oidc"
+          ],
+          "storage:refs": [],
+          "alternate:name": "HTTPS"
+        }
+      },
+      "sar:polarizations": [
+        "VH"
+      ]
+    },
+    "vv": {
+      "href": "s3://eodata/Sentinel-1/SAR/IW_GRDH_1S-COG/2026/07/30/S1D_IW_GRDH_1SDV_20260730T185910_20260730T185937_003907_00710E_0863_COG.SAFE/measurement/s1d-iw-grd-vv-20260730t185910-20260730t185937-003907-00710e-001-cog.tiff",
+      "alternate": {
+        "https": {
+          "href": "https://download.dataspace.copernicus.eu/odata/v1/Products(276a2da2-4ae2-482c-b7cc-32fc944c5253)/Nodes(S1D_IW_GRDH_1SDV_20260730T185910_20260730T185937_003907_00710E_0863_COG.SAFE)/Nodes(measurement)/Nodes(s1d-iw-grd-vv-20260730t185910-20260730t185937-003907-00710e-001-cog.tiff)/$value",
+          "auth:refs": [
+            "oidc"
+          ],
+          "storage:refs": [],
+          "alternate:name": "HTTPS"
+        }
+      },
+      "sar:polarizations": [
+        "VV"
+      ]
+    },
+    "schema-noise-vh": {
+      "href": "s3://eodata/Sentinel-1/SAR/IW_GRDH_1S-COG/2026/07/30/S1D_IW_GRDH_1SDV_20260730T185910_20260730T185937_003907_00710E_0863_COG.SAFE/annotation/calibration/noise-s1d-iw-grd-vh-20260730t185910-20260730t185937-003907-00710e-002-cog.xml",
+      "alternate": {
+        "https": {
+          "href": "https://download.dataspace.copernicus.eu/odata/v1/Products(276a2da2-4ae2-482c-b7cc-32fc944c5253)/Nodes(S1D_IW_GRDH_1SDV_20260730T185910_20260730T185937_003907_00710E_0863_COG.SAFE)/Nodes(annotation)/Nodes(calibration)/Nodes(noise-s1d-iw-grd-vh-20260730t185910-20260730t185937-003907-00710e-002-cog.xml)/$value",
+          "auth:refs": [
+            "oidc"
+          ],
+          "storage:refs": [],
+          "alternate:name": "HTTPS"
+        }
+      },
+      "sar:polarizations": [
+        "VH"
+      ]
+    },
+    "schema-noise-vv": {
+      "href": "s3://eodata/Sentinel-1/SAR/IW_GRDH_1S-COG/2026/07/30/S1D_IW_GRDH_1SDV_20260730T185910_20260730T185937_003907_00710E_0863_COG.SAFE/annotation/calibration/noise-s1d-iw-grd-vv-20260730t185910-20260730t185937-003907-00710e-001-cog.xml",
+      "alternate": {
+        "https": {
+          "href": "https://download.dataspace.copernicus.eu/odata/v1/Products(276a2da2-4ae2-482c-b7cc-32fc944c5253)/Nodes(S1D_IW_GRDH_1SDV_20260730T185910_20260730T185937_003907_00710E_0863_COG.SAFE)/Nodes(annotation)/Nodes(calibration)/Nodes(noise-s1d-iw-grd-vv-20260730t185910-20260730t185937-003907-00710e-001-cog.xml)/$value",
+          "auth:refs": [
+            "oidc"
+          ],
+          "storage:refs": [],
+          "alternate:name": "HTTPS"
+        }
+      },
+      "sar:polarizations": [
+        "VV"
+      ]
+    },
+    "schema-calibration-vh": {
+      "href": "s3://eodata/Sentinel-1/SAR/IW_GRDH_1S-COG/2026/07/30/S1D_IW_GRDH_1SDV_20260730T185910_20260730T185937_003907_00710E_0863_COG.SAFE/annotation/calibration/calibration-s1d-iw-grd-vh-20260730t185910-20260730t185937-003907-00710e-002-cog.xml",
+      "alternate": {
+        "https": {
+          "href": "https://download.dataspace.copernicus.eu/odata/v1/Products(276a2da2-4ae2-482c-b7cc-32fc944c5253)/Nodes(S1D_IW_GRDH_1SDV_20260730T185910_20260730T185937_003907_00710E_0863_COG.SAFE)/Nodes(annotation)/Nodes(calibration)/Nodes(calibration-s1d-iw-grd-vh-20260730t185910-20260730t185937-003907-00710e-002-cog.xml)/$value",
+          "auth:refs": [
+            "oidc"
+          ],
+          "storage:refs": [],
+          "alternate:name": "HTTPS"
+        }
+      },
+      "sar:polarizations": [
+        "VH"
+      ]
+    },
+    "schema-calibration-vv": {
+      "href": "s3://eodata/Sentinel-1/SAR/IW_GRDH_1S-COG/2026/07/30/S1D_IW_GRDH_1SDV_20260730T185910_20260730T185937_003907_00710E_0863_COG.SAFE/annotation/calibration/calibration-s1d-iw-grd-vv-20260730t185910-20260730t185937-003907-00710e-001-cog.xml",
+      "alternate": {
+        "https": {
+          "href": "https://download.dataspace.copernicus.eu/odata/v1/Products(276a2da2-4ae2-482c-b7cc-32fc944c5253)/Nodes(S1D_IW_GRDH_1SDV_20260730T185910_20260730T185937_003907_00710E_0863_COG.SAFE)/Nodes(annotation)/Nodes(calibration)/Nodes(calibration-s1d-iw-grd-vv-20260730t185910-20260730t185937-003907-00710e-001-cog.xml)/$value",
+          "auth:refs": [
+            "oidc"
+          ],
+          "storage:refs": [],
+          "alternate:name": "HTTPS"
+        }
+      },
+      "sar:polarizations": [
+        "VV"
+      ]
+    }
+  },
+  "bbox": [
+    -26.230534,
+    66.19828,
+    -19.560696,
+    68.293411
+  ],
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          -26.230534,
+          67.806076
+        ],
+        [
+          -25.138008,
+          66.19828
+        ],
+        [
+          -19.560696,
+          66.666328
+        ],
+        [
+          -20.276073,
+          68.293411
+        ],
+        [
+          -26.230534,
+          67.806076
+        ]
+      ]
+    ]
+  },
+  "links": []
+}

--- a/tests/fixtures/sar/items/earth_search.json
+++ b/tests/fixtures/sar/items/earth_search.json
@@ -1,0 +1,137 @@
+{
+  "type": "Feature",
+  "stac_version": "1.0.0",
+  "id": "S1D_IW_GRDH_1SDV_20260730T185910_20260730T185937_003907_00710E",
+  "properties": {
+    "sar:frequency_band": "C",
+    "sar:center_frequency": 5.405,
+    "sar:observation_direction": "right",
+    "sar:instrument_mode": "IW",
+    "sar:polarizations": [
+      "VV",
+      "VH"
+    ],
+    "sar:product_type": "GRD",
+    "sar:resolution_range": 20,
+    "sar:resolution_azimuth": 22,
+    "sar:pixel_spacing_range": 10,
+    "sar:pixel_spacing_azimuth": 10,
+    "sar:looks_range": 5,
+    "sar:looks_azimuth": 1,
+    "sar:looks_equivalent_number": 4.4,
+    "proj:epsg": 4326,
+    "proj:bbox": [
+      -26.230534,
+      66.19828,
+      -19.560696,
+      68.293411
+    ],
+    "proj:shape": [
+      25427,
+      18251
+    ],
+    "proj:transform": [
+      0.00036545055065475857,
+      0,
+      -26.230534,
+      0,
+      -8.239788413890782e-05,
+      68.293411
+    ],
+    "proj:centroid": {
+      "lat": 67.24941,
+      "lon": -22.80957
+    },
+    "datetime": "2026-07-30T18:59:24.140468Z"
+  },
+  "assets": {
+    "schema-calibration-vh": {
+      "href": "s3://sentinel-s1-l1c/GRD/2026/7/30/IW/DV/S1D_IW_GRDH_1SDV_20260730T185910_20260730T185937_003907_00710E_33E2/annotation/calibration/calibration-iw-vh.xml"
+    },
+    "schema-calibration-vv": {
+      "href": "s3://sentinel-s1-l1c/GRD/2026/7/30/IW/DV/S1D_IW_GRDH_1SDV_20260730T185910_20260730T185937_003907_00710E_33E2/annotation/calibration/calibration-iw-vv.xml"
+    },
+    "schema-noise-vh": {
+      "href": "s3://sentinel-s1-l1c/GRD/2026/7/30/IW/DV/S1D_IW_GRDH_1SDV_20260730T185910_20260730T185937_003907_00710E_33E2/annotation/calibration/noise-iw-vh.xml"
+    },
+    "schema-noise-vv": {
+      "href": "s3://sentinel-s1-l1c/GRD/2026/7/30/IW/DV/S1D_IW_GRDH_1SDV_20260730T185910_20260730T185937_003907_00710E_33E2/annotation/calibration/noise-iw-vv.xml"
+    },
+    "vh": {
+      "href": "s3://sentinel-s1-l1c/GRD/2026/7/30/IW/DV/S1D_IW_GRDH_1SDV_20260730T185910_20260730T185937_003907_00710E_33E2/measurement/iw-vh.tiff"
+    },
+    "vv": {
+      "href": "s3://sentinel-s1-l1c/GRD/2026/7/30/IW/DV/S1D_IW_GRDH_1SDV_20260730T185910_20260730T185937_003907_00710E_33E2/measurement/iw-vv.tiff"
+    }
+  },
+  "bbox": [
+    -26.0940692,
+    66.2024816,
+    -19.5833275,
+    68.2900291
+  ],
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          -20.2965279,
+          68.2900291
+        ],
+        [
+          -22.1778895,
+          68.1615854
+        ],
+        [
+          -22.1434125,
+          68.0980396
+        ],
+        [
+          -24.195131,
+          67.9310629
+        ],
+        [
+          -24.1660622,
+          67.8736012
+        ],
+        [
+          -26.0940692,
+          67.689048
+        ],
+        [
+          -25.5505497,
+          66.9041896
+        ],
+        [
+          -25.5350012,
+          66.8805289
+        ],
+        [
+          -25.5424374,
+          66.8778248
+        ],
+        [
+          -25.0989688,
+          66.2024816
+        ],
+        [
+          -22.3509504,
+          66.4593689
+        ],
+        [
+          -19.5833275,
+          66.6655548
+        ],
+        [
+          -19.9923192,
+          67.6234741
+        ],
+        [
+          -20.2965279,
+          68.2900291
+        ]
+      ]
+    ]
+  },
+  "links": []
+}

--- a/tests/fixtures/sar/items/planetary_computer.json
+++ b/tests/fixtures/sar/items/planetary_computer.json
@@ -1,0 +1,101 @@
+{
+  "type": "Feature",
+  "stac_version": "1.0.0",
+  "id": "S1C_EW_GRDM_1SDH_20260730T181143_20260730T181243_008776_01164E",
+  "properties": {
+    "datetime": "2026-07-30T18:12:13.300709Z",
+    "proj:bbox": [
+      -29.470901,
+      73.192726,
+      -10.764712,
+      77.822441
+    ],
+    "proj:epsg": 4326,
+    "proj:shape": [
+      10414,
+      9992
+    ],
+    "proj:centroid": {
+      "lat": 75.50966,
+      "lon": -19.45521
+    },
+    "proj:transform": [
+      0.0018721165932746198,
+      0.0,
+      -29.470901,
+      0.0,
+      -0.0004445664490109472,
+      77.822441
+    ],
+    "sar:looks_range": 6,
+    "sar:product_type": "GRD",
+    "sar:looks_azimuth": 2,
+    "sar:polarizations": [
+      "HH",
+      "HV"
+    ],
+    "sar:frequency_band": "C",
+    "sar:instrument_mode": "EW",
+    "sar:center_frequency": 5.405,
+    "sar:resolution_range": 93,
+    "sar:resolution_azimuth": 87,
+    "sar:pixel_spacing_range": 40,
+    "sar:observation_direction": "right",
+    "sar:pixel_spacing_azimuth": 40,
+    "sar:looks_equivalent_number": 10.7
+  },
+  "assets": {
+    "hh": {
+      "href": "https://sentinel1euwest.blob.core.windows.net/s1-grd/GRD/2026/7/30/EW/DH/S1C_EW_GRDM_1SDH_20260730T181143_20260730T181243_008776_01164E_8A8A/measurement/ew-hh.tiff"
+    },
+    "hv": {
+      "href": "https://sentinel1euwest.blob.core.windows.net/s1-grd/GRD/2026/7/30/EW/DH/S1C_EW_GRDM_1SDH_20260730T181143_20260730T181243_008776_01164E_8A8A/measurement/ew-hv.tiff"
+    },
+    "schema-noise-hh": {
+      "href": "https://sentinel1euwest.blob.core.windows.net/s1-grd/GRD/2026/7/30/EW/DH/S1C_EW_GRDM_1SDH_20260730T181143_20260730T181243_008776_01164E_8A8A/annotation/calibration/noise-ew-hh.xml"
+    },
+    "schema-noise-hv": {
+      "href": "https://sentinel1euwest.blob.core.windows.net/s1-grd/GRD/2026/7/30/EW/DH/S1C_EW_GRDM_1SDH_20260730T181143_20260730T181243_008776_01164E_8A8A/annotation/calibration/noise-ew-hv.xml"
+    },
+    "schema-calibration-hh": {
+      "href": "https://sentinel1euwest.blob.core.windows.net/s1-grd/GRD/2026/7/30/EW/DH/S1C_EW_GRDM_1SDH_20260730T181143_20260730T181243_008776_01164E_8A8A/annotation/calibration/calibration-ew-hh.xml"
+    },
+    "schema-calibration-hv": {
+      "href": "https://sentinel1euwest.blob.core.windows.net/s1-grd/GRD/2026/7/30/EW/DH/S1C_EW_GRDM_1SDH_20260730T181143_20260730T181243_008776_01164E_8A8A/annotation/calibration/calibration-ew-hv.xml"
+    }
+  },
+  "bbox": [
+    -29.470900999999998,
+    73.192726,
+    -10.764712000000003,
+    77.822441
+  ],
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          -29.470900999999998,
+          76.500153
+        ],
+        [
+          -23.52973700000001,
+          73.192726
+        ],
+        [
+          -10.764712000000003,
+          74.289749
+        ],
+        [
+          -13.712120999999996,
+          77.822441
+        ],
+        [
+          -29.470900999999998,
+          76.500153
+        ]
+      ]
+    ]
+  },
+  "links": []
+}

--- a/tests/test_sar_catalogue_contract.py
+++ b/tests/test_sar_catalogue_contract.py
@@ -1,0 +1,100 @@
+"""Catalogue-contract tests for sar_backscatter asset resolution (ADR S7.9).
+
+Table-driven over committed, trimmed real STAC items from the three catalogues
+this project targets (`tests/fixtures/sar/items/`, fetched live 2026-07-30),
+asserting the ADR S1.7 requirements: annotation siblings resolve for every
+polarisation, real GRD items are never rejected by the product-type gate, and
+a misleading `proj:*` (present on Earth Search and Planetary Computer,
+confirmed fabricated/bbox-derived) is never consulted. Adding a catalogue
+means adding a row below and a fixture, per the ADR.
+
+**What this does not verify: GCP presence.** GCPs live in the measurement
+raster's own header, not STAC metadata, so a committed-JSON fixture cannot
+assert it -- that would need a live, credentialed read of the actual asset.
+It is already measured live per catalogue (ADR S1.5's table) and was
+re-confirmed empirically against a live backend in #347's validation
+notebook (a real calibrated composite; median open-water sigma0 at
+-24.6 dB, matching the ADR's expected -20..-25 dB band). Faking that check
+against a fixture that cannot carry the property would be worse than not
+having it.
+"""
+
+import inspect
+import json
+from pathlib import Path
+
+import pytest
+
+from titiler.openeo.processes.implementations import sar as sar_module
+from titiler.openeo.processes.implementations.sar import (
+    _check_product_type,
+    _resolve_polarisation_assets,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures" / "sar" / "items"
+
+CATALOGUES = [
+    pytest.param("cdse.json", ["vv", "vh"], id="CDSE"),
+    pytest.param("earth_search.json", ["vv", "vh"], id="EarthSearch"),
+    pytest.param("planetary_computer.json", ["hh", "hv"], id="PlanetaryComputer"),
+]
+
+
+def _load(fixture_name: str) -> dict:
+    return json.loads((FIXTURES / fixture_name).read_text())
+
+
+@pytest.mark.parametrize("fixture_name,polarisations", CATALOGUES)
+def test_annotation_siblings_resolve(fixture_name, polarisations):
+    """Every requested polarisation's measurement/calibration/noise asset resolves."""
+    item = _load(fixture_name)
+    for pol in polarisations:
+        measurement_href, calibration_href, noise_href = _resolve_polarisation_assets(
+            item, pol
+        )
+        assert measurement_href and measurement_href.endswith(".tiff")
+        assert calibration_href and calibration_href.endswith(".xml")
+        assert noise_href and noise_href.endswith(".xml")
+        assert len({measurement_href, calibration_href, noise_href}) == 3
+
+
+@pytest.mark.parametrize("fixture_name,_polarisations", CATALOGUES)
+def test_product_type_gate_accepts_real_items(fixture_name, _polarisations):
+    """Real GRD items from every catalogue clear the capability gate.
+
+    CDSE has no `sar:product_type` at all (only `product:type`, a differently
+    formatted field this process does not key on); Earth Search and Planetary
+    Computer both set `sar:product_type: GRD`. Both must be accepted --
+    gate on capability (asset resolution, tested above), not identity.
+    """
+    _check_product_type(_load(fixture_name))  # must not raise
+
+
+@pytest.mark.parametrize(
+    "fixture_name", ["earth_search.json", "planetary_computer.json"]
+)
+def test_fixture_documents_the_misleading_proj_transform(fixture_name):
+    """Earth Search and Planetary Computer both publish a bbox-derived
+    `proj:transform` that is fiction for SAR geometry (ADR S1.7). Pinning its
+    presence here means a future re-fetch that silently loses it doesn't
+    quietly stop testing the case this fixture exists for.
+    """
+    item = _load(fixture_name)
+    assert "proj:transform" in item["properties"]
+
+
+def test_cdse_fixture_documents_the_absence_of_proj_metadata():
+    """CDSE publishes no `proj:*` at all (ADR S1.7) -- the cleanest catalogue
+    to confirm the resolution path needs none of it."""
+    item = _load("cdse.json")
+    assert not any(k.startswith("proj:") for k in item["properties"])
+
+
+def test_resolution_never_reads_item_proj_fields():
+    """Structural guard: sar.py's asset-resolution code must never key off
+    `proj:*` -- geometry comes only from `geocode.get_gcps` (the measurement
+    asset's own header), never from item/asset metadata (ADR S1.7). This is
+    a property of the code, not of any one fixture, so it is asserted once
+    here rather than duplicated per catalogue.
+    """
+    assert "proj:" not in inspect.getsource(sar_module)


### PR DESCRIPTION
## Summary

Completes issue #340 — increment 4/4 (ADR 0001, SAR backscatter Phase 1). Increments 1-3 (annotation/fetcher #342, geocode/calibration #346, the `sar_backscatter` process #347) are merged; this closes out the ADR's remaining documentation deliverables (§8) and test plan (§7.9).

- `docs/src/sar-backscatter.md` (new) — supported coefficients/parameters and collections, the full error taxonomy, the ADR §5 scientific accuracy statement reproduced **verbatim** (the ADR requires this), two worked process-graph examples, and a pointer to [OPERA RTC-S1](https://hyp3-docs.asf.alaska.edu/guides/opera_rtc_product_guide/) for terrain-corrected/CARD4L needs this backend doesn't serve. Added to `docs/mkdocs.yml` nav under **Architecture → Special Features**, per the ADR. `docs/adr/` stays repo-only (matching `docs/audits/`) — stated explicitly in the page rather than left implicit, resolving the ADR's "decide" item.
- `tests/test_sar_catalogue_contract.py` + `tests/fixtures/sar/items/*.json` (new) — the catalogue-contract test the ADR's test plan (§7.9) calls for: table-driven over trimmed real STAC items fetched live (2026-07-30) from all three target catalogues (CDSE, Earth Search, Planetary Computer). Asserts:
  - annotation siblings resolve for every requested polarisation
  - the product-type gate accepts real items from every catalogue (CDSE has no `sar:product_type` at all — only `product:type`, a different field — and is still accepted)
  - the misleading `proj:transform` Earth Search and Planetary Computer both publish is pinned in its fixture (CDSE publishes none), plus a structural guard that the resolution code never reads `proj:*` at all

**Explicitly not asserted: GCP presence.** GCPs live in the measurement raster's own header, not STAC metadata — a committed-JSON fixture can't verify that without a live, credentialed read of the actual asset. It's already measured live per catalogue (ADR §1.5's table) and was re-confirmed empirically in #347's validation notebook (a real calibrated composite; median open-water sigma0 at −24.6 dB, matching the ADR's expected −20…−25 dB band). Documenting the limitation rather than faking a check a fixture can't actually perform.

## Test plan

- [x] `uv run pytest tests/` — 914 passed, 12 skipped, no regressions.
- [x] `pre-commit run` (ruff, ruff-format, mypy, isort, markdownlint) passes on all changed files.
- [x] Verified the new catalogue-contract test actually discriminates — reverted the fix to a broken fixture (removed a calibration asset) and confirmed it fails with a clear message, then restored and confirmed it passes.
- [x] Built the docs site locally (`mkdocs build`, notebook plugin isolated due to an unrelated pre-existing dependency gap on `evi.ipynb`) and confirmed `sar-backscatter.md` renders with no broken-link warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)