### PR TITLE
fix: emit structured, spec-conformant openEO errors from process failures

### DIFF
--- a/tests/test_apply_graph_integration.py
+++ b/tests/test_apply_graph_integration.py
@@ -18,6 +18,7 @@ import pytest
 from openeo_pg_parser_networkx.graph import OpenEOProcessGraph
 from rio_tiler.models import ImageData
 
+from titiler.openeo.errors import ProcessParameterInvalid
 from titiler.openeo.processes import process_registry
 from titiler.openeo.processes.implementations.data_model import RasterStack
 
@@ -146,7 +147,9 @@ def test_max_rejects_non_boolean_ignore_nodata():
             "result": True,
         }
     }
-    with pytest.raises(TypeError, match="ignore_nodata.*expected 'boolean'"):
+    with pytest.raises(
+        ProcessParameterInvalid, match="ignore_nodata.*expected 'boolean'"
+    ):
         _run(pg, data=stack)
 
 

--- a/tests/test_core_coverage.py
+++ b/tests/test_core_coverage.py
@@ -26,7 +26,7 @@ from openeo_pg_parser_networkx.pg_schema import (
 )
 
 from titiler.openeo.auth import User
-from titiler.openeo.errors import ProcessParameterMissing
+from titiler.openeo.errors import ProcessParameterInvalid, ProcessParameterRequired
 from titiler.openeo.processes.implementations.apply import apply, apply_dimension
 from titiler.openeo.processes.implementations.arrays import merge_cubes
 from titiler.openeo.processes.implementations.core import (
@@ -88,7 +88,7 @@ class TestResolvePositionalArgs:
         assert result == (10, 20)
 
     def test_resolve_positional_args_missing_parameter(self):
-        """Test that missing parameter raises ProcessParameterMissing error.
+        """Test that missing parameter raises ProcessParameterRequired error.
 
         Validates: When a ParameterReference points to a non-existent parameter,
         a clear error is raised with the parameter name.
@@ -102,7 +102,7 @@ class TestResolvePositionalArgs:
 
         args = (ParameterReference(from_parameter="missing"),)
         named_parameters = {}
-        with pytest.raises(ProcessParameterMissing, match="missing"):
+        with pytest.raises(ProcessParameterRequired, match="missing"):
             _resolve_positional_args(args, named_parameters, "test_func")
 
 
@@ -559,7 +559,7 @@ class TestTypeValidation:
     """
 
     def test_validation_none_not_allowed(self):
-        """Test that None raises TypeError for non-optional parameters.
+        """Test that None raises ProcessParameterInvalid for non-optional parameters.
 
         Validates: Required parameters (int, not Optional[int]) must not be None.
 
@@ -571,13 +571,14 @@ class TestTypeValidation:
         def requires_int(x: int) -> int:
             return x * 2
 
-        with pytest.raises(TypeError, match="cannot be None"):
+        with pytest.raises(ProcessParameterInvalid, match="cannot be None"):
             requires_int(x=None)
 
     def test_validation_dict_to_array_mismatch(self):
         """Test dict to array type mismatch detection via Pydantic.
 
-        Validates: Passing a dict when List[int] expected raises clear TypeError.
+        Validates: Passing a dict when List[int] expected raises clear
+        ProcessParameterInvalid.
 
         Why important: Plain dicts are no longer pre-rejected as datacubes.
         Instead, Pydantic validation catches the type mismatch and reports
@@ -588,7 +589,7 @@ class TestTypeValidation:
         def requires_array(data: List[int]) -> int:
             return len(data)
 
-        with pytest.raises(TypeError, match="expected.*got.*object"):
+        with pytest.raises(ProcessParameterInvalid, match="expected.*got.*object"):
             requires_array(data={"a": 1})
 
     def test_validation_lazy_raster_stack_to_array_mismatch(self):
@@ -606,7 +607,9 @@ class TestTypeValidation:
 
         # Create an empty RasterStack (without tasks, but with required timestamp_fn)
         mock_stack = RasterStack(tasks=[], timestamp_fn=lambda x: datetime.now())
-        with pytest.raises(TypeError, match="expected.*List.*got.*datacube"):
+        with pytest.raises(
+            ProcessParameterInvalid, match="expected.*List.*got.*datacube"
+        ):
             requires_array(data=mock_stack)
 
     def test_validation_skip_for_empty_annotation(self):
@@ -627,19 +630,21 @@ class TestTypeValidation:
         assert result == "anything"
 
     def test_validation_pydantic_error_handling(self):
-        """Test Pydantic ValidationError is caught and converted to TypeError.
+        """Test Pydantic ValidationError is caught and converted to ProcessParameterInvalid.
 
         Validates: Invalid types caught by Pydantic get clear error messages.
 
         Why important: Pydantic ValidationErrors can be technical. We convert
-        them to TypeErrors with OpenEO terminology for better UX.
+        them to ProcessParameterInvalid errors with OpenEO terminology for
+        better UX, and so the API reports a spec-compliant 400 instead of a
+        bare 500.
         """
 
         @process
         def requires_int(x: int) -> int:
             return x * 2
 
-        with pytest.raises(TypeError) as exc_info:
+        with pytest.raises(ProcessParameterInvalid) as exc_info:
             requires_int(x="not_an_int")
 
         assert "expected 'integer'" in str(exc_info.value)
@@ -678,7 +683,7 @@ class TestTypeValidation:
         # Pass TemporalInterval when BoundingBox expected
         interval = TemporalInterval(["2020-01-01", "2020-12-31"])
         # This should pass through Pydantic validation which will catch the error
-        with pytest.raises(TypeError):
+        with pytest.raises(ProcessParameterInvalid):
             accepts_bbox(bbox=interval)
 
     def test_validation_complex_type_exception_handling(self):
@@ -735,7 +740,7 @@ class TestProcessDecoratorEdgeCases:
     ensuring robustness and clear error messages.
 
     Scenarios covered:
-    - Missing parameter references (should raise ProcessParameterMissing)
+    - Missing parameter references (should raise ProcessParameterRequired)
     - Special arguments removal (namespace, positional_parameters, etc.)
     - Named parameters passthrough when expected by function
     - Debug logging (should not crash)
@@ -745,7 +750,7 @@ class TestProcessDecoratorEdgeCases:
     """
 
     def test_missing_parameter_in_named_parameters(self):
-        """Test ProcessParameterMissing raised for unresolvable ParameterReference.
+        """Test ProcessParameterRequired raised for unresolvable ParameterReference.
 
         Validates: ParameterReference to non-existent key raises clear error.
 
@@ -757,7 +762,7 @@ class TestProcessDecoratorEdgeCases:
         def add(a: int, b: int) -> int:
             return a + b
 
-        with pytest.raises(ProcessParameterMissing, match="missing"):
+        with pytest.raises(ProcessParameterRequired, match="missing"):
             add(
                 a=ParameterReference(from_parameter="missing_param"),
                 b=5,
@@ -823,7 +828,7 @@ class TestProcessDecoratorEdgeCases:
             return x * 2
 
         # Pass context as ParameterReference to non-existent parameter
-        # This should NOT raise ProcessParameterMissing
+        # This should NOT raise ProcessParameterRequired
         result = simple_func(
             x=5,
             context=ParameterReference(from_parameter="context"),
@@ -905,7 +910,7 @@ class TestProcessDecoratorEdgeCases:
     def test_parameter_resolution_with_exception(self):
         """Test clear error when ParameterReference points to missing key.
 
-        Validates: ProcessParameterMissing raised with parameter name.
+        Validates: ProcessParameterRequired raised with parameter name.
 
         Why important: Error message must indicate which parameter couldn't
         be resolved, helping users fix their OpenEO graph.
@@ -917,7 +922,7 @@ class TestProcessDecoratorEdgeCases:
 
         # When a ParameterReference points to a missing parameter
         # the decorator will try to resolve from named_parameters in the kwargs resolution phase
-        with pytest.raises(ProcessParameterMissing, match="missing"):
+        with pytest.raises(ProcessParameterRequired, match="missing"):
             test_func(x=ParameterReference(from_parameter="missing"))
 
     def test_resolve_special_parameter_with_error(self):
@@ -926,7 +931,7 @@ class TestProcessDecoratorEdgeCases:
         Validates: ParameterReference resolution checks named_parameters exists.
 
         Why important: If named_parameters is empty or missing the key,
-        should raise ProcessParameterMissing with helpful message.
+        should raise ProcessParameterRequired with helpful message.
         """
 
         @process
@@ -934,7 +939,7 @@ class TestProcessDecoratorEdgeCases:
             return x
 
         # Test error from kwargs resolution when named_parameters entry doesn't exist
-        with pytest.raises(ProcessParameterMissing, match="from_nonexistent"):
+        with pytest.raises(ProcessParameterRequired, match="from_nonexistent"):
             test_func(
                 x=ParameterReference(from_parameter="from_nonexistent"),
                 named_parameters={},

--- a/tests/test_exception_handlers.py
+++ b/tests/test_exception_handlers.py
@@ -1,0 +1,80 @@
+"""Tests for ExceptionHandler: openEO-spec-compliant error responses.
+
+See https://api.openeo.org/#section/API-Principles/Error-Handling and the
+standardized error-code registry at
+https://github.com/Open-EO/openeo-api/blob/master/errors.json.
+"""
+
+import json
+import logging
+
+import pytest
+
+from titiler.openeo.errors import (
+    ExceptionHandler,
+    ProcessParameterInvalid,
+    ProcessParameterRequired,
+)
+
+
+@pytest.fixture
+def handler():
+    return ExceptionHandler(logger=logging.getLogger("test"))
+
+
+def _body(response):
+    return json.loads(response.body)
+
+
+class TestOpenEOExceptionHandler:
+    """A specific OpenEOException always yields its own code and status."""
+
+    def test_process_parameter_invalid(self, handler):
+        """A bad parameter value/type yields code=ProcessParameterInvalid, status=400."""
+        exc = ProcessParameterInvalid(
+            "Parameter 'x' in process 'requires_int': expected 'integer' but got 'string'"
+        )
+        response = handler.openeo_exception_handler(None, exc)
+
+        assert response.status_code == 400
+        assert _body(response) == {
+            "code": "ProcessParameterInvalid",
+            "message": "Parameter 'x' in process 'requires_int': expected 'integer' but got 'string'",
+        }
+
+    def test_process_parameter_required(self, handler):
+        """A missing required parameter yields code=ProcessParameterRequired, status=400."""
+        exc = ProcessParameterRequired("bbox")
+        response = handler.openeo_exception_handler(None, exc)
+
+        assert response.status_code == 400
+        body = _body(response)
+        assert body["code"] == "ProcessParameterRequired"
+        assert "bbox" in body["message"]
+
+
+class TestGeneralExceptionHandler:
+    """The catch-all is a safety net for exceptions not raised as OpenEOException."""
+
+    def test_bare_value_error_is_client_error(self, handler):
+        """A ValueError not yet raised as an OpenEOException still reports 400."""
+        response = handler.general_exception_handler(None, ValueError("bad value"))
+
+        assert response.status_code == 400
+        assert _body(response) == {"code": "InvalidRequest", "message": "bad value"}
+
+    def test_bare_type_error_is_client_error(self, handler):
+        """A TypeError that slipped through unwrapped still reports 400, not 500."""
+        response = handler.general_exception_handler(None, TypeError("bad type"))
+
+        assert response.status_code == 400
+        assert _body(response) == {"code": "InvalidRequest", "message": "bad type"}
+
+    def test_genuine_internal_error_uses_standardized_code(self, handler):
+        """A real server fault uses the registered `Internal` code, not a proprietary one."""
+        response = handler.general_exception_handler(None, RuntimeError("disk full"))
+
+        assert response.status_code == 500
+        body = _body(response)
+        assert body["code"] == "Internal"
+        assert body["message"] == "Server error: disk full"

--- a/tests/test_get_param_item.py
+++ b/tests/test_get_param_item.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from titiler.openeo.errors import ProcessParameterInvalid, ProcessParameterMissing
+from titiler.openeo.errors import ProcessParameterInvalid, ProcessParameterRequired
 from titiler.openeo.processes.implementations.get_param_item import get_param_item
 
 
@@ -30,7 +30,7 @@ def test_get_param_item_basic():  # Test basic dictionary access
 def test_get_param_item_errors():  # Test missing path
     param = {"metadata": {"resolution": 10}}
 
-    with pytest.raises(ProcessParameterMissing) as excinfo:
+    with pytest.raises(ProcessParameterRequired) as excinfo:
         get_param_item(param, "$.nonexistent")
         assert "not found in parameter" in str(excinfo.value)
 

--- a/tests/test_parameter_reference_resolution.py
+++ b/tests/test_parameter_reference_resolution.py
@@ -236,7 +236,7 @@ def test_callback_scoped_parameter_reference_not_resolved():
     itself executes.
 
     Regression test for: load_collection with a properties filter containing
-    {"from_parameter": "value"} raised ProcessParameterMissing because _resolve_nested
+    {"from_parameter": "value"} raised ProcessParameterRequired because _resolve_nested
     tried to look up "value" in the outer named_parameters.
     """
     received = {}
@@ -254,7 +254,7 @@ def test_callback_scoped_parameter_reference_not_resolved():
         named_parameters={"indicator": 0},  # 'value' is intentionally absent
     )
 
-    # The ParameterReference must be left intact, not raise ProcessParameterMissing
+    # The ParameterReference must be left intact, not raise ProcessParameterRequired
     assert isinstance(
         received["properties"]["eo:cloud_cover"], ParameterReference
     ), "Callback-scoped ParameterReference should be passed through unchanged"

--- a/tests/test_type_validation.py
+++ b/tests/test_type_validation.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pytest
 
+from titiler.openeo.errors import ProcessParameterInvalid
 from titiler.openeo.processes.implementations.arrays import array_create
 from titiler.openeo.processes.implementations.data_model import RasterStack
 
@@ -23,7 +24,7 @@ def test_array_create_with_raster_stack():
 
     # Create an actual RasterStack instance (not a plain dict)
     raster_stack = RasterStack(tasks=[], timestamp_fn=lambda x: datetime.now())
-    with pytest.raises(TypeError):
+    with pytest.raises(ProcessParameterInvalid):
         _ = array_create(data=raster_stack, repeat=1)
 
 

--- a/tests/test_udp_endpoints.py
+++ b/tests/test_udp_endpoints.py
@@ -458,4 +458,4 @@ def test_validation_flags_missing_required_param(app_no_auth):
     resp = client.post("/validation", json=body)
     assert resp.status_code == 200
     errs = resp.json()["errors"]
-    assert any("ProcessParameterMissing" in e["code"] for e in errs)
+    assert any("ProcessParameterRequired" in e["code"] for e in errs)

--- a/titiler/openeo/errors.py
+++ b/titiler/openeo/errors.py
@@ -95,7 +95,7 @@ class ExceptionHandler:
         return JSONResponse(
             status_code=exc.status_code,
             content={
-                "code": "ServerError" if exc.status_code >= 500 else "InvalidRequest",
+                "code": "Internal" if exc.status_code >= 500 else "InvalidRequest",
                 "message": exc.detail,
             },
         )
@@ -103,9 +103,17 @@ class ExceptionHandler:
     def general_exception_handler(
         self, request: Request, exc: Exception
     ) -> JSONResponse:
-        """Handle general exceptions."""
+        """Handle general exceptions.
+
+        This is a safety net for exceptions that are not (yet) raised as a
+        specific ``OpenEOException`` subclass. ``ValueError``/``TypeError`` are
+        treated as client-input errors, since process implementations raise
+        them for bad parameter values/types; anything else is a genuine
+        server fault, reported with the standardized ``Internal`` code (see
+        https://github.com/Open-EO/openeo-api/blob/master/errors.json).
+        """
         self.logger.error(f"General Exception: {str(exc)}", exc_info=exc)
-        if isinstance(exc, ValueError):
+        if isinstance(exc, (ValueError, TypeError)):
             return JSONResponse(
                 status_code=400,
                 content={
@@ -116,8 +124,8 @@ class ExceptionHandler:
         return JSONResponse(
             status_code=500,
             content={
-                "code": "ServerError",
-                "message": str(exc),
+                "code": "Internal",
+                "message": f"Server error: {exc}",
             },
         )
 
@@ -134,15 +142,15 @@ class ProcessParameterInvalid(OpenEOException):
         )
 
 
-class ProcessParameterMissing(OpenEOException):
-    """Invalid Parameters."""
+class ProcessParameterRequired(OpenEOException):
+    """A required process parameter is missing."""
 
     def __init__(self, parameter: str):
         """Initialize error with missing process parameter."""
         super().__init__(
             message=f"Required process parameter '{parameter}' is missing",
-            code="ProcessParameterMissing",
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            code="ProcessParameterRequired",
+            status_code=status.HTTP_400_BAD_REQUEST,
         )
 
 

--- a/titiler/openeo/factory.py
+++ b/titiler/openeo/factory.py
@@ -809,7 +809,7 @@ class EndpointsFactory(BaseFactory):
                     if param_name not in args or args.get(param_name) is None:
                         errors.append(
                             {
-                                "code": "ProcessParameterMissing",
+                                "code": "ProcessParameterRequired",
                                 "message": f"Required parameter '{param_name}' missing for process '{process_id}'",
                             }
                         )

--- a/titiler/openeo/openapi.yaml
+++ b/titiler/openeo/openapi.yaml
@@ -433,7 +433,7 @@ info:
     The value for the parameter MUST be resolved as follows:
     1. In general the most specific parameter value is used. This means the parameter value is resolved starting from the current scope and then checking each parent for a suitable parameter value until a parameter values is found or the "root" process graph has been reached.
     2. In case a parameter value is not available, the most unspecific default value from the process graph parameter definitions are used. For example, if default values are available for the root process graph and all children, the default value from the root process graph is used.
-    3. If no default values are available either, the error `ProcessParameterMissing` must be thrown.
+    3. If no default values are available either, the error `ProcessParameterRequired` must be thrown.
 
     ### Full example for an EVI computation
 

--- a/titiler/openeo/processes/data/get_param_item.json
+++ b/titiler/openeo/processes/data/get_param_item.json
@@ -32,7 +32,7 @@
     }
   },
   "exceptions": {
-    "ProcessParameterMissing": {
+    "ProcessParameterRequired": {
       "message": "Path not found in parameter",
       "http": 400
     },

--- a/titiler/openeo/processes/implementations/core.py
+++ b/titiler/openeo/processes/implementations/core.py
@@ -39,7 +39,7 @@ from openeo_pg_parser_networkx.pg_schema import (
 )
 from pydantic import BaseModel, TypeAdapter, ValidationError
 
-from ...errors import ProcessParameterMissing
+from ...errors import ProcessParameterInvalid, ProcessParameterRequired
 from .data_model import RasterStack
 
 # Union of all GeoJSON types for validation
@@ -103,13 +103,13 @@ def _resolve_positional_args(
         Tuple of resolved arguments (only those that were ParameterReferences)
 
     Raises:
-        ProcessParameterMissing: If a parameter reference cannot be resolved
+        ProcessParameterRequired: If a parameter reference cannot be resolved
     """
     resolved = []
     for arg in args:
         if isinstance(arg, ParameterReference):
             if arg.from_parameter not in named_parameters:
-                raise ProcessParameterMissing(
+                raise ProcessParameterRequired(
                     f"Parameter '{arg.from_parameter}' missing for process '{func_name}'"
                 )
             resolved.append(named_parameters[arg.from_parameter])
@@ -245,7 +245,7 @@ def _resolve_kwargs(
     non-existent parameters, as they will be removed later if not in the function signature.
 
     Raises:
-        ProcessParameterMissing: If a required parameter reference cannot be resolved
+        ProcessParameterRequired: If a required parameter reference cannot be resolved
     """
     resolved = {}
     for key, value in kwargs.items():
@@ -259,7 +259,7 @@ def _resolve_kwargs(
             # They will be removed later by _handle_special_args if not in signature
             if key in _SPECIAL_OPENEO_ARGS:
                 continue
-            raise ProcessParameterMissing(
+            raise ProcessParameterRequired(
                 f"Parameter '{ref_name}' missing for process '{func_name}'"
             )
 
@@ -423,7 +423,7 @@ def _validate_datacube_param(
         return
 
     if not _is_rasterstack_type_expected(param_type):
-        raise TypeError(
+        raise ProcessParameterInvalid(
             f"Parameter '{param_name}' in process '{func_name}': "
             f"expected '{_type_to_openeo_name(param_type)}' but got '{_value_to_openeo_name(param_value)}'"
         )
@@ -453,7 +453,7 @@ def _validate_with_pydantic(
     try:
         TypeAdapter(param_type).validate_python(param_value)
     except ValidationError as e:
-        raise TypeError(
+        raise ProcessParameterInvalid(
             f"Parameter '{param_name}' in process '{func_name}': "
             f"expected '{_type_to_openeo_name(param_type)}' but got '{_value_to_openeo_name(param_value)}'. "
             f"Details: {e}"
@@ -487,7 +487,7 @@ def _validate_parameter_types(
         if param_value is None:
             is_optional, _ = _is_optional_type(param_type)
             if not is_optional:
-                raise TypeError(
+                raise ProcessParameterInvalid(
                     f"Parameter '{param_name}' in process '{func_name}' cannot be None"
                 )
             continue
@@ -530,7 +530,7 @@ def _resolve_parameter_reference(
     ref_param = value.from_parameter
 
     if ref_param not in named_parameters:
-        raise ProcessParameterMissing(
+        raise ProcessParameterRequired(
             f"Parameter '{ref_param}' missing for process '{func_name}'"
         )
 

--- a/titiler/openeo/processes/implementations/get_param_item.py
+++ b/titiler/openeo/processes/implementations/get_param_item.py
@@ -10,7 +10,7 @@ from jsonpath_ng import parse
 from jsonpath_ng.exceptions import JsonPathParserError
 from pydantic import BaseModel
 
-from ...errors import ProcessParameterInvalid, ProcessParameterMissing
+from ...errors import ProcessParameterInvalid, ProcessParameterRequired
 
 __all__ = [
     "get_param_item",
@@ -73,11 +73,11 @@ def get_param_item(parameter: Any, path: str) -> Any:
         matches = jsonpath_expr.find(parameter)
 
         if not matches:
-            raise ProcessParameterMissing("Path not found in parameter")
+            raise ProcessParameterRequired("Path not found in parameter")
 
         return matches[0].value
 
-    except ProcessParameterMissing as err:
+    except ProcessParameterRequired as err:
         raise err from err
     except JsonPathParserError as err:
         raise ProcessParameterInvalid("Invalid JSONPath expression") from err


### PR DESCRIPTION
## Summary

Closes #334.

- `core.py`'s parameter validation raised bare `TypeError`, which fell through the catch-all exception handler as an unhelpful `500`, even though it's always a client-input problem. It now raises `ProcessParameterInvalid`, using the process/parameter context already available at each validation site — this was the issue's own example.
- Corrects two pre-existing conformance bugs against the [openEO error-code registry](https://github.com/Open-EO/openeo-api/blob/master/errors.json), found while scoping this fix (details in [issue comment](https://github.com/sentinel-hub/titiler-openeo/issues/334#issuecomment-5202462138)):
  - `ProcessParameterMissing` (status 422) isn't a registered code. The real one is `ProcessParameterRequired`, at status 400. Renamed throughout (`errors.py`, `core.py`, `get_param_item.py`, `factory.py`'s `/validation` endpoint, `openapi.yaml`, `get_param_item.json`).
  - The catch-all's generic `500` used the code `"ServerError"`, also unregistered. The registry defines `"Internal"` for exactly this case.
- Added `tests/test_exception_handlers.py` covering the acceptance criteria from #334: invalid parameter value, missing parameter, and a genuine internal error, each asserting status code + body.

`indices.py`'s `_resolve_band_index` (bare `ValueError`) and `InvalidProcessGraph`'s registry-name/status mismatch (should be `ProcessGraphInvalid` at 400, not 422) are left for a follow-up — noted in the issue comment, out of scope here.

## Test plan
- [x] `uv run pytest -q` — 919 passed, 12 skipped
- [x] pre-commit hooks (isort, ruff, ruff-format, mypy) pass