### PR TITLE
ci: make rebuild-release-images manual-only

### DIFF
--- a/.github/workflows/rebuild-release-images.yml
+++ b/.github/workflows/rebuild-release-images.yml
@@ -1,11 +1,7 @@
 name: Rebuild Release Images
 
 on:
-  push:
-    branches:
-      - '**'  # Trigger on any branch push
-    paths:
-      - '.github/workflows/rebuild-release-images.yml'
+  workflow_dispatch: {}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- `rebuild-release-images.yml` was a one-time restoration job for release tags that got wiped by a bug in `developmentseed/container-registry-cleanup` (untagged multi-arch manifest children weren't protected by reference).
- That bug is fixed upstream as of `v0.2.1`, which `cleanup-images.yml` already pins. The cleanup job has run weekly + after every release since with no further incidents.
- The `push`/`paths` trigger on `rebuild-release-images.yml` still fires whenever any branch's history picks up a past edit to that file (e.g. via a rebase across a Dependabot SHA bump), rebuilding all 10 pinned images for no reason.
- Restrict the trigger to `workflow_dispatch` so it stays available as a manual break-glass tool without auto-firing.

## Test plan
- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Pre-commit hooks passed
- [x] Confirm the workflow still runs correctly via manual dispatch from the Actions tab