### PR TITLE
fix: add band summaries derivation from item_assets metadata

### DIFF
--- a/tests/test_band_summaries.py
+++ b/tests/test_band_summaries.py
@@ -1,0 +1,155 @@
+"""Tests for summaries.bands derivation from item_assets band metadata.
+
+openEO Studio's band parser (as of
+https://github.com/developmentseed/openeo-studio/pull/103) only reads
+summaries.bands; backends that publish bands solely via the datacube
+extension's cube:dimensions show no bands in the UI until that parser fix
+lands. ``stacApiBackend._add_band_summaries`` derives the same rich
+per-band objects from item_assets so those collections work today.
+"""
+
+from titiler.openeo.stacapi import stacApiBackend
+
+
+def _backend() -> stacApiBackend:
+    return stacApiBackend(url="https://example.com")
+
+
+def test_add_band_summaries_derives_from_eo_bands():
+    collection = {
+        "id": "sentinel-2-l2a",
+        "item_assets": {
+            "B02": {
+                "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                "roles": ["data"],
+                "description": "Blue (band 2) - 10m",
+                "eo:bands": [
+                    {
+                        "name": "B02",
+                        "common_name": "blue",
+                        "center_wavelength": 0.49,
+                        "full_width_half_max": 0.098,
+                    }
+                ],
+            },
+            "B03": {
+                "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                "roles": ["data"],
+                "description": "Green (band 3) - 10m",
+                "eo:bands": [{"name": "B03", "common_name": "green"}],
+            },
+            "granule_metadata": {
+                "type": "application/xml",
+                "roles": ["metadata"],
+            },
+        },
+    }
+
+    stacApiBackend._add_band_summaries(collection)
+
+    bands = collection["summaries"]["bands"]
+    assert bands == [
+        {
+            "name": "B02",
+            "description": "Blue (band 2) - 10m",
+            "eo:common_name": "blue",
+            "eo:center_wavelength": 0.49,
+            "eo:full_width_half_max": 0.098,
+        },
+        {
+            "name": "B03",
+            "description": "Green (band 3) - 10m",
+            "eo:common_name": "green",
+        },
+    ]
+
+
+def test_add_band_summaries_supports_stac_1_1_unprefixed_bands():
+    collection = {
+        "id": "sentinel-2-l2a",
+        "item_assets": {
+            "B02": {
+                "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                "roles": ["data"],
+                "title": "Blue - 10m",
+                "bands": [
+                    {
+                        "name": "B02",
+                        "common_name": "blue",
+                        "center_wavelength": 0.49,
+                    }
+                ],
+            },
+        },
+    }
+
+    stacApiBackend._add_band_summaries(collection)
+
+    assert collection["summaries"]["bands"] == [
+        {
+            "name": "B02",
+            "description": "Blue - 10m",
+            "eo:common_name": "blue",
+            "eo:center_wavelength": 0.49,
+        },
+    ]
+
+
+def test_add_band_summaries_leaves_existing_summaries_bands_untouched():
+    existing_bands = [{"name": "B02", "description": "Already rich"}]
+    collection = {
+        "id": "eopf-collection",
+        "summaries": {"bands": existing_bands},
+        "item_assets": {
+            "B02": {
+                "type": "image/tiff",
+                "roles": ["data"],
+                "eo:bands": [{"name": "B02"}],
+            },
+        },
+    }
+
+    stacApiBackend._add_band_summaries(collection)
+
+    assert collection["summaries"]["bands"] is existing_bands
+
+
+def test_add_band_summaries_noop_when_no_band_metadata():
+    collection = {
+        "id": "sentinel-1-grd",
+        "item_assets": {
+            "vh": {"type": "image/tiff", "roles": ["data"]},
+        },
+    }
+
+    stacApiBackend._add_band_summaries(collection)
+
+    assert "bands" not in collection.get("summaries", {})
+
+
+def test_add_band_summaries_noop_without_item_assets():
+    collection = {"id": "no-assets"}
+
+    stacApiBackend._add_band_summaries(collection)
+
+    assert "summaries" not in collection or "bands" not in collection["summaries"]
+
+
+def test_fix_collection_wires_band_summaries_in():
+    collection = {
+        "id": "sentinel-2-l2a",
+        "item_assets": {
+            "B02": {
+                "type": "image/tiff",
+                "roles": ["data"],
+                "description": "Blue (band 2)",
+                "eo:bands": [{"name": "B02", "common_name": "blue"}],
+            },
+        },
+    }
+
+    _backend()._fix_collection(collection)
+
+    assert collection["summaries"]["bands"] == [
+        {"name": "B02", "description": "Blue (band 2)", "eo:common_name": "blue"},
+    ]

--- a/titiler/openeo/stacapi.py
+++ b/titiler/openeo/stacapi.py
@@ -112,7 +112,63 @@ class stacApiBackend:
 
     def _fix_collection(self, collection: Dict) -> None:
         self._normalize_summaries(collection)
+        self._add_band_summaries(collection)
         return
+
+    @staticmethod
+    def _add_band_summaries(collection: Dict) -> None:
+        """Populate summaries.bands from item_assets band metadata.
+
+        openEO Studio's band parser currently only reads summaries.bands
+        (rich per-band objects); it does not yet fall back to the datacube
+        extension's cube:dimensions bands dimension that ``getdimensions``
+        produces below. Until that parser fix lands
+        (https://github.com/developmentseed/openeo-studio/pull/103), derive
+        the same per-band objects here from each item_asset's eo:bands (or
+        STAC 1.1 unprefixed bands) metadata, so collections with no
+        pre-existing summaries.bands still show their bands in the UI.
+        """
+        summaries = collection.get("summaries")
+        if not isinstance(summaries, dict):
+            summaries = {}
+            collection["summaries"] = summaries
+        if summaries.get("bands"):
+            return
+
+        item_assets = collection.get("item_assets") or {}
+        band_summaries: List[Dict] = []
+        for key, asset in item_assets.items():
+            asset_bands = asset.get("eo:bands") or asset.get("bands")
+            if not asset_bands:
+                continue
+
+            description = asset.get("description") or asset.get("title") or key
+            for band in asset_bands:
+                entry: Dict[str, Any] = {
+                    "name": band.get("name", key),
+                    "description": description,
+                }
+
+                common_name = band.get("eo:common_name") or band.get("common_name")
+                if common_name:
+                    entry["eo:common_name"] = common_name
+
+                center_wavelength = band.get("eo:center_wavelength") or band.get(
+                    "center_wavelength"
+                )
+                if center_wavelength is not None:
+                    entry["eo:center_wavelength"] = center_wavelength
+
+                fwhm = band.get("eo:full_width_half_max") or band.get(
+                    "full_width_half_max"
+                )
+                if fwhm is not None:
+                    entry["eo:full_width_half_max"] = fwhm
+
+                band_summaries.append(entry)
+
+        if band_summaries:
+            summaries["bands"] = band_summaries
 
     @staticmethod
     def _normalize_summaries(collection: Dict):


### PR DESCRIPTION
## Description

Implement functionality to derive band summaries from item_assets metadata, ensuring that collections without pre-existing summaries still display their bands correctly in the UI.

## Testing

Tested the new functionality by adding unit tests that verify the correct derivation of band summaries from various item_assets configurations.

- [ ] I have run the existing test suite and all tests pass
- [ ] I have tested this change manually

## Documentation

- [ ] I have updated the documentation accordingly
- [ ] My changes do not require documentation updates

## Checklist

- [ ] My PR title follows [conventional commit format](https://www.conventionalcommits.org/) (e.g., `feat: add new feature`, `fix: resolve issue`)
- [ ] My changes generate no new warnings
- [ ] I updated the Helm chart version if applicable

## Related Issues

Fixes #

