### PR TITLE
feat(api): discover derived bands from non-raster STAC assets [1/N]

### DIFF
--- a/tests/fixtures/sar/README.md
+++ b/tests/fixtures/sar/README.md
@@ -45,3 +45,22 @@ manifests and other unrelated assets are dropped.
 
 Adding a catalogue means adding a row here and a fixture, per the ADR — this
 is what makes portability a verified claim rather than an assumption.
+
+## STAC collection fixtures (`collections/`)
+
+Trimmed real STAC collections — one per catalogue, `item_assets` only — fetched
+live 2026-08-06 against each catalogue's `/collections/sentinel-1-grd`, used by
+`tests/test_band_sources_discovery.py` (docs/adr/0002-band-sources.md §1.2).
+Unlike the item fixtures above, these describe the *collection's* declared
+asset shape (media type, roles), not one item's actual hrefs.
+
+| File | Notable difference from the others |
+| --- | --- |
+| `cdse.json` | Only catalogue with a `Product` asset (`application/zip`, roles include `data`) — the fixture that pins the `Product`-as-band fix. Manifest key is `safe_manifest` (underscore). |
+| `earth_search.json` | No `Product` asset. Manifest key is `safe-manifest` (hyphen). |
+| `planetary_computer.json` | Same shape as Earth Search. |
+
+All three publish `schema-calibration-<pol>`/`schema-noise-<pol>`/
+`schema-product-<pol>` as `application/xml` with role `metadata`, and all
+three currently use the collection id `sentinel-1-grd` — verified live, not
+assumed.

--- a/tests/fixtures/sar/collections/cdse.json
+++ b/tests/fixtures/sar/collections/cdse.json
@@ -1,0 +1,54 @@
+{
+  "type": "Collection",
+  "stac_version": "1.0.0",
+  "id": "sentinel-1-grd",
+  "description": "Sentinel-1 GRD (CDSE) -- trimmed collection fixture, item_assets only.",
+  "license": "proprietary",
+  "extent": {
+    "spatial": {"bbox": [[-180, -90, 180, 90]]},
+    "temporal": {"interval": [["2014-01-01T00:00:00Z", null]]}
+  },
+  "links": [],
+  "item_assets": {
+    "Product": {
+      "type": "application/zip",
+      "roles": ["data", "metadata", "archive"]
+    },
+    "hh": {
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": ["data"]
+    },
+    "hv": {
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": ["data"]
+    },
+    "vh": {
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": ["data"]
+    },
+    "vv": {
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": ["data"]
+    },
+    "safe_manifest": {
+      "type": "application/xml",
+      "roles": ["metadata"]
+    },
+    "thumbnail": {
+      "type": "image/png",
+      "roles": ["thumbnail"]
+    },
+    "schema-calibration-hh": {"type": "application/xml", "roles": ["metadata"]},
+    "schema-calibration-hv": {"type": "application/xml", "roles": ["metadata"]},
+    "schema-calibration-vh": {"type": "application/xml", "roles": ["metadata"]},
+    "schema-calibration-vv": {"type": "application/xml", "roles": ["metadata"]},
+    "schema-noise-hh": {"type": "application/xml", "roles": ["metadata"]},
+    "schema-noise-hv": {"type": "application/xml", "roles": ["metadata"]},
+    "schema-noise-vh": {"type": "application/xml", "roles": ["metadata"]},
+    "schema-noise-vv": {"type": "application/xml", "roles": ["metadata"]},
+    "schema-product-hh": {"type": "application/xml", "roles": ["metadata"]},
+    "schema-product-hv": {"type": "application/xml", "roles": ["metadata"]},
+    "schema-product-vh": {"type": "application/xml", "roles": ["metadata"]},
+    "schema-product-vv": {"type": "application/xml", "roles": ["metadata"]}
+  }
+}

--- a/tests/fixtures/sar/collections/earth_search.json
+++ b/tests/fixtures/sar/collections/earth_search.json
@@ -1,0 +1,50 @@
+{
+  "type": "Collection",
+  "stac_version": "1.0.0",
+  "id": "sentinel-1-grd",
+  "description": "Sentinel-1 GRD (Earth Search) -- trimmed collection fixture, item_assets only.",
+  "license": "proprietary",
+  "extent": {
+    "spatial": {"bbox": [[-180, -90, 180, 90]]},
+    "temporal": {"interval": [["2014-01-01T00:00:00Z", null]]}
+  },
+  "links": [],
+  "item_assets": {
+    "hh": {
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": ["data"]
+    },
+    "hv": {
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": ["data"]
+    },
+    "vh": {
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": ["data"]
+    },
+    "vv": {
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": ["data"]
+    },
+    "safe-manifest": {
+      "type": "application/xml",
+      "roles": ["metadata"]
+    },
+    "thumbnail": {
+      "type": "image/png",
+      "roles": ["thumbnail"]
+    },
+    "schema-calibration-hh": {"type": "application/xml", "roles": ["metadata"]},
+    "schema-calibration-hv": {"type": "application/xml", "roles": ["metadata"]},
+    "schema-calibration-vh": {"type": "application/xml", "roles": ["metadata"]},
+    "schema-calibration-vv": {"type": "application/xml", "roles": ["metadata"]},
+    "schema-noise-hh": {"type": "application/xml", "roles": ["metadata"]},
+    "schema-noise-hv": {"type": "application/xml", "roles": ["metadata"]},
+    "schema-noise-vh": {"type": "application/xml", "roles": ["metadata"]},
+    "schema-noise-vv": {"type": "application/xml", "roles": ["metadata"]},
+    "schema-product-hh": {"type": "application/xml", "roles": ["metadata"]},
+    "schema-product-hv": {"type": "application/xml", "roles": ["metadata"]},
+    "schema-product-vh": {"type": "application/xml", "roles": ["metadata"]},
+    "schema-product-vv": {"type": "application/xml", "roles": ["metadata"]}
+  }
+}

--- a/tests/fixtures/sar/collections/planetary_computer.json
+++ b/tests/fixtures/sar/collections/planetary_computer.json
@@ -1,0 +1,50 @@
+{
+  "type": "Collection",
+  "stac_version": "1.0.0",
+  "id": "sentinel-1-grd",
+  "description": "Sentinel-1 GRD (Planetary Computer) -- trimmed collection fixture, item_assets only.",
+  "license": "proprietary",
+  "extent": {
+    "spatial": {"bbox": [[-180, -90, 180, 90]]},
+    "temporal": {"interval": [["2014-01-01T00:00:00Z", null]]}
+  },
+  "links": [],
+  "item_assets": {
+    "hh": {
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": ["data"]
+    },
+    "hv": {
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": ["data"]
+    },
+    "vh": {
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": ["data"]
+    },
+    "vv": {
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": ["data"]
+    },
+    "safe-manifest": {
+      "type": "application/xml",
+      "roles": ["metadata"]
+    },
+    "thumbnail": {
+      "type": "image/png",
+      "roles": ["thumbnail"]
+    },
+    "schema-calibration-hh": {"type": "application/xml", "roles": ["metadata"]},
+    "schema-calibration-hv": {"type": "application/xml", "roles": ["metadata"]},
+    "schema-calibration-vh": {"type": "application/xml", "roles": ["metadata"]},
+    "schema-calibration-vv": {"type": "application/xml", "roles": ["metadata"]},
+    "schema-noise-hh": {"type": "application/xml", "roles": ["metadata"]},
+    "schema-noise-hv": {"type": "application/xml", "roles": ["metadata"]},
+    "schema-noise-vh": {"type": "application/xml", "roles": ["metadata"]},
+    "schema-noise-vv": {"type": "application/xml", "roles": ["metadata"]},
+    "schema-product-hh": {"type": "application/xml", "roles": ["metadata"]},
+    "schema-product-hv": {"type": "application/xml", "roles": ["metadata"]},
+    "schema-product-vh": {"type": "application/xml", "roles": ["metadata"]},
+    "schema-product-vv": {"type": "application/xml", "roles": ["metadata"]}
+  }
+}

--- a/tests/test_band_sources_discovery.py
+++ b/tests/test_band_sources_discovery.py
@@ -1,0 +1,299 @@
+"""Tests for band-source discovery (issue #348, ADR 0002, increment 1).
+
+Two layers: `registry.derive_bands` in isolation (pure, no pystac -- matching
+logic only), and `stacApiBackend.getdimensions` end to end against real,
+trimmed collection fixtures for the three catalogues this project targets.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import pystac
+import pytest
+
+from titiler.openeo.bandsources import BAND_SOURCES, BandSource, derive_bands
+from titiler.openeo.stacapi import stacApiBackend
+
+FIXTURES = Path(__file__).parent / "fixtures" / "sar" / "collections"
+
+CATALOGUES = [
+    pytest.param("cdse.json", id="CDSE"),
+    pytest.param("earth_search.json", id="EarthSearch"),
+    pytest.param("planetary_computer.json", id="PlanetaryComputer"),
+]
+
+#: The bands every catalogue's fixture must produce (ADR 0002 S2.5), for each
+#: of the four polarisations present in every fixture's item_assets.
+_EXPECTED_DERIVED_SUFFIXES = (
+    "sigma0_lut",
+    "beta0_lut",
+    "gamma0_lut",
+    "dn_lut",
+    "ellipsoid_incidence_angle",
+    "noise_lut",
+)
+_POLARISATIONS = ("hh", "hv", "vh", "vv")
+
+
+def _load_collection(fixture_name: str) -> pystac.Collection:
+    data = json.loads((FIXTURES / fixture_name).read_text())
+    return pystac.Collection.from_dict(data)
+
+
+def _backend() -> stacApiBackend:
+    return stacApiBackend(url="https://example.com")
+
+
+# --------------------------------------------------------------------------
+# registry.derive_bands -- pure matching logic, no pystac
+# --------------------------------------------------------------------------
+
+
+def test_derive_bands_formats_named_groups_into_band_names():
+    source = BandSource(
+        collection=re.compile("my-collection"),
+        media_types=frozenset({"application/xml"}),
+        roles=frozenset({"metadata"}),
+        asset=re.compile(r"noise-(?P<pol>[a-z]{2})"),
+        bands=("{pol}_noise_lut",),
+    )
+    assets = [("noise-vv", "application/xml", ["metadata"])]
+
+    assert derive_bands("my-collection", assets, [source]) == ["vv_noise_lut"]
+
+
+def test_derive_bands_requires_matching_media_type():
+    source = BandSource(
+        collection=re.compile("my-collection"),
+        media_types=frozenset({"application/xml"}),
+        roles=frozenset({"metadata"}),
+        asset=re.compile(r"noise-(?P<pol>[a-z]{2})"),
+        bands=("{pol}_noise_lut",),
+    )
+    assets = [("noise-vv", "application/json", ["metadata"])]
+
+    assert derive_bands("my-collection", assets, [source]) == []
+
+
+def test_derive_bands_requires_matching_role():
+    source = BandSource(
+        collection=re.compile("my-collection"),
+        media_types=frozenset({"application/xml"}),
+        roles=frozenset({"metadata"}),
+        asset=re.compile(r"noise-(?P<pol>[a-z]{2})"),
+        bands=("{pol}_noise_lut",),
+    )
+    assets = [("noise-vv", "application/xml", ["data"])]
+
+    assert derive_bands("my-collection", assets, [source]) == []
+
+
+def test_derive_bands_asset_key_must_fullmatch():
+    """A source's asset regex must match the whole key, not a substring --
+    otherwise `schema-noise-vv` would also match a hypothetical
+    `schema-noise-vv-extra` sibling asset."""
+    source = BandSource(
+        collection=re.compile("my-collection"),
+        media_types=frozenset({"application/xml"}),
+        roles=frozenset({"metadata"}),
+        asset=re.compile(r"noise-(?P<pol>[a-z]{2})"),
+        bands=("{pol}_noise_lut",),
+    )
+    assets = [("noise-vv-extra", "application/xml", ["metadata"])]
+
+    assert derive_bands("my-collection", assets, [source]) == []
+
+
+def test_derive_bands_requires_matching_collection():
+    source = BandSource(
+        collection=re.compile("sentinel-1-grd"),
+        media_types=frozenset({"application/xml"}),
+        roles=frozenset({"metadata"}),
+        asset=re.compile(r"noise-(?P<pol>[a-z]{2})"),
+        bands=("{pol}_noise_lut",),
+    )
+    assets = [("noise-vv", "application/xml", ["metadata"])]
+
+    assert derive_bands("sentinel-2-l2a", assets, [source]) == []
+
+
+def test_derive_bands_sorted_and_deduplicated():
+    """Two sources contributing the same name must not duplicate it, and the
+    result must be sorted regardless of match order (issue #280)."""
+    sources = [
+        BandSource(
+            collection=re.compile("c"),
+            media_types=frozenset({"application/xml"}),
+            roles=frozenset({"metadata"}),
+            asset=re.compile(r"z-(?P<pol>[a-z]{2})"),
+            bands=("{pol}_shared",),
+        ),
+        BandSource(
+            collection=re.compile("c"),
+            media_types=frozenset({"application/xml"}),
+            roles=frozenset({"metadata"}),
+            asset=re.compile(r"a-(?P<pol>[a-z]{2})"),
+            bands=("{pol}_shared", "{pol}_only_here"),
+        ),
+    ]
+    assets = [
+        ("z-vv", "application/xml", ["metadata"]),
+        ("a-vv", "application/xml", ["metadata"]),
+    ]
+
+    assert derive_bands("c", assets, sources) == ["vv_only_here", "vv_shared"]
+
+
+def test_derive_bands_empty_roles_never_matches():
+    source = BandSource(
+        collection=re.compile("c"),
+        media_types=frozenset({"application/xml"}),
+        roles=frozenset({"metadata"}),
+        asset=re.compile(r"noise-(?P<pol>[a-z]{2})"),
+        bands=("{pol}_noise_lut",),
+    )
+    assets = [("noise-vv", "application/xml", [])]
+
+    assert derive_bands("c", assets, [source]) == []
+
+
+# --------------------------------------------------------------------------
+# The shipped registry against real, trimmed catalogue fixtures
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("fixture_name", CATALOGUES)
+def test_shipped_registry_derives_expected_bands(fixture_name):
+    collection = _load_collection(fixture_name)
+    dims = _backend().getdimensions(collection)
+
+    values = set(dims["spectral"].values)
+
+    for pol in _POLARISATIONS:
+        for suffix in _EXPECTED_DERIVED_SUFFIXES:
+            assert f"{pol}_{suffix}" in values
+
+
+@pytest.mark.parametrize("fixture_name", CATALOGUES)
+def test_manifest_and_schema_product_never_match(fixture_name):
+    """schema-product-* and the SAFE manifest are application/xml + metadata,
+    same as schema-calibration-*/schema-noise-*, but must not be mistaken for
+    them -- the asset key is the only thing that discriminates these.
+
+    Every fixture's item_assets carries schema-calibration-*, schema-noise-*
+    AND schema-product-* for all four polarisations, plus a manifest asset --
+    all application/xml + metadata. If schema-product-* or the manifest also
+    matched a registry entry, the derived count below would be higher than
+    exactly 6 bands per polarisation (4 LUT vectors + incidence angle from
+    schema-calibration-*, + noise_lut from schema-noise-*).
+    """
+    collection = _load_collection(fixture_name)
+    dims = _backend().getdimensions(collection)
+    derived = set(dims["spectral"].values) - set(_POLARISATIONS)
+
+    assert len(derived) == len(_POLARISATIONS) * len(_EXPECTED_DERIVED_SUFFIXES)
+
+
+@pytest.mark.parametrize("fixture_name", CATALOGUES)
+def test_derived_band_names_never_collide_with_real_asset_keys(fixture_name):
+    """Abandon condition from the plan: derived names must never collide with
+    an actual asset key on any target catalogue.
+
+    Checked against `derive_bands` directly (not `getdimensions`'s merged
+    output, which trivially contains real keys like `hh` from the pre-existing
+    role=data behaviour and would make this check meaningless).
+    """
+    collection = _load_collection(fixture_name)
+    item_assets = collection.extra_fields["item_assets"]
+    real_asset_keys = set(item_assets.keys())
+
+    asset_facts = [
+        (key, asset.get("type"), asset.get("roles") or [])
+        for key, asset in item_assets.items()
+    ]
+    derived = set(derive_bands(collection.id, asset_facts, BAND_SOURCES))
+
+    assert not (real_asset_keys & derived)
+
+
+def test_cdse_product_asset_is_not_advertised_as_a_band():
+    """CDSE's `Product` asset is `application/zip` with role `data` among
+    others -- it is not a raster, and must not be advertised as one."""
+    collection = _load_collection("cdse.json")
+    dims = _backend().getdimensions(collection)
+
+    assert "Product" not in dims["spectral"].values
+
+
+@pytest.mark.parametrize("fixture_name", CATALOGUES)
+def test_measurement_bands_still_advertised(fixture_name):
+    """The pre-existing behaviour (real raster assets with role `data`) must
+    survive unchanged alongside the new derived bands."""
+    collection = _load_collection(fixture_name)
+    dims = _backend().getdimensions(collection)
+    values = set(dims["spectral"].values)
+
+    for pol in _POLARISATIONS:
+        assert pol in values
+
+
+@pytest.mark.parametrize("fixture_name", CATALOGUES)
+def test_spectral_dimension_values_are_sorted(fixture_name):
+    collection = _load_collection(fixture_name)
+    dims = _backend().getdimensions(collection)
+
+    assert dims["spectral"].values == sorted(dims["spectral"].values)
+
+
+def test_collection_matching_no_registry_entry_is_unaffected():
+    """A collection with real raster assets but nothing matching any
+    band-source entry must behave exactly as before this change: only its
+    role=data assets are advertised."""
+    collection = pystac.Collection.from_dict(
+        {
+            "type": "Collection",
+            "stac_version": "1.0.0",
+            "id": "sentinel-2-l2a",
+            "description": "test",
+            "license": "proprietary",
+            "extent": {
+                "spatial": {"bbox": [[-180, -90, 180, 90]]},
+                "temporal": {"interval": [["2015-01-01T00:00:00Z", None]]},
+            },
+            "links": [],
+            "item_assets": {
+                "B02": {
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                },
+                "B03": {
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                },
+                "granule_metadata": {
+                    "type": "application/xml",
+                    "roles": ["metadata"],
+                },
+            },
+        }
+    )
+
+    dims = _backend().getdimensions(collection)
+
+    assert set(dims["spectral"].values) == {"B02", "B03"}
+
+
+def test_no_band_sources_match_when_registry_is_empty(monkeypatch):
+    """derive_bands contributing nothing must not affect the pre-existing
+    role=data behaviour at all."""
+    monkeypatch.setattr("titiler.openeo.stacapi.BAND_SOURCES", [])
+    collection = _load_collection("cdse.json")
+
+    dims = _backend().getdimensions(collection)
+    values = set(dims["spectral"].values)
+
+    for pol in _POLARISATIONS:
+        assert pol in values
+    for suffix in _EXPECTED_DERIVED_SUFFIXES:
+        assert f"vv_{suffix}" not in values

--- a/titiler/openeo/bandsources/__init__.py
+++ b/titiler/openeo/bandsources/__init__.py
@@ -1,0 +1,9 @@
+"""Band sources: derive cube bands from non-raster STAC assets.
+
+See docs/adr/0002-band-sources.md.
+"""
+
+from .registry import BandSource, derive_bands
+from .sources import BAND_SOURCES
+
+__all__ = ["BandSource", "derive_bands", "BAND_SOURCES"]

--- a/titiler/openeo/bandsources/registry.py
+++ b/titiler/openeo/bandsources/registry.py
@@ -1,0 +1,95 @@
+"""Match STAC-observable facts to derived band names.
+
+See docs/adr/0002-band-sources.md. A collection's non-raster assets (annotation
+XML, geolocation grids, ...) can carry data that belongs on the cube as bands,
+but nothing in the asset itself says which asset gives which band -- that
+mapping is a property of the collection's convention (e.g. Sentinel-1 GRD's
+`schema-calibration-<pol>`/`schema-noise-<pol>` naming), so it is looked up in
+a small, in-code registry rather than inferred.
+
+Media type and role alone are not enough to tell these assets apart: on every
+target catalogue, `schema-calibration-*`, `schema-noise-*`, `schema-product-*`
+and the SAFE manifest are all `application/xml` with role `metadata` (ADR
+0002 S1.2). The asset *key* is therefore part of the match, and its regex's
+named groups double as the parameters for the derived band names -- e.g. a
+group named `pol` both discriminates `schema-noise-vv` from
+`schema-noise-vh` and lets one entry describe every polarisation at once.
+
+Increment 1 (issue #348) covers discovery only: this module says which band
+names a collection's assets make available, for `/collections`
+`cube:dimensions`. Actually producing them at read time is a later increment.
+"""
+
+import re
+from dataclasses import dataclass
+from typing import FrozenSet, Iterable, List, Optional, Sequence, Set, Tuple
+
+__all__ = ["BandSource", "derive_bands"]
+
+
+@dataclass(frozen=True)
+class BandSource:
+    """One collection-level rule: which assets give rise to which band names.
+
+    ``collection`` and ``asset`` are pre-compiled patterns so a registry with
+    many entries does not recompile them per lookup. ``collection`` is matched
+    with :meth:`re.Pattern.search` (a substring match, since deployments may
+    suffix or version a collection id); ``asset`` is matched with
+    :meth:`re.Pattern.fullmatch` against the whole asset key, since asset keys
+    are exact tokens, not free text.
+
+    ``bands`` are name templates formatted with the ``asset`` match's named
+    groups (``str.format(**match.groupdict())``), so ``"{pol}_noise_lut"``
+    resolves to ``"vv_noise_lut"`` when ``asset`` matched with ``pol="vv"``.
+    """
+
+    collection: "re.Pattern[str]"
+    media_types: FrozenSet[str]
+    roles: FrozenSet[str]
+    asset: "re.Pattern[str]"
+    bands: Tuple[str, ...]
+
+
+def derive_bands(
+    collection_id: str,
+    assets: Iterable[Tuple[str, Optional[str], Sequence[str]]],
+    sources: Sequence[BandSource],
+) -> List[str]:
+    """Return the sorted, de-duplicated derived band names for a collection.
+
+    Args:
+        collection_id: The STAC collection id.
+        assets: ``(asset_key, media_type, roles)`` triples -- one per entry in
+            the collection's ``item_assets``. ``media_type`` and ``roles``
+            mirror the STAC fields of the same name (``roles`` may be empty).
+        sources: The registry entries to match against, e.g.
+            :data:`titiler.openeo.bandsources.sources.BAND_SOURCES`. Accepting
+            this as a parameter (rather than importing the shipped registry
+            directly) keeps this function trivially testable against
+            synthetic entries.
+
+    Returns:
+        Sorted band names with no duplicates. Sorted rather than left as a set
+        so callers get a deterministic ``cube:dimensions`` order (issue #280).
+    """
+    assets = list(assets)
+    names: Set[str] = set()
+
+    for source in sources:
+        if not source.collection.search(collection_id):
+            continue
+
+        for asset_key, media_type, roles in assets:
+            if media_type not in source.media_types:
+                continue
+            if not source.roles & set(roles or ()):
+                continue
+
+            match = source.asset.fullmatch(asset_key)
+            if not match:
+                continue
+
+            groups = match.groupdict()
+            names.update(band.format(**groups) for band in source.bands)
+
+    return sorted(names)

--- a/titiler/openeo/bandsources/sources.py
+++ b/titiler/openeo/bandsources/sources.py
@@ -1,0 +1,54 @@
+"""Shipped band-source entries.
+
+Sentinel-1 GRD only, for now. Verified live against CDSE, Earth Search and
+Planetary Computer (2026-08-06, docs/adr/0002-band-sources.md S1.2): all three
+publish `schema-calibration-<pol>` and `schema-noise-<pol>` as
+`application/xml` with role `metadata`, and all three currently use the
+collection id `sentinel-1-grd`.
+
+The band names mirror openEO's calibration vocabulary rather than ESA's XML
+tag names (`sigmaNought`, `betaNought`, `gamma`, `dn`), and are polarisation-
+prefixed throughout -- a flat `sigma0_lut` would collide the moment an item
+has more than one polarisation, which every target catalogue's GRD items do.
+"""
+
+import re
+
+from .registry import BandSource
+
+__all__ = ["BAND_SOURCES"]
+
+#: All three target catalogues use this id today; `search` (not `fullmatch`)
+#: so a future deployment-specific suffix (e.g. a regional variant) still
+#: matches.
+_S1_GRD_COLLECTION = re.compile(r"sentinel-1-grd")
+
+_XML = frozenset({"application/xml"})
+_METADATA = frozenset({"metadata"})
+
+BAND_SOURCES = [
+    # One calibration annotation yields four LUT vectors plus the incidence
+    # angle recovered from two of them (annotation.CalibrationLUT) -- ADR
+    # 0002 S2.5.
+    BandSource(
+        collection=_S1_GRD_COLLECTION,
+        media_types=_XML,
+        roles=_METADATA,
+        asset=re.compile(r"schema-calibration-(?P<pol>[a-z]{2})"),
+        bands=(
+            "{pol}_sigma0_lut",
+            "{pol}_beta0_lut",
+            "{pol}_gamma0_lut",
+            "{pol}_dn_lut",
+            "{pol}_ellipsoid_incidence_angle",
+        ),
+    ),
+    # One noise annotation yields the thermal-noise LUT (annotation.NoiseLUT).
+    BandSource(
+        collection=_S1_GRD_COLLECTION,
+        media_types=_XML,
+        roles=_METADATA,
+        asset=re.compile(r"schema-noise-(?P<pol>[a-z]{2})"),
+        bands=("{pol}_noise_lut",),
+    ),
+]

--- a/titiler/openeo/stacapi.py
+++ b/titiler/openeo/stacapi.py
@@ -1,7 +1,7 @@
 """Stac API backend."""
 
 from threading import Lock
-from typing import Any, Dict, List, Optional, Sequence, Union
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union
 
 import pyproj
 import pystac
@@ -27,6 +27,7 @@ from rio_tiler.mosaic.reader import mosaic_reader
 from rio_tiler.tasks import create_tasks
 from urllib3 import Retry
 
+from .bandsources import BAND_SOURCES, derive_bands
 from .errors import (
     ItemsLimitExceeded,
     NoDataAvailable,
@@ -50,6 +51,13 @@ collections_cache: TTLCache = TTLCache(
 collection_cache: TTLCache = TTLCache(
     maxsize=cache_config.maxsize, ttl=cache_config.ttl
 )
+
+#: Media types that indicate a packaged archive rather than a single raster
+#: asset. CDSE's Sentinel-1 GRD ``Product`` asset has role ``data`` and media
+#: type ``application/zip``, which without this exclusion gets advertised as
+#: a spectral band even though it is not a raster (docs/adr/0002-band-sources.md
+#: S1.2, consequence 4).
+_ARCHIVE_MEDIA_TYPES = frozenset({"application/zip"})
 
 
 @define
@@ -184,15 +192,27 @@ class stacApiBackend:
         # bands
         if "item_assets" in collection.extra_fields:
             ia.ItemAssetsExtension.add_to(collection)
-            bands_name = set()
+
+            band_names: Set[str] = set()
+            asset_facts: List[Tuple[str, Optional[str], Sequence[str]]] = []
             for key, asset in collection.ext.item_assets.items():
-                if "data" in asset.properties.get("roles", []):
-                    bands_name.add(key)
-            if len(bands_name) > 0:
+                roles = asset.roles or []
+                asset_facts.append((key, asset.media_type, roles))
+                if "data" in roles and asset.media_type not in _ARCHIVE_MEDIA_TYPES:
+                    band_names.add(key)
+
+            # Bands derived from non-raster assets (e.g. Sentinel-1 GRD's
+            # calibration/noise annotation XML) -- see
+            # docs/adr/0002-band-sources.md.
+            band_names.update(derive_bands(collection.id, asset_facts, BAND_SOURCES))
+
+            if band_names:
                 dims["spectral"] = dc.Dimension.from_dict(
                     {
                         "type": "bands",
-                        "values": bands_name,
+                        # Sorted rather than left as a set for a deterministic
+                        # client-visible order (issue #280).
+                        "values": sorted(band_names),
                     }
                 )
 


### PR DESCRIPTION
Increment 1 of #348 (stacked on #353's ADR — **base branch is `feat/band-sources`, not `main`**).

Discovery only: `/collections` `cube:dimensions` advertises derived bands; reading one still fails at read time until increment 2 builds its reader.

## What this adds

- `titiler/openeo/bandsources/registry.py` — `BandSource` (a match rule: collection-id regex, asset media types, asset roles, asset-key regex with named groups, band-name templates) and `derive_bands()`, pure and pystac-free.
- `titiler/openeo/bandsources/sources.py` — the shipped Sentinel-1 GRD entries: `schema-calibration-<pol>` → 4 LUT vectors + incidence angle, `schema-noise-<pol>` → noise LUT.
- `stacApiBackend.getdimensions` now unions `derive_bands(...)` into `cube:dimensions.spectral.values`, alongside the existing real-asset (`role=data`) bands.

## Two pre-existing fixes shipped alongside

Found while mapping the discovery path, both small and directly related:

- **CDSE's `Product` asset** (`application/zip`, roles include `data`) was advertised as a spectral band. Excluding known archive media types fixes this confirmed case — I'm not claiming a general "is this a raster" classifier, just excluding the one broken case found.
- **`cube:dimensions.spectral.values` was an unordered `set`** (#280) — now a sorted list.

## Why in-code, not configured

Registry entries are shipped in code, not JSON/env config. #281's plugin mechanism was sent back to draft specifically because it bound bands to collections by hand-written configuration — reproducibility means keying off what the STAC API itself publishes, not a deployment's config file. See ADR 0002 (#353) for the full reasoning.

Verified live against CDSE / Earth Search / Planetary Computer's `sentinel-1-grd` collections (2026-08-06): all three publish `schema-calibration-<pol>` and `schema-noise-<pol>` as `application/xml` + role `metadata` — but so do `schema-product-<pol>` and the SAFE manifest, so the asset **key** (not media type/role alone) has to discriminate, and its named groups double as the band-name parameters.

## Test fixtures

New `tests/fixtures/sar/collections/{cdse,earth_search,planetary_computer}.json` — trimmed real `item_assets` per catalogue, mirroring the existing `items/` fixture convention. Table-driven tests in `tests/test_band_sources_discovery.py` assert:

- the full expected band set per catalogue (28 = 4 raster + 4 pols × 6 derived)
- `schema-product-*` and the manifest never match (exact count check, not string-guessing)
- the `Product` zip is gone
- **no derived name collides with a real asset key** — the plan's abandon condition, checked against `derive_bands` directly
- output is sorted
- a collection matching no registry entry (e.g. Sentinel-2) is unaffected — only its `role=data` assets are advertised, exactly as before this change

## Deliberately descoped

ADR 0002 §2.2 describes also augmenting collections that already declare their own `cube:dimensions` (`add_data_cubes_if_missing` currently skips those entirely). No target catalogue needs this today — verified live, all three currently declare no `cube:dimensions` at all — so it's left undone rather than built speculatively. Flagging so it isn't mistaken for an oversight.

## Test plan

- [x] `uv run pytest tests/test_band_sources_discovery.py -q` — 25 passed
- [x] `uv run pytest -q` — 957 passed, 12 skipped, no regressions
- [x] `uv run pre-commit run --all-files` — isort, ruff, ruff-format, mypy, markdownlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)