### PR TITLE
docs(api): settle the reader-requirement channel unknowns (increment 4)

### DIFF
--- a/docs/adr/0002-band-sources.md
+++ b/docs/adr/0002-band-sources.md
@@ -329,21 +329,58 @@ signature, spec or output band names; fixing item-provenance loss in the 30+
 
 ### 3.1 Open risks
 
-- **Injected bands are visible to a `load_collection` node's other consumers.** If
-  one node feeds both `sar_backscatter` and, say, `reduce_dimension`, the extra bands
-  change the second consumer's result. `results_cache._tag_single_consumer`
-  (`results_cache.py:82`) already computes single-consumer status from graph
-  topology and is reusable. Increment 4 decides whether to restrict injection to the
-  single-consumer case initially, or to strip injected bands for non-requiring
-  consumers.
-- **§7.10(b)'s channel does not obviously support per-node requirements.** It
-  rebinds **one shared** `load_collection` callable, yet asserts that multiple
-  `load_collection` nodes "are resolved independently". Those do not reconcile as
-  written. Candidate resolutions: dispatch on the incoming argument signature
-  (`resolved_kwargs` carries `id` and `bands`), or take a conservative union across
-  nodes. Settled by the increment-4 spike.
-- **Does registry rebinding survive `openeo_pg_parser_networkx`'s `Process`
-  wrapping?** §7.10(b) flags this as worth a spike; increment 4 does it.
+- **Resolved by increment 4 — registry rebinding survives `Process` wrapping, but
+  only if the copy is isolated deeper than the ADR text implies.** `to_callable`
+  looks up `process_registry[process_id].implementation` — `Process.__setitem__`
+  re-applies `wrap_funcs` to whatever implementation it's given, so a rebound
+  callable is wrapped exactly like any other registration
+  (`test_isolated_copy_rebinds_without_leaking`). But `copy.copy(registry)` — the
+  literal reading of "a shallow copy" — copies the `ProcessRegistry` object's
+  attributes by reference, so `registry.store` (a `dict[namespace, dict[process_id,
+  Process]]`) is **shared, not copied**. Rebinding `"load_collection"` on that
+  "copy" mutates the dict the real, application-lifetime registry also reads from
+  — every subsequent request, not just a concurrent one, would see the rebind
+  (`test_naive_copy_copy_leaks_rebind_into_shared_registry`, confirmed against the
+  real `openeo_pg_parser_networkx.process_registry.ProcessRegistry`). The correct
+  per-request recipe copies `store` one namespace-dict level deeper —
+  `{ns: dict(procs) for ns, procs in registry.store.items()}` — leaving untouched
+  `Process` entries shared (they're never mutated in place) while isolating the
+  one being rebound. Increment 5 must use this recipe, not `copy.copy` alone.
+- **Resolved by increment 4 — §7.10(b)'s channel cannot resolve per graph-node
+  identity, only per call-time signature.** `_map_node_to_callable`
+  (`graph.py:339-382`) bakes each node's own `resolved_kwargs` into that node's
+  `functools.partial` at graph-*construction* time, before rebinding is even
+  relevant to it; the rebound `load_collection` implementation, once installed,
+  receives only the kwargs a node happens to pass (`id`, `bands`, …), never a node
+  identifier. Two `load_collection` nodes with identical `id`/`bands` are
+  therefore provably indistinguishable at call time — proved directly against the
+  real parser, not inferred (`test_identical_signature_nodes_are_indistinguishable_at_call_time`).
+  "Dispatch on the incoming argument signature" is thus not one option among
+  several — it is the *only* information the channel exposes. The other candidate
+  named in the ADR, an unconditional single requirement applied to every call, is
+  actively wrong, not just imprecise: `test_naive_unconditional_dispatch_contaminates_unrelated_collection`
+  shows it injects a SAR-only band into an unrelated Sentinel-2 load that happens
+  to share the callable. The decision: increment 5's planner keys resolved
+  requirements by `(id, tuple(bands))` and unions across every `load_collection`
+  node sharing that key (`test_signature_keyed_dispatch_serves_both_nodes`). This
+  is a conservative union, not per-node precision — which sharpens the risk below
+  from a possible edge case into the channel's structural default.
+- **Sharpened by increment 4 — injected-band leakage to a signature-sharing
+  sibling is not an edge case, it is what the chosen channel does by
+  construction.** Two nodes with the same `id`/`bands` cannot be told apart (see
+  above), so if one needs an injected band and the other doesn't, the union
+  reaches both (`test_signature_keyed_dispatch_unions_same_signature_nodes`).
+  `results_cache._tag_single_consumer` (`results_cache.py:82`) already computes
+  single-consumer status from graph topology and is reusable. Increment 5 still
+  decides whether to restrict injection to the single-consumer case, or strip
+  injected bands post-mosaic for a signature-sharing consumer that didn't need
+  them — increment 4 only establishes that some such mitigation is now required,
+  not optional polish.
+
+  Proof for all three points: `tests/test_reader_requirement_channel_spike.py`.
+  Both fixes (the copy recipe and the signature-keyed dispatch) were confirmed
+  load-bearing by reverting each in turn and observing the corresponding test
+  fail before restoring the fix.
 - **Inverse-map duplication across readers — resolved in increment 3.** Two
   derived bands of the same polarisation are two assets, so each reader would
   build its own TPS map for the same GCPs and grid unless something shares it.
@@ -385,7 +422,7 @@ Delivered as **stacked pull requests**, one per increment, based on this branch.
 | 1 | **Discovery only.** Registry module + `getdimensions` pass. Bands advertised; requesting one still fails at read time. Ships the `Product` fix and #280. | Abandon if derived names collide with real asset keys on any target catalogue. |
 | 2 | **One reader end to end.** `NoiseBandReader` — the narrowest path exercising pseudo-asset resolution, `reader_options` injection, sibling GCP lookup, inverse map, grid alignment, mask inheritance and mosaicking. | **Gate:** per-tile wall time at 256² and 1024², decomposed (independent DN + `NoiseBandReader` reads) vs. fused (`sar_backscatter`'s existing DN-read-then-geocode-then-evaluate body) — not vs. DN alone, since both decomposed and fused pay the same TPS inverse-map cost once; that comparison would measure the cost of wanting a LUT at all, not the cost of decomposition. **Measured:** 1.00× at both 256² and 1024² on the real 440-GCP polar fixture (0.20 s / 3.03 s respectively for both shapes) — decomposition adds no measurable overhead. Abandon if mask inheritance cannot hold or the mosaic case does not work — both invalidate §2.3. |
 | 3 | **The remaining bands.** `CalibrationBandReader` for the four LUT vectors plus the incidence angle — one class, all five, dispatching on a `quantity` string (`BandSource.bands` became `(name_template, quantity)` pairs; `ResolvedBand` carries `quantity` through to the reader's constructor). Not, as originally planned here, "the existing `bands`/`indexes` selection in `_get_options`" — that mechanism resolves a real STAC asset's own declared `eo:bands`/`bands` metadata, which a calibration XML asset has none of; `quantity` is this increment's own, simpler answer to the same "one asset, several bands" question. Also added `CalibrationLUT.dn()` (`sar/annotation.py`, mirroring the other three accessors — `dn` was already parsed, just not exposed) and the `_inverse_map_cache`/`_inverse_map_lock` memo the increment-2 risk log anticipated (see above). | **Gate:** a concurrency bug, not a timing one — see the risk log above. Fixed with a lock; `tests/test_calibration_band_reader.py`'s call-count tests are the regression guard, run in this project's default single-worker pytest config, not proof against every possible scheduling. |
-| 4 | **Spike the requirement channel.** Settle both §3.1 unknowns. Deliverable is a decision plus a failing-then-passing test, not production code. | — |
+| 4 | **Spike the requirement channel.** Settle both §3.1 unknowns. Deliverable is a decision plus a failing-then-passing test, not production code. | **Decided:** rebinding survives `Process` wrapping, but only with a copy recipe that isolates `ProcessRegistry.store` per namespace — `copy.copy(registry)` alone aliases it and permanently corrupts the shared, app-lifetime registry (confirmed against the real dependency, then fixed). The channel exposes no per-node identity, only each call's own `resolved_kwargs`, so increment 5 must key resolved requirements by `(id, tuple(bands))` and union across nodes sharing a signature — not attempt per-node precision, and not apply one requirement unconditionally (shown to contaminate an unrelated collection). This also promotes §3.1's "injected bands visible to other consumers" risk from a possible edge case to the channel's structural default. See `tests/test_reader_requirement_channel_spike.py`. |
 | 5 | **Build the planner.** Requirement registry, DAG pass, per-request registry, resolved-requirement logging. | A graph with no requiring process must produce a byte-identical read. |
 | 6 | **Convergence.** `sar_backscatter` consumes injected bands; `calibrate` reduces to arithmetic; delete `_resolve_stack_assets`, `_resolve_polarisation_assets`, `_find_annotation_asset` and the `sar.py:212` rejection (~150 lines). | Abandon if increment 2's gate showed the decomposed read is materially more expensive. Then stop at 3, keep `sar_backscatter` fused, and record why here. |
 | 7 | **Document.** `docs/src/sar-backscatter.md` band table; update ADR 0001 §7.10(b)'s "deferred, no first client" caveat and §7.6's framing of `AssetFetcher`. | — |

--- a/tests/test_reader_requirement_channel_spike.py
+++ b/tests/test_reader_requirement_channel_spike.py
@@ -1,0 +1,337 @@
+"""Increment 4 spike (issue #348, ADR 0002 S3.1 / S4): settles the two open
+questions about the reader-requirement channel ADR 0001 S7.10(b) chose --
+a per-request process registry with `load_collection` rebound -- before the
+planner (increments 5-6) is built on top of it.
+
+1. Does rebinding `load_collection` in a shallow-copied process registry
+   survive `openeo_pg_parser_networkx`'s `Process` wrapping? Yes, but only if
+   the copy actually isolates the registry's storage. `copy.copy(registry)`
+   -- the literal reading of "a shallow copy" -- copies the `ProcessRegistry`
+   object's attributes by reference, so `registry.store` (and each per-namespace
+   dict inside it) is *shared*, not copied. Rebinding "load_collection" on the
+   copy mutates the dict the original, application-lifetime-scoped registry
+   also reads from: every later request, not just concurrent ones, would see
+   the rebind. See `test_naive_copy_copy_leaks_rebind_into_shared_registry`
+   (documents the trap) and `test_isolated_copy_rebinds_without_leaking` (the
+   corrected recipe: copy `store` one level deeper).
+
+2. How does one rebound callable serve several `load_collection` nodes with
+   different requirements, when S7.10(b) asserts nodes "are resolved
+   independently"? Not by node identity -- there isn't one to dispatch on.
+   `OpenEOProcessGraph._map_node_to_callable` looks up
+   `process_registry[process_id].implementation` once per node at
+   graph-construction time and bakes that node's own `resolved_kwargs` into a
+   `functools.partial`; the callable itself receives only those baked kwargs
+   at call time, nothing that identifies which graph node it is being called
+   for. `test_identical_signature_nodes_are_indistinguishable_at_call_time`
+   proves two nodes with the same `id`/`bands` are indistinguishable from
+   inside the callable. The sound channel is therefore a signature-keyed
+   union -- key resolved requirements by `(id, tuple(bands))` and union across
+   every node sharing a key -- not per-node injection and not an unconditional
+   "apply the one resolved requirement to every call", which
+   `test_naive_unconditional_dispatch_contaminates_unrelated_collection` shows
+   corrupts an unrelated `load_collection` node that happens to share the
+   callable. `test_signature_keyed_dispatch_serves_both_nodes` is the
+   corrected channel.
+
+Decision recorded in docs/adr/0002-band-sources.md S3.1 and the increment 4
+row of S4. This file is the spike's proof, not the increment 5 planner: the
+helpers below are deliberately local and minimal, standing in for the real
+requirement registry / DAG pass increment 5 builds.
+"""
+
+import copy
+from dataclasses import dataclass
+from typing import Any, Dict, FrozenSet, Tuple
+
+import networkx as nx
+from openeo_pg_parser_networkx import OpenEOProcessGraph
+from openeo_pg_parser_networkx.process_registry import Process, ProcessRegistry
+
+# ---------------------------------------------------------------------------
+# Question 1: does the copy actually isolate the registry?
+# ---------------------------------------------------------------------------
+
+
+def test_naive_copy_copy_leaks_rebind_into_shared_registry():
+    """`copy.copy(registry)` shares `registry.store` by reference, so rebinding
+    the "copy" rebinds the original too -- the literal ADR wording is a trap."""
+    registry = ProcessRegistry()
+    registry["load_collection"] = Process(
+        spec={}, implementation=lambda **kw: "original"
+    )
+
+    per_request = copy.copy(registry)
+    per_request["load_collection"] = Process(
+        spec={}, implementation=lambda **kw: "rebound"
+    )
+
+    # The bug: the shared, application-lifetime registry is now permanently
+    # rebound too, for every request that follows -- not just concurrent ones.
+    assert registry["load_collection"].implementation() == "rebound"
+
+
+def _isolated_copy(registry: ProcessRegistry) -> ProcessRegistry:
+    """The corrected per-request recipe: copy the registry object *and* its
+    per-namespace dicts, so `__setitem__` on the copy can never mutate the
+    original. Individual `Process` objects for untouched process ids are still
+    shared -- fine, since nothing mutates a `Process` in place."""
+    isolated = copy.copy(registry)
+    isolated.store = {ns: dict(procs) for ns, procs in registry.store.items()}
+    return isolated
+
+
+def test_isolated_copy_rebinds_without_leaking():
+    """The corrected recipe rebinds `load_collection` for the request only,
+    leaving the shared registry -- and its other entries -- untouched. This is
+    the answer to "does rebinding survive Process wrapping": yes, `__setitem__`
+    re-applies `wrap_funcs` to the new implementation exactly as it does for
+    any other registration, once the copy is isolated enough for the rebind
+    not to be a global mutation."""
+    calls = []
+
+    def wrap(fn):
+        def wrapped(**kw):
+            calls.append("wrapped")
+            return fn(**kw)
+
+        return wrapped
+
+    registry = ProcessRegistry(wrap_funcs=[wrap])
+    registry["load_collection"] = Process(
+        spec={}, implementation=lambda **kw: "original"
+    )
+    registry["save_result"] = Process(spec={}, implementation=lambda **kw: "unrelated")
+
+    per_request = _isolated_copy(registry)
+    per_request["load_collection"] = Process(
+        spec={}, implementation=lambda **kw: "rebound"
+    )
+
+    assert per_request["load_collection"].implementation() == "rebound"
+    assert calls == ["wrapped"]  # the rebind went through the same wrap_funcs
+    assert registry["load_collection"].implementation() == "original"  # not leaked
+    assert per_request["save_result"].implementation() == "unrelated"  # untouched
+
+
+# ---------------------------------------------------------------------------
+# Question 2: can the callable tell nodes apart?
+# ---------------------------------------------------------------------------
+
+
+def _two_load_collection_graph(same_collection: bool) -> OpenEOProcessGraph:
+    """lc_a feeds sar_backscatter (needs the sigma0 LUT band); lc_b feeds a
+    plain reduce_dimension (needs nothing extra). `same_collection` controls
+    whether both nodes load the same id/bands (the ambiguous case, S3.1's
+    first open risk) or different collections (the case a *global* dispatch
+    gets wrong)."""
+    lc_b_id = "sentinel-1-grd" if same_collection else "sentinel-2-l2a"
+    lc_b_bands = ["vv", "vh"] if same_collection else ["B04", "B03", "B02"]
+    pg = {
+        "lc_a": {
+            "process_id": "load_collection",
+            "arguments": {"id": "sentinel-1-grd", "bands": ["vv", "vh"]},
+        },
+        "lc_b": {
+            "process_id": "load_collection",
+            "arguments": {"id": lc_b_id, "bands": lc_b_bands},
+        },
+        "sar": {
+            "process_id": "sar_backscatter",
+            "arguments": {
+                "data": {"from_node": "lc_a"},
+                "coefficient": "sigma0-ellipsoid",
+            },
+        },
+        "reduced": {
+            "process_id": "reduce_dimension",
+            "arguments": {"data": {"from_node": "lc_b"}, "dimension": "t"},
+        },
+        "merged": {
+            "process_id": "merge_cubes",
+            "arguments": {
+                "cube1": {"from_node": "sar"},
+                "cube2": {"from_node": "reduced"},
+            },
+        },
+        "combined": {
+            "process_id": "save_result",
+            "arguments": {"data": {"from_node": "merged"}, "format": "GTiff"},
+            "result": True,
+        },
+    }
+    return OpenEOProcessGraph(pg_data=pg)
+
+
+def _base_registry() -> ProcessRegistry:
+    registry = ProcessRegistry()
+    registry["sar_backscatter"] = Process(
+        spec={}, implementation=lambda data, **kw: f"sar({data})"
+    )
+    registry["reduce_dimension"] = Process(
+        spec={}, implementation=lambda data, **kw: f"reduced({data})"
+    )
+    registry["merge_cubes"] = Process(
+        spec={}, implementation=lambda cube1, cube2, **kw: f"merged({cube1},{cube2})"
+    )
+    registry["save_result"] = Process(
+        spec={}, implementation=lambda data, **kw: f"saved({data})"
+    )
+    return registry
+
+
+def test_identical_signature_nodes_are_indistinguishable_at_call_time():
+    """Node identity never reaches the rebound callable. Two load_collection
+    nodes with the same id/bands produce literally identical call-time kwargs,
+    even though one feeds sar_backscatter and the other doesn't -- confirming
+    S7.10(b)'s "resolved independently" cannot mean "distinguished at call
+    time"; independence can only happen earlier, during graph planning."""
+    graph = _two_load_collection_graph(same_collection=True)
+    calls = []
+
+    def load_collection_impl(id, bands=None, named_parameters=None, **kwargs):
+        calls.append({"id": id, "bands": tuple(bands or ())})
+        return f"cube({id},{bands})"
+
+    registry = _base_registry()
+    registry["load_collection"] = Process(spec={}, implementation=load_collection_impl)
+
+    graph.to_callable(process_registry=registry)()
+
+    assert len(calls) == 2
+    assert calls[0] == calls[1]  # nothing at call time tells them apart
+
+
+@dataclass(frozen=True)
+class _Requirement:
+    """Stand-in for increment 5's real value object -- just enough to prove
+    the dispatch shape works."""
+
+    extra_bands: FrozenSet[str] = frozenset()
+
+    def __or__(self, other: "_Requirement") -> "_Requirement":
+        return _Requirement(extra_bands=self.extra_bands | other.extra_bands)
+
+
+_NONE = _Requirement()
+
+
+def _resolve_requirements_by_signature(
+    graph: OpenEOProcessGraph,
+) -> Dict[Tuple[Any, Tuple[str, ...]], _Requirement]:
+    """The pre-execution pass from ADR 0002 S2.6.2, keyed by each
+    load_collection node's own resolved_kwargs signature -- the only key the
+    rebound callable can observe at call time (see the test above) -- instead
+    of by node identity. Nodes sharing a signature have their requirements
+    unioned, per S3.1's "conservative union across nodes" candidate."""
+    requirements: Dict[Tuple[Any, Tuple[str, ...]], _Requirement] = {}
+    for node in graph.G.nodes:
+        data = graph.G.nodes[node]
+        if data["process_id"] != "load_collection":
+            continue
+        ancestor_processes = {
+            graph.G.nodes[a]["process_id"] for a in nx.ancestors(graph.G, node)
+        }
+        req = (
+            _Requirement(extra_bands=frozenset({"vv_sigma0_lut"}))
+            if "sar_backscatter" in ancestor_processes
+            else _NONE
+        )
+        kwargs = data["resolved_kwargs"]
+        key = (kwargs["id"], tuple(kwargs.get("bands") or ()))
+        requirements[key] = requirements.get(key, _NONE) | req
+    return requirements
+
+
+def _rebind_with_unconditional_requirement(
+    registry: ProcessRegistry, requirement: _Requirement
+) -> ProcessRegistry:
+    """The naive reading of "one rebound callable": apply the single resolved
+    requirement to every load_collection call, regardless of which collection
+    it is. This is what `test_naive_unconditional_dispatch_...` shows is
+    wrong."""
+
+    def rebound(id, bands=None, named_parameters=None, **kwargs):
+        merged = list(bands or []) + [
+            b for b in sorted(requirement.extra_bands) if b not in (bands or [])
+        ]
+        return f"cube({id},{merged})"
+
+    isolated = _isolated_copy(registry)
+    isolated["load_collection"] = Process(spec={}, implementation=rebound)
+    return isolated
+
+
+def _rebind_with_signature_dispatch(
+    registry: ProcessRegistry,
+    requirements: Dict[Tuple[Any, Tuple[str, ...]], _Requirement],
+) -> ProcessRegistry:
+    """The corrected channel: the one rebound callable looks up the requirement
+    for *its own call-time signature* before deciding what to inject."""
+
+    def rebound(id, bands=None, named_parameters=None, **kwargs):
+        key = (id, tuple(bands or ()))
+        requirement = requirements.get(key, _NONE)
+        merged = list(bands or []) + [
+            b for b in sorted(requirement.extra_bands) if b not in (bands or [])
+        ]
+        return f"cube({id},{merged})"
+
+    isolated = _isolated_copy(registry)
+    isolated["load_collection"] = Process(spec={}, implementation=rebound)
+    return isolated
+
+
+def test_naive_unconditional_dispatch_contaminates_unrelated_collection():
+    """lc_a (sentinel-1-grd) needs the LUT band; lc_b (sentinel-2-l2a) is an
+    unrelated collection that must not receive it. Applying the one resolved
+    requirement to every load_collection call -- the naive reading of "one
+    shared rebound callable" -- injects the SAR LUT band into the Sentinel-2
+    load too. This is the failing case the signature-keyed channel exists to
+    avoid."""
+    graph = _two_load_collection_graph(same_collection=False)
+    requirements = _resolve_requirements_by_signature(graph)
+    single_requirement = next(iter(requirements.values()))
+
+    registry = _rebind_with_unconditional_requirement(
+        _base_registry(), single_requirement
+    )
+    result = graph.to_callable(process_registry=registry)()
+
+    assert "cube(sentinel-1-grd,['vv', 'vh', 'vv_sigma0_lut'])" in result
+    # The bug: an optical collection now carries a SAR-only band name.
+    assert "vv_sigma0_lut" in result.split("cube(sentinel-2-l2a,")[1]
+
+
+def test_signature_keyed_dispatch_serves_both_nodes():
+    """The corrected channel: one rebound `load_collection` callable, shared by
+    both nodes, injects the LUT band only for the signature that needs it.
+    sentinel-1-grd gets `vv_sigma0_lut`; sentinel-2-l2a is untouched."""
+    graph = _two_load_collection_graph(same_collection=False)
+    requirements = _resolve_requirements_by_signature(graph)
+
+    registry = _rebind_with_signature_dispatch(_base_registry(), requirements)
+    result = graph.to_callable(process_registry=registry)()
+
+    assert "cube(sentinel-1-grd,['vv', 'vh', 'vv_sigma0_lut'])" in result
+    assert "cube(sentinel-2-l2a,['B04', 'B03', 'B02'])" in result
+    assert "vv_sigma0_lut" not in result.split("cube(sentinel-2-l2a,")[1]
+
+
+def test_signature_keyed_dispatch_unions_same_signature_nodes():
+    """S3.1's residual, explicitly deferred risk: when two nodes *do* share a
+    signature (test_identical_signature_nodes_are_indistinguishable_at_call_time),
+    the signature-keyed channel cannot tell them apart either, so the union
+    reaches both -- reduce_dimension's input picks up a band it never asked
+    for. Increment 5 decides whether to restrict injection to single-consumer
+    load_collection nodes or strip injected bands post-mosaic for non-requiring
+    consumers (ADR 0002 S3.1); this test just pins down that the contamination
+    is real and bounded to same-signature siblings, not global."""
+    graph = _two_load_collection_graph(same_collection=True)
+    requirements = _resolve_requirements_by_signature(graph)
+
+    registry = _rebind_with_signature_dispatch(_base_registry(), requirements)
+    result = graph.to_callable(process_registry=registry)()
+
+    # Both branches read sentinel-1-grd,['vv','vh'] -- the union reaches both.
+    assert result.count("vv_sigma0_lut") == 2


### PR DESCRIPTION
## Summary

Increment 4 of issue #348 / ADR 0002. Stacked on #357. Spikes both unknowns ADR 0002 §3.1 flags for the reader-requirement channel (ADR 0001 §7.10(b): a per-request process registry with `load_collection` rebound) before the planner (increments 5-6) gets built on top of it. No production code ships here — deliverable is a decision plus a failing-then-passing test, per the ADR's increment-4 scope.

**Q1: Does registry rebinding survive `openeo_pg_parser_networkx`'s `Process` wrapping?**
Yes — `Process.__setitem__` re-applies `wrap_funcs` to any implementation it's given. But `copy.copy(registry)`, the literal reading of "a shallow copy" in the ADR text, shares `ProcessRegistry.store` by reference. Rebinding `"load_collection"` on that "copy" mutates the real, application-lifetime registry too — permanently, for every later request, not just concurrent ones. Confirmed against the real dependency, then fixed: the correct recipe copies `store` one namespace-dict level deeper.

**Q2: How does one rebound callable serve several `load_collection` nodes with different requirements?**
It can't by node identity — there isn't one at call time. `to_callable()` bakes each node's own `resolved_kwargs` into a `functools.partial` at graph-construction time; the rebound callable only ever sees a node's own `id`/`bands`. Two nodes with identical `id`/`bands` are proven indistinguishable. So "dispatch on the incoming argument signature" isn't one option among several, it's the only one the channel exposes — and applying one resolved requirement unconditionally (the other candidate named in the ADR) is shown to actively contaminate an unrelated collection sharing the callable. Decision: key requirements by `(id, tuple(bands))`, union across nodes sharing a signature.

That union also sharpens the existing "injected bands visible to other consumers" risk from a possible edge case to the channel's structural default — increment 5 still owns the mitigation (single-consumer restriction vs. post-mosaic stripping).

Full writeup in `docs/adr/0002-band-sources.md` §3.1 and the increment 4 row of §4.

## Test plan

- [x] `tests/test_reader_requirement_channel_spike.py` — 6 tests, all passing. Both fixes (the copy recipe, the signature-keyed dispatch) were confirmed load-bearing by reverting each in turn during development and observing the corresponding test fail before restoring it.
- [x] `uv run pytest -q` — 989 passed, 12 skipped, no regressions.
- [x] `uv run pre-commit run --all-files` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)