### PR TITLE
feat(auth): harden OIDC so Microsoft Entra ID works

### DIFF
--- a/docs/adr/0006-microsoft-entra-oidc.md
+++ b/docs/adr/0006-microsoft-entra-oidc.md
@@ -1,0 +1,219 @@
+# ADR 0006 — Microsoft Entra ID as an OIDC provider
+
+- **Status:** Proposed
+- **Date:** 2026-08-10
+- **Deciders:** @emmanuelmathot
+- **Supersedes / superseded by:** —
+
+---
+
+## 1. Context
+
+The Planetary Computer deployment target (see [ADR 0005](0005-asset-href-signing.md))
+needs user identity from Microsoft Entra ID, the identity platform behind
+Azure and Microsoft 365.
+
+This backend already speaks OIDC. `OIDCAuth` (`auth.py:88-272`) fetches a
+provider's discovery document, fetches its JWKS, verifies an RS256 signature by
+hand with `cryptography`, and builds a `User` from the token payload.
+`/credentials/oidc` (`factory.py:273-341`) advertises the provider to openEO
+clients with authorization-code+PKCE and device-code grants. A CDSE Keycloak
+realm is driven through this path in production today.
+
+So this ADR is not about adding a provider. It is about the distance between
+"works against one Keycloak realm" and "works against Entra without failing in
+production a few weeks later".
+
+### 1.1 Verified evidence (2026-08-10)
+
+Probed live against `https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration`
+and its JWKS endpoint.
+
+| Claim | Evidence | Consequence |
+| --- | --- | --- |
+| Entra signs with RS256 only | `id_token_signing_alg_values_supported: ["RS256"]` | The existing hand-rolled PKCS1v15+SHA256 verification is the right algorithm |
+| Entra publishes six RSA signing keys | `common/discovery/v2.0/keys` returns six `kty: RSA` entries | Key rotation is real and continuous |
+| JWK entries carry no `alg` field | Confirmed on all six | `_get_key`'s `kty`-only check is correct; an `alg`-based lookup would fail |
+| The `common` endpoint returns a **templated** issuer | `"issuer": "https://login.microsoftonline.com/{tenantid}/v2.0"` | Unusable for `iss` comparison, and invalid in the `/credentials/oidc` response — a single-tenant `wk_url` is required |
+| Entra supports the device-code grant | `device_authorization_endpoint` present | The grant list `/credentials/oidc` already hardcodes is accurate |
+| `sub` is pairwise | `subject_types_supported: ["pairwise"]` | `sub` is stable per (user, application). Changing the app registration orphans every stored service, which are keyed on `user_id` |
+| `preferred_username`, `name`, `email` are all available | `claims_supported` | `name_claim` has a sensible Entra value already |
+
+### 1.2 The gaps
+
+Reading the current implementation against that evidence:
+
+1. **`_jwks_cache` never refreshes** (`auth.py:127-134`). It is populated once
+   and held for the life of the process. Entra rotates its six keys
+   continuously. When a token arrives signed by a key minted after the cache was
+   filled, `_get_key` raises 401 and **every subsequent login fails until the
+   process restarts**. This is the blocker, and it is a latent bug for Keycloak
+   too — it has simply not been hit yet.
+2. **The discovery document is cached forever** (`auth.py:110-118`), with the
+   same failure mode if a provider moves its `jwks_uri`.
+3. **`iss` is never validated.** `_verify_token` (`auth.py:162-206`) checks the
+   signature, the audience and expiry, but never compares the issuer. A token
+   from any issuer whose key happens to be in the cached JWKS would pass.
+4. **The token header is parsed and discarded** (`auth.py:169-171`). `alg` is
+   never checked, and verification is hardcoded to PKCS1v15+SHA256 regardless of
+   what the token claims. This is the classic algorithm-confusion shape.
+5. **`exp` is optional** (`auth.py:197`): `if payload.get("exp") and …`. A token
+   with no `exp` at all validates.
+6. **The audience check assumes an ID token** (`auth.py:190-193`): it accepts
+   `azp == client_id` or `client_id in aud`. Entra *access* tokens for a custom
+   API carry the application ID URI (`api://<client_id>`) in `aud`, not the bare
+   client id, and so are rejected.
+7. **`user_id` is hardcoded to `sub`** (`auth.py:257`). Given §1.1's pairwise
+   note, an operator has no way to pin identity to the tenant-stable `oid`.
+8. **`AuthSettings.__init__` clobbers its own argument** (`settings.py:118-121`):
+   `kwargs["oidc"] = OIDCConfig()` runs unconditionally, so `AuthSettings(oidc=…)`
+   is silently ignored, `self.oidc` is always truthy, and the
+   `validate_oidc_config` model validator (`settings.py:123-128`) and the
+   `if not settings.oidc` guards in `get_auth` (`auth.py:81`) and
+   `__attrs_post_init__` (`auth.py:105`) are all dead code. A deployment with
+   `method=oidc` and an unset `wk_url` starts cleanly and fails on the first
+   request with an `httpx` error.
+
+---
+
+## 2. Decision
+
+Fix the eight gaps in place. Keep the hand-rolled verification.
+
+### 2.1 Why not adopt a JWT library
+
+`PyJWT[crypto]` or `joserfc` with a `PyJWKClient` would provide rotation,
+`iss`/`aud`/`exp`/`nbf`/`alg` validation and non-RSA algorithms for free, and is
+the choice most projects should make.
+
+It is not made here because the change it competes with is small and the code it
+would replace is tested and working. Every gap in §1.2 is between four and
+fifteen lines. Adding a dependency to the `oidc` extra to rewrite a correct RS256
+verifier is a larger diff with a wider blast radius than the fixes themselves.
+
+The condition to revisit is explicit: **the first provider this backend must
+support that signs with anything other than RS256.** At that point the hand-rolled
+path stops being a small amount of correct code and starts being a re-implementation
+of a library, and it should be replaced wholesale rather than extended.
+
+### 2.2 The changes
+
+| # | Change | Location |
+| --- | --- | --- |
+| 1 | On an unknown `kid`, invalidate the JWKS cache and refetch **once**, behind a `Lock` and a cooldown so unknown kids cannot cause a fetch storm | `auth.py::_get_key` |
+| 2 | Cache the discovery document with a TTL instead of forever | `auth.py::config` |
+| 3 | Validate `iss` against the discovery document's `issuer` | `auth.py::_verify_token` |
+| 4 | Require the header's `alg` to be `RS256` before verifying | `auth.py::_verify_token` |
+| 5 | Require `exp`; check `nbf` when present | `auth.py::_verify_token` |
+| 6 | Accept an operator-supplied audience list alongside `client_id` | `auth.py::_verify_token`, `settings.py::OIDCConfig.audiences` |
+| 7 | Take `user_id` from a configurable claim, default `sub` | `auth.py::validate`, `settings.py::OIDCConfig.user_id_claim` |
+| 8 | Stop clobbering `oidc`; validate `wk_url` and `client_id` at startup when `method=oidc` | `settings.py::AuthSettings` |
+
+### 2.3 The templated issuer is a startup error, not a runtime one
+
+§1.1 shows the `common` endpoint returns `https://login.microsoftonline.com/{tenantid}/v2.0`.
+That string is useless for change 3, and `/credentials/oidc` would advertise it
+verbatim to openEO clients as the provider `issuer`.
+
+Rather than substituting the token's `tid` into it — which would accept tokens
+from every tenant in the world, the opposite of what an `iss` check is for —
+a discovery document whose `issuer` contains `{tenantid}` is rejected with a
+message naming the fix: configure a single-tenant `wk_url`,
+`https://login.microsoftonline.com/<tenant_id>/v2.0/.well-known/openid-configuration`.
+
+Multi-tenant support is a real feature, and this deliberately does not provide
+it. It needs an allow-list of tenant ids, which is a policy decision no default
+can make.
+
+### 2.4 `user_id` stability is the operator's problem, and they need the lever
+
+Services, UDPs and tile assignments are all keyed on `User.user_id`
+(`services/base.py`). §1.1 shows Entra's `sub` is pairwise: it is stable for a
+given user *in a given application registration*, and changes if the operator
+re-registers the app. `oid` is stable across applications within a tenant.
+
+Neither is correct in general — `oid` is not unique across tenants, and `sub` is
+the specification's own answer — so change 7 supplies a default of `sub` and a
+documented lever, rather than choosing for the operator. The documentation
+states plainly that changing this setting on a running deployment orphans every
+stored service.
+
+---
+
+## 3. Consequences
+
+**Gained.** Entra works, and keeps working across key rotation. `iss`, `alg` and
+`exp` are enforced for every provider, not just Entra — Keycloak deployments get
+the same hardening. `AuthSettings(oidc=…)` becomes assignable, which makes the
+existing settings validators live and lets tests construct real settings objects
+instead of `Mock()` (`tests/test_auth.py:23-27`).
+
+**Accepted costs.** Four new validation paths that can reject a token which is
+accepted today. The most likely to bite is change 5: any provider issuing tokens
+without `exp` now fails. This is intended — such a token is not safely
+verifiable — but it is a behaviour change, and it is called out in the release
+notes rather than buried.
+
+**Deliberately not done.** A JWT library (§2.1). Multi-tenant Entra (§2.3).
+Non-RSA signature algorithms. Token refresh, introspection or revocation
+checking. Mapping Entra groups or app roles onto the `roles` field that
+`AuthSettings.users` already carries and nothing reads — authorization is
+[ADR 0003](0003-service-access-control.md)'s subject, not this one.
+
+### 3.1 Open risks
+
+- **The JWKS refetch is a request-triggered outbound call.** A flood of tokens
+  with unknown kids would otherwise become a flood of requests to the provider.
+  The cooldown bounds this, but the bound is a constant, not a rate limiter. If
+  this ever matters, the correct fix is a background refresh rather than a
+  tighter cooldown.
+- **`_get_key` and `config` are per-process, unsynchronised caches.** Adding a
+  `Lock` fixes the refetch stampede within one worker. Across workers, each
+  holds its own cache and refetches independently. This is acceptable at the
+  observed key-rotation rate and is not worth a shared cache.
+- **Change 6 widens the audience check.** An operator who sets `audiences` to a
+  value they do not control weakens validation. The default is an empty list,
+  which preserves today's behaviour exactly, and the documentation frames the
+  setting as "the application ID URI of your own API", not "audiences to trust".
+
+---
+
+## 4. Implementation plan
+
+Delivered as a single increment — the changes are individually small, share one
+test surface, and splitting them would ship a validator in a half-hardened state.
+
+| # | Increment | Gate / abandon condition |
+| --- | --- | --- |
+| 1 | This ADR | Docs only |
+| 2 | Changes 1–8, with tests | An unknown `kid` triggers exactly one refetch and then succeeds; a second unknown `kid` inside the cooldown does not refetch; `iss`, `alg`, `exp` and `aud` each have a rejection test; `/me` is unchanged for a valid token |
+
+### 4.1 Verification
+
+Unit tests follow `tests/test_auth.py`'s existing shape: a hand-built JWT plus
+`@patch.object(OIDCAuth, "_get_key")`. Rotation is tested by patching the JWKS
+fetch to return different key sets on successive calls and asserting the call
+count. Endpoint behaviour uses the `app_with_auth` / `app_no_auth` fixture pair
+in `tests/conftest.py`.
+
+```bash
+uv run pytest --cov=titiler.openeo --cov-report=term-missing
+uv run pre-commit run --all-files
+```
+
+Live check against a real tenant: point `TITILER_OPENEO_AUTH_OIDC_WK_URL` at a
+single-tenant discovery document, confirm `GET /credentials/oidc` returns a
+concrete `issuer` rather than the templated form, and confirm `GET /me` with a
+real Entra token returns the expected `user_id`.
+
+---
+
+## 5. Related
+
+- [ADR 0003 — Service access control](0003-service-access-control.md) — what a
+  `User` is allowed to do, once this ADR has established who they are.
+- [ADR 0005 — Asset href signing](0005-asset-href-signing.md) — the data-access
+  half of the same deployment target, and the consumer of the per-user seam.
+- [Microsoft identity platform and OpenID Connect](https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols-oidc).
+- `docs/src/openid-connect.md` — the operator-facing configuration guide this ADR
+  extends.

--- a/docs/adr/upstream/openeo-python-client-scope-intersection.md
+++ b/docs/adr/upstream/openeo-python-client-scope-intersection.md
@@ -1,0 +1,104 @@
+# Upstream issue draft — openeo-python-client
+
+- **Target:** [Open-EO/openeo-python-client](https://github.com/Open-EO/openeo-python-client)
+- **Status:** Draft, not yet filed
+- **Date:** 2026-08-11
+- **Affects:** `openeo` 0.48.0
+- **Local workaround:** `titiler.openeo.client_compat.patch_openeo_client_scopes()`
+
+Paste the section below into a new GitHub issue.
+
+---
+
+## Title
+
+Cannot authenticate against a Microsoft Entra ID protected backend: Entra never advertises custom scopes in `scopes_supported`
+
+## The problem
+
+Microsoft Entra ID cannot advertise an application's custom API scopes in its
+OIDC discovery document. Its `scopes_supported` is tenant-wide and permanently
+fixed at `["openid", "profile", "email", "offline_access"]`. This is by design,
+per Microsoft in
+[AzureAD/microsoft-identity-web#1689](https://github.com/AzureAD/microsoft-identity-web/discussions/1689):
+
+> The OIDC metadata endpoint just returns Azure AD's STS metadata. There's no
+> concept of custom resources or custom scopes here.
+
+`OidcProviderInfo.__init__` intersects the scopes a backend declares at
+`/credentials/oidc` against that list
+(`openeo/rest/auth/oidc.py`, 0.48.0):
+
+```python
+self._scopes = {"openid"}.union(scopes or []).intersection(self._supported_scopes)
+```
+
+A sensible default against a well-behaved provider — but with Entra it drops the
+one scope that matters:
+
+```python
+provider = OidcProviderInfo(
+    issuer=f"https://login.microsoftonline.com/{TENANT}/v2.0",
+    scopes=["openid", "profile", "email", f"api://{CLIENT_ID}/openeo"],
+)
+provider.get_scopes_string()
+# -> 'email openid profile'      the api:// scope never reaches Entra
+```
+
+With no resource scope requested, Entra issues an access token audienced at
+Microsoft Graph. Those carry a `nonce` header and are signed over a modified
+header, so no third party can verify them — deliberately, as the
+audience-confusion defence. The backend rejects the token, and the user sees a
+signature error with no obvious connection to a dropped scope (it is only
+`log.debug`-ed).
+
+The net effect is that **no openEO backend protected by Entra can be
+authenticated against with this client**, and nothing the backend or the app
+registration can configure will change that.
+
+## Possible accommodations
+
+Any of these would be enough:
+
+1. **Warn instead of dropping** — keep the declared scopes, `log.warning` when
+   one is not advertised. Preserves the diagnostic value without the breakage.
+2. **Opt out** — e.g. `OidcProviderInfo(..., strict_scopes=False)`, plumbed
+   through `Connection.authenticate_oidc*`.
+3. **Do not intersect at all** — [RFC 8414](https://www.rfc-editor.org/rfc/rfc8414#section-2)
+   makes `scopes_supported` RECOMMENDED and descriptive, and RFC 6749 §3.3 puts
+   the grant decision on the authorization server, which reports the result in
+   the `scope` response parameter.
+
+Options 1 and 3 also help any other provider with incomplete metadata; option 2
+leaves each user to discover the problem first.
+
+## Workaround
+
+```python
+from openeo.rest.auth.oidc import OidcProviderInfo
+
+_orig_init = OidcProviderInfo.__init__
+
+def _patched_init(self, issuer=None, discovery_url=None, scopes=None, **kwargs):
+    _orig_init(self, issuer=issuer, discovery_url=discovery_url, scopes=scopes, **kwargs)
+    self._scopes = {"openid"} | set(scopes or [])
+
+OidcProviderInfo.__init__ = _patched_init
+```
+
+## Environment
+
+`openeo` 0.48.0 · Python 3.13 · Entra ID v2.0 endpoint, single tenant ·
+backend: [titiler-openeo](https://github.com/sentinel-hub/titiler-openeo)
+
+---
+
+## Notes for us (not part of the issue)
+
+- Shipped as `titiler.openeo.client_compat.patch_openeo_client_scopes()`,
+  documented in `docs/src/openid-connect.md`. Import-side-effect free and
+  idempotent; tested against a stand-in reproducing the upstream intersection,
+  so it needs no dependency on the client.
+- Delete the helper once a release carrying a fix is our minimum.
+- Affects any Entra-protected openEO backend, so worth filing despite the local
+  fix.

--- a/docs/src/openid-connect.md
+++ b/docs/src/openid-connect.md
@@ -38,23 +38,179 @@ TITILER_OPENEO_AUTH_OIDC_SCOPES="openid email profile"  # Space-separated list (
 TITILER_OPENEO_AUTH_OIDC_NAME_CLAIM="name"  # Claim to use for user name (default)
 TITILER_OPENEO_AUTH_OIDC_TITLE="OIDC"  # Provider title (default)
 TITILER_OPENEO_AUTH_OIDC_DESCRIPTION="OpenID Connect (OIDC) Authorization Code Flow with PKCE"  # Provider description (default)
+TITILER_OPENEO_AUTH_OIDC_AUDIENCES=""  # Space-separated extra accepted `aud` values
+TITILER_OPENEO_AUTH_OIDC_USER_ID_CLAIM="sub"  # Claim used as User.user_id (default)
 ```
+
+`TITILER_OPENEO_AUTH_METHOD=oidc` is validated at startup: the backend refuses
+to start if `CLIENT_ID` or `WK_URL` is unset, rather than failing on the first
+request.
+
+!!! warning "`USER_ID_CLAIM` is not safe to change on a running deployment"
+    Services, UDPs and tile assignments are all keyed on `User.user_id`.
+    Changing which claim produces it orphans everything already stored.
+
+## Microsoft Entra ID
+
+[Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols-oidc)
+works with the configuration above, with one requirement.
+
+**Use a single-tenant well-known URL.** The multi-tenant `common` endpoint
+returns a templated issuer, `https://login.microsoftonline.com/{tenantid}/v2.0`,
+which is a literal placeholder rather than a URL. It cannot be compared against
+a token's `iss` and cannot be advertised to openEO clients, so the backend
+rejects it with a message naming the fix.
+
+```bash
+TITILER_OPENEO_AUTH_METHOD=oidc
+TITILER_OPENEO_AUTH_OIDC_CLIENT_ID="<application (client) ID>"
+TITILER_OPENEO_AUTH_OIDC_WK_URL="https://login.microsoftonline.com/<tenant_id>/v2.0/.well-known/openid-configuration"
+TITILER_OPENEO_AUTH_OIDC_REDIRECT_URL="http://localhost:8080/"
+TITILER_OPENEO_AUTH_OIDC_NAME_CLAIM="preferred_username"
+TITILER_OPENEO_AUTH_OIDC_TITLE="Microsoft Entra ID"
+```
+
+### Expose an API scope, and mint the token out-of-band
+
+openEO clients send the **access token**, never the ID token. With only
+`openid profile email` requested, Entra issues an access token audienced at
+**Microsoft Graph**, and those cannot be validated by anyone but Graph: they
+carry a `nonce` in the JWT header and their signature will not verify against
+the tenant's published JWKS. The symptom is a 401 with *"Token signature
+verification failed"*.
+
+Entra must therefore issue a token audienced at *this* backend:
+
+1. App registration → **Expose an API** → **Set** the Application ID URI →
+   accept the default `api://<client_id>`.
+2. **Add a scope**, e.g. `openeo`, with admin and user consent enabled.
+3. **Manifest** → set `"requestedAccessTokenVersion": 2`. Without this Entra
+   issues a v1 access token whose `iss` is `https://sts.windows.net/<tenant>/`,
+   which will not match the v2 discovery document's issuer and fails the `iss`
+   check with *"Invalid issuer"*.
+
+```bash
+TITILER_OPENEO_AUTH_OIDC_AUDIENCES="api://<client_id>"
+```
+
+!!! warning "The openEO **Python** client drops this scope by default"
+    `openeo` (checked at 0.48.0) intersects the scopes a backend advertises with
+    the provider's own `scopes_supported`
+    (`openeo/rest/auth/oidc.py`, `OidcProviderInfo.__init__`):
+    `{"openid"}.union(scopes).intersection(self._supported_scopes)`. Microsoft
+    Entra advertises a fixed `["openid", "profile", "email", "offline_access"]`
+    — static platform metadata that by construction never lists an app's custom
+    API scopes — so `api://<client_id>/openeo` is **silently dropped** and Entra
+    falls back to a Graph-audienced token. `scopes_supported` is *RECOMMENDED*
+    and informational per [RFC 8414](https://www.rfc-editor.org/rfc/rfc8414),
+    so this client-side filtering is arguably too strict. Microsoft has
+    [confirmed](https://github.com/AzureAD/microsoft-identity-web/discussions/1689)
+    that Entra will never advertise custom scopes, so this cannot be fixed from
+    the provider side.
+
+Undo the intersection with the helper this project ships. Call it once, before
+connecting — from any notebook or script:
+
+```python
+from titiler.openeo.client_compat import patch_openeo_client_scopes
+
+patch_openeo_client_scopes()
+
+import openeo
+connection = openeo.connect("http://127.0.0.1:8083/").authenticate_oidc()
+```
+
+The call is idempotent, so re-running a cell is harmless, and importing the
+module patches nothing on its own. `_scopes` is computed once in
+`OidcProviderInfo.__init__`, so this covers every flow — authorization code,
+device code and refresh token all read it through `get_scopes_string`.
+
+With it in place `TITILER_OPENEO_AUTH_OIDC_SCOPES` works as documented and the
+ordinary `authenticate_oidc()` flow succeeds, keeping refresh-token caching.
+Patch at runtime rather than editing the installed package — `uv sync` reverts a
+site-packages edit.
+
+The upstream report is drafted at
+`docs/adr/upstream/openeo-python-client-scope-intersection.md`; drop the helper
+once a release carrying a fix is the minimum this project supports.
+
+If you would rather not patch a third-party class, mint the token out-of-band
+with MSAL and hand it over with `authenticate_oidc_access_token()`
+(openeo >= 0.31); this also needs no redirect URI:
+
+```python
+import msal, openeo
+
+TENANT, CLIENT_ID = "<tenant_id>", "<client_id>"
+app = msal.PublicClientApplication(
+    CLIENT_ID, authority=f"https://login.microsoftonline.com/{TENANT}"
+)
+flow = app.initiate_device_flow(scopes=[f"api://{CLIENT_ID}/openeo"])
+print(flow["message"])          # sign in at microsoft.com/devicelogin
+token = app.acquire_token_by_device_flow(flow)["access_token"]
+
+connection = openeo.connect("http://127.0.0.1:8083/").authenticate_oidc_access_token(token)
+```
+
+In the Entra app registration:
+
+- Register a **public client**; both grants openEO clients use — authorization
+  code with PKCE, and device code — are supported.
+- Add your openEO client's redirect URL (the Web Editor's is its own origin).
+- If your clients present **access** tokens audienced at your own API rather
+  than ID tokens, add that audience:
+  `TITILER_OPENEO_AUTH_OIDC_AUDIENCES="api://<client_id>"`.
+
+Entra's `sub` is *pairwise*: stable for a given user in a given app
+registration, and different if you re-register the app. If you expect to
+re-register, consider pinning identity to the tenant-stable object id with
+`TITILER_OPENEO_AUTH_OIDC_USER_ID_CLAIM="oid"` — but decide before going live,
+per the warning above.
+
+For asset access on Microsoft Planetary Computer, see
+[Microsoft Planetary Computer](planetary-computer.md). Note that Entra
+identifies your users; it does not change what they can read there.
+
+### `GET /credentials/oidc` returns 404
+
+That is expected when the backend is not configured for OIDC. openEO backends
+advertise only the authentication method they actually support, so
+`/credentials/oidc` and `/credentials/basic` are **mutually exclusive** — the
+one that does not apply is never registered:
+
+| `TITILER_OPENEO_AUTH_METHOD` | Registered route |
+| --- | --- |
+| `basic` (default) | `/credentials/basic` |
+| `oidc` | `/credentials/oidc` |
+
+Set `TITILER_OPENEO_AUTH_METHOD=oidc` together with `CLIENT_ID` and `WK_URL`.
+If any of those are missing the backend now refuses to start and names the
+variable, rather than starting and failing on the first request.
 
 ## Token Validation
 
-The OIDC implementation performs the following validations in the [`_verify_token`](https://github.com/sentinel-hub/titiler-openeo/blob/main/titiler/openeo/auth.py#L177) method:
+Validation is performed in the [`_verify_token`](https://github.com/sentinel-hub/titiler-openeo/blob/main/titiler/openeo/auth.py)
+and `_verify_claims` methods:
 
-1. Verifies the token signature using the provider's JWKS
-2. Validates token claims including:
-   - Client ID matches the configured one
-   - Token expiration
-   - Token audience
+1. The header's `alg` must be `RS256`, the only algorithm this backend verifies.
+2. The signature is verified against the provider's JWKS. If the token's key id
+   is not in the cached key set, the JWKS is refetched once — providers rotate
+   signing keys continuously, and Entra publishes six at a time.
+3. `iss` must match the discovery document's `issuer`.
+4. `aud` must contain the client ID or one of the configured `AUDIENCES`, or
+   `azp` must equal one of them.
+5. `exp` is **required**, and checked with 60 seconds of clock-skew allowance.
+   `nbf` is checked when present.
+
+The discovery document is cached for an hour rather than for the life of the
+process, so a provider that moves its `jwks_uri` does not break a running
+deployment permanently.
 
 ## User Information
 
-Upon successful validation, a [`User`](https://github.com/sentinel-hub/titiler-openeo/blob/main/titiler/openeo/auth.py#L35) object is created with:
+Upon successful validation, a [`User`](https://github.com/sentinel-hub/titiler-openeo/blob/main/titiler/openeo/models/auth.py) object is created with:
 
-- `user_id`: Subject claim from the token (`sub`)
+- `user_id`: the claim named by `USER_ID_CLAIM` (defaults to `sub`)
 - `email`: Email claim if available
 - `name`: Value from the configured name claim (defaults to "name")
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -2,32 +2,54 @@
 
 import base64
 import json
-from unittest.mock import Mock, patch
+import time
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from pydantic import ValidationError
 
 from titiler.openeo.auth import AuthToken, OIDCAuth, OIDCConfig
+from titiler.openeo.settings import AuthSettings
+
+ISSUER = "https://auth.example.com"
+JWKS_URI = "https://auth.example.com/jwks"
+WK_URL = "https://auth.example.com/.well-known/openid-configuration"
+DISCOVERY = {"issuer": ISSUER, "jwks_uri": JWKS_URI}
 
 
 @pytest.fixture
 def oidc_config():
-    return OIDCConfig(
-        issuer="https://auth.example.com",
-        client_id="test-client-id",
-        jwks_uri="https://auth.example.com/jwks",
-    )
+    return OIDCConfig(client_id="test-client-id", wk_url=WK_URL)
 
 
 @pytest.fixture
-def mock_settings(oidc_config):
-    settings = Mock()
-    settings.oidc = oidc_config
-    return settings
+def settings(oidc_config):
+    """Real settings, not a Mock.
+
+    Possible only because `AuthSettings.__init__` no longer overwrites its own
+    `oidc` argument (docs/adr/0006-microsoft-entra-oidc.md S1.2 gap 8).
+    """
+    return AuthSettings(method="oidc", oidc=oidc_config)
 
 
-def create_mock_token(payload: dict) -> str:
-    header = {"alg": "RS256", "typ": "JWT", "kid": "test-key"}
+@pytest.fixture
+def auth(settings):
+    """An OIDCAuth whose discovery document is pre-seeded, so no network."""
+    instance = OIDCAuth(settings=settings, store=Mock())
+    instance._config_cache = dict(DISCOVERY)
+    instance._config_fetched_at = time.monotonic()
+    return instance
+
+
+@pytest.fixture
+def mock_key():
+    key = Mock()
+    key.verify = Mock()
+    return key
+
+
+def create_mock_token(payload: dict, alg: str = "RS256") -> str:
+    header = {"alg": alg, "typ": "JWT", "kid": "test-key"}
     header_b64 = (
         base64.urlsafe_b64encode(json.dumps(header).encode()).decode().rstrip("=")
     )
@@ -38,60 +60,268 @@ def create_mock_token(payload: dict) -> str:
     return f"{header_b64}.{payload_b64}.{signature_b64}"
 
 
-@patch.object(OIDCAuth, "_get_key")
-def test_oidc_auth_audience_as_array(mock_get_key, mock_settings):
-    mock_key = Mock()
-    mock_key.verify = Mock()
-    mock_get_key.return_value = mock_key
-
-    mock_store = Mock()
-    auth = OIDCAuth(settings=mock_settings, store=mock_store)
-
-    payload = {
-        "aud": ["test-client-id", "other-audience"],
-        "exp": 9999999999,
-        "iat": 1000000000,
+def _payload(**overrides) -> dict:
+    base = {
+        "iss": ISSUER,
+        "sub": "user-1",
+        "aud": ["test-client-id"],
+        "exp": time.time() + 3600,
+        "iat": time.time() - 10,
     }
-    token = create_mock_token(payload)
-    auth._verify_token(token, mock_key)
+    base.update(overrides)
+    return base
 
 
-@patch.object(OIDCAuth, "_get_key")
-def test_oidc_auth_audience_as_string(mock_get_key, mock_settings):
-    mock_key = Mock()
-    mock_key.verify = Mock()
-    mock_get_key.return_value = mock_key
-
-    mock_store = Mock()
-    auth = OIDCAuth(settings=mock_settings, store=mock_store)
-
-    payload = {
-        "aud": "test-client-id other-audience",
-        "exp": 9999999999,
-        "iat": 1000000000,
-    }
-    token = create_mock_token(payload)
-    auth._verify_token(token, mock_key)
+# ---------------------------------------------------------------------------
+# Audience
+# ---------------------------------------------------------------------------
 
 
-@patch.object(OIDCAuth, "_get_key")
-def test_oidc_auth_audience_invalid(mock_get_key, mock_settings):
-    mock_key = Mock()
-    mock_key.verify = Mock()
-    mock_get_key.return_value = mock_key
+def test_oidc_auth_audience_as_array(auth, mock_key):
+    auth._verify_token(
+        create_mock_token(_payload(aud=["test-client-id", "other"])), mock_key
+    )
 
-    mock_store = Mock()
-    auth = OIDCAuth(settings=mock_settings, store=mock_store)
 
-    payload = {
-        "aud": ["wrong-client-id"],
-        "exp": 9999999999,
-        "iat": 1000000000,
-    }
-    token = create_mock_token(payload)
+def test_oidc_auth_audience_as_string(auth, mock_key):
+    auth._verify_token(
+        create_mock_token(_payload(aud="test-client-id other")), mock_key
+    )
 
+
+def test_oidc_auth_audience_from_azp(auth, mock_key):
+    auth._verify_token(
+        create_mock_token(_payload(aud=["someone-else"], azp="test-client-id")),
+        mock_key,
+    )
+
+
+def test_oidc_auth_audience_invalid(auth, mock_key):
     with pytest.raises(Exception, match="Invalid audience"):
-        auth._verify_token(token, mock_key)
+        auth._verify_token(
+            create_mock_token(_payload(aud=["wrong-client-id"])), mock_key
+        )
+
+
+def test_oidc_auth_accepts_a_configured_extra_audience(settings, mock_key):
+    """Entra access tokens are audienced at the API's app ID URI, not the client."""
+    settings.oidc.audiences = ["api://test-client-id"]
+    auth = OIDCAuth(settings=settings, store=Mock())
+    auth._config_cache = dict(DISCOVERY)
+    auth._config_fetched_at = time.monotonic()
+
+    auth._verify_token(
+        create_mock_token(_payload(aud="api://test-client-id")), mock_key
+    )
+
+
+# ---------------------------------------------------------------------------
+# Issuer, algorithm, expiry
+# ---------------------------------------------------------------------------
+
+
+def test_rejects_a_token_from_another_issuer(auth, mock_key):
+    with pytest.raises(Exception, match="Invalid issuer"):
+        auth._verify_token(
+            create_mock_token(_payload(iss="https://evil.example")), mock_key
+        )
+
+
+def test_rejects_a_non_rs256_algorithm(auth, mock_key):
+    """The signature check is hardcoded to RS256, so the header must agree."""
+    with pytest.raises(Exception, match="Unsupported token algorithm"):
+        auth._verify_token(create_mock_token(_payload(), alg="HS256"), mock_key)
+
+    mock_key.verify.assert_not_called()
+
+
+def test_rejects_a_token_with_no_exp(auth, mock_key):
+    payload = _payload()
+    del payload["exp"]
+    with pytest.raises(Exception, match="no 'exp' claim"):
+        auth._verify_token(create_mock_token(payload), mock_key)
+
+
+def test_rejects_an_expired_token(auth, mock_key):
+    with pytest.raises(Exception, match="Token expired"):
+        auth._verify_token(
+            create_mock_token(_payload(exp=time.time() - 3600)), mock_key
+        )
+
+
+def test_rejects_a_token_that_is_not_yet_valid(auth, mock_key):
+    with pytest.raises(Exception, match="not yet valid"):
+        auth._verify_token(
+            create_mock_token(_payload(nbf=time.time() + 3600)), mock_key
+        )
+
+
+def test_tolerates_clock_skew(auth, mock_key):
+    """A few seconds either side must not reject an otherwise valid token."""
+    auth._verify_token(create_mock_token(_payload(exp=time.time() - 5)), mock_key)
+    auth._verify_token(create_mock_token(_payload(nbf=time.time() + 5)), mock_key)
+
+
+# ---------------------------------------------------------------------------
+# JWKS rotation -- the production blocker (ADR 0006 S1.2 gap 1)
+# ---------------------------------------------------------------------------
+
+
+def _jwk(kid: str) -> dict:
+    return {
+        "kid": kid,
+        "kty": "RSA",
+        "n": base64.urlsafe_b64encode((123456789).to_bytes(64, "big"))
+        .decode()
+        .rstrip("="),
+        "e": base64.urlsafe_b64encode((65537).to_bytes(3, "big")).decode().rstrip("="),
+    }
+
+
+def _patch_jwks(*responses):
+    """Patch httpx so each successive JWKS fetch returns the next key set."""
+    client = MagicMock()
+    client.__enter__.return_value = client
+    client.get.side_effect = [
+        MagicMock(json=MagicMock(return_value=r)) for r in responses
+    ]
+    httpx = MagicMock()
+    httpx.Client.return_value = client
+    return patch("titiler.openeo.auth.httpx", httpx), client
+
+
+def test_unknown_kid_triggers_exactly_one_refetch(auth):
+    """A key minted after the cache was filled must not fail forever."""
+    patcher, client = _patch_jwks({"keys": [_jwk("old")]}, {"keys": [_jwk("new")]})
+    with patcher:
+        assert auth._get_key("new") is not None
+
+    assert client.get.call_count == 2
+
+
+def test_a_known_kid_does_not_refetch(auth):
+    patcher, client = _patch_jwks({"keys": [_jwk("old")]})
+    with patcher:
+        assert auth._get_key("old") is not None
+
+    assert client.get.call_count == 1
+
+
+def test_a_still_unknown_kid_is_rejected_after_the_refetch(auth):
+    patcher, client = _patch_jwks({"keys": [_jwk("old")]}, {"keys": [_jwk("other")]})
+    with patcher:
+        with pytest.raises(Exception, match="Unable to find appropriate key"):
+            auth._get_key("nope")
+
+    assert client.get.call_count == 2
+
+
+def test_the_refetch_is_rate_limited(auth):
+    """A flood of junk kids must not become a flood of provider requests."""
+    patcher, client = _patch_jwks(
+        {"keys": [_jwk("old")]}, {"keys": [_jwk("old")]}, {"keys": [_jwk("old")]}
+    )
+    with patcher:
+        for _ in range(3):
+            with pytest.raises(Exception, match="Unable to find appropriate key"):
+                auth._get_key("junk")
+
+    # One initial fetch, one refetch; every later refresh is inside the cooldown.
+    assert client.get.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Discovery document
+# ---------------------------------------------------------------------------
+
+
+def test_a_templated_issuer_is_rejected_with_the_fix_in_the_message(settings):
+    """Entra's multi-tenant `common` endpoint returns this (ADR 0006 S1.1)."""
+    auth = OIDCAuth(settings=settings, store=Mock())
+    templated = {
+        "issuer": "https://login.microsoftonline.com/{tenantid}/v2.0",
+        "jwks_uri": JWKS_URI,
+    }
+
+    client = MagicMock()
+    client.__enter__.return_value = client
+    client.get.return_value = MagicMock(json=MagicMock(return_value=templated))
+    httpx = MagicMock()
+    httpx.Client.return_value = client
+
+    with patch("titiler.openeo.auth.httpx", httpx):
+        with pytest.raises(ValueError, match="single-tenant"):
+            _ = auth.config
+
+
+def test_discovery_document_is_cached(auth):
+    """Pre-seeded by the fixture; reading it again must not refetch."""
+    httpx = MagicMock()
+    with patch("titiler.openeo.auth.httpx", httpx):
+        assert auth.config["issuer"] == ISSUER
+        assert auth.config["issuer"] == ISSUER
+
+    httpx.Client.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# User identity
+# ---------------------------------------------------------------------------
+
+
+def test_user_id_comes_from_the_configured_claim(settings, mock_key):
+    settings.oidc.user_id_claim = "oid"
+    store = Mock()
+    auth = OIDCAuth(settings=settings, store=store)
+    auth._config_cache = dict(DISCOVERY)
+    auth._config_fetched_at = time.monotonic()
+
+    token = create_mock_token(_payload(oid="entra-object-id", name="Alice"))
+    with patch.object(OIDCAuth, "_get_key", return_value=mock_key):
+        user = auth.validate(f"oidc/oidc/{token}")
+
+    assert user.user_id == "entra-object-id"
+    store.track_user_login.assert_called_once()
+
+
+def test_user_id_defaults_to_sub(auth, mock_key):
+    token = create_mock_token(_payload(sub="subject-1"))
+    with patch.object(OIDCAuth, "_get_key", return_value=mock_key):
+        user = auth.validate(f"oidc/oidc/{token}")
+
+    assert user.user_id == "subject-1"
+
+
+# ---------------------------------------------------------------------------
+# Settings
+# ---------------------------------------------------------------------------
+
+
+def test_auth_settings_no_longer_clobbers_its_oidc_argument():
+    config = OIDCConfig(client_id="mine", wk_url=WK_URL)
+    assert AuthSettings(method="oidc", oidc=config).oidc is config
+
+
+def test_oidc_method_requires_client_id_and_wk_url():
+    with pytest.raises(ValidationError, match="TITILER_OPENEO_AUTH_OIDC_WK_URL"):
+        AuthSettings(method="oidc", oidc=OIDCConfig(client_id="mine"))
+
+    with pytest.raises(ValidationError, match="TITILER_OPENEO_AUTH_OIDC_CLIENT_ID"):
+        AuthSettings(method="oidc", oidc=OIDCConfig(wk_url=WK_URL))
+
+
+def test_basic_method_needs_no_oidc_config():
+    assert AuthSettings(method="basic").method == "basic"
+
+
+def test_audiences_parse_space_separated():
+    config = OIDCConfig(client_id="c", wk_url=WK_URL, audiences=["a", "b"])
+    assert config.audiences == ["a", "b"]
+
+
+# ---------------------------------------------------------------------------
+# AuthToken
+# ---------------------------------------------------------------------------
 
 
 def test_auth_token_empty_string_validation():
@@ -115,3 +345,83 @@ def test_auth_token_from_token():
     assert token.method == "oidc"
     assert token.provider == "realm"
     assert token.token == "my_access_token"
+
+
+# ---------------------------------------------------------------------------
+# Error reporting
+# ---------------------------------------------------------------------------
+
+
+def test_a_bad_signature_reports_a_usable_message(auth):
+    """`str(InvalidSignature())` is empty, which used to surface as "401:"."""
+    from cryptography.exceptions import InvalidSignature
+
+    key = Mock()
+    key.verify = Mock(side_effect=InvalidSignature())
+
+    with pytest.raises(Exception) as excinfo:
+        auth._verify_token(create_mock_token(_payload()), key)
+
+    message = str(excinfo.value)
+    assert "signature verification failed" in message
+    # The token's own facts, so the cause is readable off the error.
+    assert "kid='test-key'" in message
+    assert "nonce_in_header=False" in message
+
+
+def test_a_nonced_header_is_named_as_the_cause(auth):
+    """Entra signs its own-resource tokens over a header whose `nonce` has been
+    replaced by its SHA-256, so a correct key still cannot verify them."""
+    explanation = OIDCAuth._explain_bad_signature(
+        {"alg": "RS256", "kid": "k1", "nonce": "abc"},
+        {
+            "aud": "00000003-0000-0000-c000-000000000000",
+            "iss": "https://sts.windows.net/t/",
+        },
+    )
+    assert "`nonce` in its JWT header" in explanation
+    assert "by design and not a misconfiguration" in explanation
+    assert "nonce_in_header=True" in explanation
+
+
+def test_a_plain_bad_signature_does_not_blame_entra(auth):
+    """Without a nonce the honest answer is "the key did not verify it"."""
+    explanation = OIDCAuth._explain_bad_signature(
+        {"alg": "RS256", "kid": "k1"}, {"aud": "client", "iss": "https://idp/"}
+    )
+    assert "nonce" not in explanation.split("Token facts:")[0]
+    assert "did not verify this token" in explanation
+
+
+def test_the_explanation_never_echoes_the_signature(auth):
+    """It is built from header/payload only -- no token material."""
+    explanation = OIDCAuth._explain_bad_signature(
+        {"alg": "RS256", "kid": "k1", "nonce": "s3cret-nonce"},
+        {"aud": "a", "iss": "b", "appid": "c"},
+    )
+    assert "s3cret-nonce" not in explanation
+
+
+def test_validate_does_not_double_wrap_an_http_exception(auth, mock_key):
+    """Re-wrapping produced details like "401: 401:", hiding the real cause."""
+    from fastapi.exceptions import HTTPException
+
+    with patch.object(
+        OIDCAuth, "_get_key", side_effect=HTTPException(401, "Unable to find key")
+    ):
+        with pytest.raises(HTTPException) as excinfo:
+            auth.validate(f"oidc/oidc/{create_mock_token(_payload())}")
+
+    assert excinfo.value.detail == "Unable to find key"
+
+
+def test_a_blank_exception_still_yields_a_named_detail(auth, mock_key):
+    class Blank(Exception):
+        def __str__(self):
+            return ""
+
+    with patch.object(OIDCAuth, "_get_key", side_effect=Blank()):
+        with pytest.raises(Exception) as excinfo:
+            auth.validate(f"oidc/oidc/{create_mock_token(_payload())}")
+
+    assert "Blank during token validation" in str(excinfo.value)

--- a/tests/test_client_compat.py
+++ b/tests/test_client_compat.py
@@ -1,0 +1,123 @@
+"""Tests for titiler.openeo.client_compat.
+
+The openEO client is not a dependency of this project, so these exercise the
+patch against a faithful stand-in for `OidcProviderInfo` -- one that reproduces
+the intersection at `openeo/rest/auth/oidc.py` `__init__`. The real class is
+also patched, but only when the client happens to be installed.
+"""
+
+import pytest
+
+from titiler.openeo.client_compat import patch_openeo_client_scopes
+
+ENTRA_SUPPORTED = ["openid", "profile", "email", "offline_access"]
+CUSTOM_SCOPE = "api://4c866cbc-a39d-4eff-b598-73e23309b51c/openeo"
+
+
+def _make_stub(supported=None):
+    """A stand-in reproducing upstream's scope intersection."""
+    supported = supported if supported is not None else ENTRA_SUPPORTED
+
+    class OidcProviderInfoStub:
+        def __init__(self, issuer=None, discovery_url=None, scopes=None, **kwargs):
+            self.issuer = issuer
+            self.kwargs = kwargs
+            self._supported_scopes = supported
+            self._scopes = {"openid"}.union(scopes or []).intersection(
+                self._supported_scopes
+            )
+
+        def get_scopes_string(self, request_refresh_token: bool = False) -> str:
+            scopes = self._scopes
+            if request_refresh_token and "offline_access" in self._supported_scopes:
+                scopes = scopes | {"offline_access"}
+            return " ".join(sorted(scopes))
+
+    return OidcProviderInfoStub
+
+
+def test_the_stub_reproduces_the_upstream_defect():
+    """Guard the premise: without the patch the custom scope is dropped."""
+    cls = _make_stub()
+    provider = cls(issuer="https://idp", scopes=["openid", "email", CUSTOM_SCOPE])
+    assert provider.get_scopes_string() == "email openid"
+
+
+def test_patch_restores_the_backend_declared_scopes():
+    cls = _make_stub()
+    assert patch_openeo_client_scopes(cls) is True
+
+    provider = cls(issuer="https://idp", scopes=["openid", "email", CUSTOM_SCOPE])
+    assert CUSTOM_SCOPE in provider.get_scopes_string()
+    assert provider.get_scopes_string() == f"{CUSTOM_SCOPE} email openid"
+
+
+def test_patch_leaves_offline_access_handling_to_upstream():
+    cls = _make_stub()
+    patch_openeo_client_scopes(cls)
+
+    provider = cls(issuer="https://idp", scopes=["openid", CUSTOM_SCOPE])
+    assert provider.get_scopes_string(request_refresh_token=True) == (
+        f"{CUSTOM_SCOPE} offline_access openid"
+    )
+
+
+def test_openid_is_always_present():
+    cls = _make_stub()
+    patch_openeo_client_scopes(cls)
+
+    provider = cls(issuer="https://idp", scopes=[CUSTOM_SCOPE])
+    assert "openid" in provider.get_scopes_string().split()
+
+
+def test_no_declared_scopes_still_yields_openid():
+    cls = _make_stub()
+    patch_openeo_client_scopes(cls)
+
+    assert cls(issuer="https://idp").get_scopes_string() == "openid"
+
+
+def test_patch_is_idempotent():
+    """Notebooks get re-run; a second call must not stack wrappers."""
+    cls = _make_stub()
+    assert patch_openeo_client_scopes(cls) is True
+    assert patch_openeo_client_scopes(cls) is False
+
+    provider = cls(issuer="https://idp", scopes=["openid", CUSTOM_SCOPE])
+    assert CUSTOM_SCOPE in provider.get_scopes_string()
+
+
+def test_patch_preserves_the_rest_of_init():
+    """Discovery, issuer resolution and default_clients stay upstream's job."""
+    cls = _make_stub()
+    patch_openeo_client_scopes(cls)
+
+    provider = cls(
+        issuer="https://idp", scopes=["openid"], default_clients=[{"id": "x"}]
+    )
+    assert provider.issuer == "https://idp"
+    assert provider.kwargs["default_clients"] == [{"id": "x"}]
+    assert provider._supported_scopes == ENTRA_SUPPORTED
+
+
+def test_a_provider_that_advertises_everything_is_unaffected():
+    """Against a compliant provider the patch changes nothing observable."""
+    supported = ["openid", "profile", "email", "offline_access", CUSTOM_SCOPE]
+    declared = ["openid", "email", CUSTOM_SCOPE]
+
+    before = _make_stub(supported)(issuer="https://idp", scopes=declared)
+    after_cls = _make_stub(supported)
+    patch_openeo_client_scopes(after_cls)
+    after = after_cls(issuer="https://idp", scopes=declared)
+
+    assert after.get_scopes_string() == before.get_scopes_string()
+
+
+def test_importing_the_module_has_no_side_effects():
+    """The patch must only ever be applied by an explicit call."""
+    openeo = pytest.importorskip("openeo")  # noqa: F841
+    from openeo.rest.auth.oidc import OidcProviderInfo
+
+    import titiler.openeo.client_compat  # noqa: F401
+
+    assert not getattr(OidcProviderInfo, "_titiler_openeo_scopes_patched", False)

--- a/titiler/openeo/auth.py
+++ b/titiler/openeo/auth.py
@@ -3,9 +3,11 @@
 import abc
 import base64
 import json
+import logging
 import time
 from base64 import b64decode
 from enum import Enum
+from threading import Lock
 from typing import Any, Dict, Literal, Optional
 
 from attrs import define, field
@@ -38,6 +40,35 @@ except ImportError:  # pragma: nocover
     hashes = None  # type: ignore
     padding = None  # type: ignore
     RSAPublicNumbers = None  # type: ignore
+
+
+logger = logging.getLogger(__name__)
+
+#: The only signature algorithm this backend verifies. Pinned from the token
+#: header rather than trusted from it: verification below is hardcoded to
+#: RS256 (PKCS1v15 + SHA256), so accepting a token that *claims* anything else
+#: would be an algorithm-confusion hole. Microsoft Entra advertises exactly
+#: this one (`id_token_signing_alg_values_supported: ["RS256"]`), as does the
+#: Keycloak realm already in production. Supporting a second algorithm is the
+#: documented trigger to replace this module with a JWT library
+#: (docs/adr/0006-microsoft-entra-oidc.md S2.1).
+_SUPPORTED_ALG = "RS256"
+
+#: Clock-skew allowance, in seconds, for `exp` and `nbf`.
+_CLOCK_SKEW_LEEWAY = 60.0
+
+#: How long a provider's discovery document is trusted before it is refetched.
+_DISCOVERY_TTL = 3600.0
+
+#: Minimum gap between JWKS refetches triggered by an unknown `kid`. Rotation
+#: is continuous but slow; without this floor, a flood of tokens carrying junk
+#: kids would become a flood of requests to the provider (ADR 0006 S3.1).
+_JWKS_REFRESH_COOLDOWN = 300.0
+
+#: Issuer placeholder returned by Entra's multi-tenant `common` endpoint.
+#: Useless for comparison and invalid to advertise, so it is rejected with a
+#: message naming the fix rather than silently accepted (ADR 0006 S2.3).
+_TEMPLATED_ISSUER_MARKER = "{tenantid}"
 
 
 class AuthMethod(Enum):
@@ -90,9 +121,26 @@ class OIDCAuth(Auth):
     """OpenID Connect authentication implementation."""
 
     method: AuthMethod = field(default=AuthMethod("oidc"), init=False)
-    settings: AuthSettings = field(default=AuthSettings())
+    # `factory`, not `default`: a bare `AuthSettings()` here is evaluated at
+    # class-definition time, i.e. at import, which reads the environment before
+    # any caller can configure it and would now also run this class's own
+    # startup validation at the wrong moment.
+    settings: AuthSettings = field(factory=AuthSettings)
     _config_cache: Optional[Dict] = field(default=None, init=False)
+    _config_fetched_at: float = field(default=0.0, init=False)
     _jwks_cache: Optional[Dict] = field(default=None, init=False)
+    # When the JWKS was last refetched *because a `kid` was unknown*. Tracked
+    # separately from the initial fetch: the cooldown exists to damp a storm of
+    # junk kids, and must not block the first genuine rotation, which typically
+    # arrives moments after the cache was first filled. `None` means "never
+    # refreshed", so the first refresh always proceeds.
+    _jwks_refreshed_at: Optional[float] = field(default=None, init=False)
+    # Two locks, never nested: `get_jwks` needs `jwks_uri` from the discovery
+    # document, so a single lock covering both would deadlock on itself
+    # (`threading.Lock` is not reentrant). `config` is always resolved before
+    # `_jwks_lock` is acquired.
+    _config_lock: Lock = field(factory=Lock, init=False)
+    _jwks_lock: Lock = field(factory=Lock, init=False)
     _oidc_config: OIDCConfig = field(init=False)
 
     def __attrs_post_init__(self):
@@ -109,13 +157,41 @@ class OIDCAuth(Auth):
 
     @property
     def config(self) -> Dict:
-        """Get OIDC configuration."""
-        if self._config_cache is None:
+        """The provider's discovery document, cached for `_DISCOVERY_TTL`.
+
+        Previously cached for the life of the process, which left a deployment
+        permanently broken if a provider moved its `jwks_uri`.
+        """
+        with self._config_lock:
+            cached = self._config_cache
+            age = time.monotonic() - self._config_fetched_at
+            if cached is not None and age <= _DISCOVERY_TTL:
+                return cached
+
             with httpx.Client() as client:
                 response = client.get(str(self._oidc_config.wk_url))
                 response.raise_for_status()
-                self._config_cache = response.json()
-        return self._config_cache
+                config: Dict = response.json()
+
+            self._check_discovery(config)
+            self._config_cache = config
+            self._config_fetched_at = time.monotonic()
+            return config
+
+    @staticmethod
+    def _check_discovery(config: Dict) -> None:
+        """Reject a discovery document this backend cannot validate against."""
+        issuer = config.get("issuer") or ""
+        if _TEMPLATED_ISSUER_MARKER in issuer:
+            raise ValueError(
+                f"The OIDC discovery document advertises a templated issuer "
+                f"({issuer!r}), which cannot be validated against a token's `iss` "
+                "and cannot be advertised to openEO clients. This is what "
+                "Microsoft Entra's multi-tenant `common` endpoint returns; "
+                "configure a single-tenant discovery URL instead, e.g. "
+                "https://login.microsoftonline.com/<tenant_id>/v2.0/"
+                ".well-known/openid-configuration"
+            )
 
     def ping(self, timeout: float = 2.0) -> None:
         """Verify the OIDC well-known endpoint is reachable. Raises on failure."""
@@ -124,54 +200,109 @@ class OIDCAuth(Auth):
             response = client.get(str(self._oidc_config.wk_url))
             response.raise_for_status()
 
-    def get_jwks(self) -> Dict:
-        """Get JSON Web Key Set."""
-        if self._jwks_cache is None:
+    def get_jwks(self, refresh: bool = False) -> Dict:
+        """Get the JSON Web Key Set, optionally forcing a refetch.
+
+        Args:
+            refresh: Refetch even if a set is already cached. Rate-limited to
+                one refetch per `_JWKS_REFRESH_COOLDOWN`; inside the cooldown
+                the cached set is returned unchanged.
+        """
+        # Resolved before the lock is taken: `config` takes `_config_lock`, and
+        # nesting the two would deadlock on a non-reentrant lock.
+        jwks_uri = self.config["jwks_uri"]
+
+        with self._jwks_lock:
+            cached = self._jwks_cache
+            if cached is not None:
+                if not refresh:
+                    return cached
+                if (
+                    self._jwks_refreshed_at is not None
+                    and time.monotonic() - self._jwks_refreshed_at
+                    < _JWKS_REFRESH_COOLDOWN
+                ):
+                    return cached
+
             with httpx.Client() as client:
-                response = client.get(self.config["jwks_uri"])
+                response = client.get(jwks_uri)
                 response.raise_for_status()
-                self._jwks_cache = response.json()
-        return self._jwks_cache
+                jwks: Dict = response.json()
+
+            self._jwks_cache = jwks
+            if refresh:
+                self._jwks_refreshed_at = time.monotonic()
+
+            return jwks
+
+    @staticmethod
+    def _find_key(jwks: Dict, kid: str):
+        """Build the public key for `kid` from `jwks`, or ``None`` if absent."""
+        for jwk in jwks.get("keys", []):
+            if jwk.get("kid") != kid:
+                continue
+
+            if jwk.get("kty") != "RSA":
+                raise ValueError(f"Unsupported key type: {jwk.get('kty')}")
+
+            # Convert JWK to public key
+            numbers = RSAPublicNumbers(
+                e=int.from_bytes(
+                    base64.urlsafe_b64decode(jwk["e"] + "=" * (-len(jwk["e"]) % 4)),
+                    byteorder="big",
+                ),
+                n=int.from_bytes(
+                    base64.urlsafe_b64decode(jwk["n"] + "=" * (-len(jwk["n"]) % 4)),
+                    byteorder="big",
+                ),
+            )
+            return numbers.public_key()
+
+        return None
 
     def _get_key(self, kid: str):
-        """Get public key from JWKS."""
-        jwks = self.get_jwks()
-        for jwk in jwks["keys"]:
-            if jwk["kid"] == kid:
-                if jwk["kty"] != "RSA":
-                    raise ValueError(f"Unsupported key type: {jwk['kty']}")
+        """Get the public key for `kid`, refetching the JWKS if it is unknown.
 
-                # Convert JWK to public key
-                numbers = RSAPublicNumbers(
-                    e=int.from_bytes(
-                        base64.urlsafe_b64decode(jwk["e"] + "=" * (-len(jwk["e"]) % 4)),
-                        byteorder="big",
-                    ),
-                    n=int.from_bytes(
-                        base64.urlsafe_b64decode(jwk["n"] + "=" * (-len(jwk["n"]) % 4)),
-                        byteorder="big",
-                    ),
-                )
-                return numbers.public_key()
+        A `kid` that is not in the cached set is the *expected* steady state,
+        not an attack: providers rotate signing keys continuously -- Microsoft
+        Entra publishes six at a time. Without this refetch the cache goes
+        stale and every login fails until the process restarts
+        (docs/adr/0006-microsoft-entra-oidc.md S1.2 gap 1).
+        """
+        key = self._find_key(self.get_jwks(), kid)
+        if key is None:
+            logger.info("OIDC key id %r not in cached JWKS; refetching", kid)
+            key = self._find_key(self.get_jwks(refresh=True), kid)
 
-        raise HTTPException(
-            status_code=HTTP_401_UNAUTHORIZED,
-            detail="Unable to find appropriate key",
-        )
+        if key is None:
+            raise HTTPException(
+                status_code=HTTP_401_UNAUTHORIZED,
+                detail="Unable to find appropriate key",
+            )
+
+        return key
 
     def _verify_token(self, token: str, key) -> Dict:
-        """Verify JWT token signature and return payload."""
+        """Verify JWT token signature and claims, and return the payload."""
         try:
             # Split the JWT
             header_b64, payload_b64, signature_b64 = token.split(".")
 
             # Decode header and payload
-            json.loads(
+            header = json.loads(
                 base64.urlsafe_b64decode(header_b64 + "=" * (-len(header_b64) % 4))
             )
             payload = json.loads(
                 base64.urlsafe_b64decode(payload_b64 + "=" * (-len(payload_b64) % 4))
             )
+
+            # The signature check below is hardcoded to RS256, so the header's
+            # own claim must agree with it rather than be ignored.
+            if header.get("alg") != _SUPPORTED_ALG:
+                raise ValueError(
+                    f"Unsupported token algorithm {header.get('alg')!r}; "
+                    f"only {_SUPPORTED_ALG} is accepted"
+                )
 
             # Verify signature
             signature = base64.urlsafe_b64decode(
@@ -184,26 +315,98 @@ class OIDCAuth(Auth):
                 hashes.SHA256(),
             )
 
-            # Verify claims
-            aud = payload.get("aud", [])
-            aud_list = aud.split() if isinstance(aud, str) else aud
-            if not (
-                payload.get("azp") == self._oidc_config.client_id
-                or self._oidc_config.client_id in aud_list
-            ):
-                raise ValueError("Invalid audience")
-
-            current_time = time.time()
-            if payload.get("exp") and payload["exp"] < current_time:
-                raise ValueError("Token expired")
-
+            self._verify_claims(payload)
             return payload
 
-        except (ValueError, InvalidSignature) as err:
+        except InvalidSignature as err:
+            # `str(InvalidSignature())` is the empty string, so this needs its
+            # own message or the failure surfaces as a bare "401:". Report what
+            # the token actually says rather than guessing at the cause: the
+            # key id was found (or `_get_key` would have failed first), so the
+            # question is only ever *why* a known key does not verify it.
+            detail = self._explain_bad_signature(header, payload)
+            logger.warning("OIDC signature verification failed. %s", detail)
+            raise HTTPException(
+                status_code=HTTP_401_UNAUTHORIZED,
+                detail=detail,
+            ) from err
+        except ValueError as err:
             raise HTTPException(
                 status_code=HTTP_401_UNAUTHORIZED,
                 detail=str(err),
             ) from err
+
+    @staticmethod
+    def _explain_bad_signature(header: Dict, payload: Dict) -> str:
+        """Describe a signature failure using the token's own metadata.
+
+        Nothing secret is echoed -- no signature, no token, only the routing
+        claims the caller already holds. `aud` is what decides which key really
+        signed the token, so it is the single most useful fact to report.
+        """
+        aud = payload.get("aud")
+        facts = (
+            f"alg={header.get('alg')!r} kid={header.get('kid')!r} "
+            f"nonce_in_header={'nonce' in header} aud={aud!r} "
+            f"iss={payload.get('iss')!r} appid={payload.get('appid') or payload.get('azp')!r}"
+        )
+
+        if "nonce" in header:
+            # Microsoft's documented behaviour: for tokens audienced at one of
+            # its own resources, the signature is computed over a header whose
+            # `nonce` has been replaced by its SHA-256. A standard RS256
+            # verifier therefore cannot validate it *even with the correct
+            # key*, which is exactly the state this branch is in.
+            return (
+                "Token signature verification failed: this token carries a "
+                "`nonce` in its JWT header, which means Microsoft Entra issued "
+                "it for one of its own resources (typically Microsoft Graph). "
+                "Entra signs those over a modified header, so no third party "
+                "can verify them -- this is by design and not a "
+                "misconfiguration of this backend. Obtain a token audienced at "
+                "this backend instead (Expose an API on the app registration, "
+                "and note that the openEO Python client cannot request such a "
+                "scope -- see docs/src/openid-connect.md). "
+                f"Token facts: {facts}"
+            )
+
+        return (
+            "Token signature verification failed: the key id was found in the "
+            "provider's JWKS but did not verify this token. Check that the "
+            "token comes from the configured provider and has not been "
+            f"truncated or re-encoded in transit. Token facts: {facts}"
+        )
+
+    def _verify_claims(self, payload: Dict) -> None:
+        """Check `iss`, `aud`/`azp`, `exp` and `nbf`. Raises `ValueError`."""
+        # Issuer. Previously unchecked entirely, which meant a token from any
+        # issuer whose signing key happened to be in the cached JWKS passed.
+        expected_issuer = self.config.get("issuer")
+        if expected_issuer and payload.get("iss") != expected_issuer:
+            raise ValueError("Invalid issuer")
+
+        # Audience. `client_id` covers ID tokens; `audiences` covers access
+        # tokens audienced at an API instead of at the client (ADR 0006 S2.2).
+        allowed = {self._oidc_config.client_id, *self._oidc_config.audiences}
+        allowed.discard("")
+
+        aud = payload.get("aud") or []
+        aud_list = aud.split() if isinstance(aud, str) else list(aud)
+        if not (payload.get("azp") in allowed or allowed & set(aud_list)):
+            raise ValueError("Invalid audience")
+
+        # Expiry. Now required: a token with no `exp` never expires, and
+        # treating that as valid made the check optional in practice.
+        now = time.time()
+        exp = payload.get("exp")
+        if exp is None:
+            raise ValueError("Token has no 'exp' claim")
+        if exp < now - _CLOCK_SKEW_LEEWAY:
+            raise ValueError("Token expired")
+
+        nbf = payload.get("nbf")
+        if nbf is not None and nbf > now + _CLOCK_SKEW_LEEWAY:
+            raise ValueError("Token is not yet valid")
 
     def login(self, authorization: str = Header()) -> Any:
         """OIDC doesn't support direct login - must be done through provider."""
@@ -253,8 +456,17 @@ class OIDCAuth(Auth):
             if self.settings.oidc and self.settings.oidc.name_claim:
                 name_claim = payload.get(self.settings.oidc.name_claim)
 
+            # Configurable because `sub` is pairwise on some providers and
+            # every stored service is keyed on this value (ADR 0006 S2.4).
+            id_claim = self._oidc_config.user_id_claim or "sub"
+            user_id = payload.get(id_claim)
+            if not user_id:
+                raise ValueError(
+                    f"Token has no {id_claim!r} claim to identify the user"
+                )
+
             user = User(
-                user_id=payload["sub"],
+                user_id=user_id,
                 email=payload.get("email"),
                 name=name_claim,
             )
@@ -264,10 +476,17 @@ class OIDCAuth(Auth):
 
             return user
 
+        except HTTPException:
+            # Already a considered response with its own detail. Re-wrapping it
+            # produced messages like "401: 401:" -- the outer detail being
+            # `str()` of the inner exception -- which hid the real cause.
+            raise
         except Exception as err:
             raise HTTPException(
                 status_code=HTTP_401_UNAUTHORIZED,
-                detail=str(err),
+                # Some exceptions (notably cryptography's) stringify to "",
+                # which would otherwise produce an empty, useless detail.
+                detail=str(err) or f"{type(err).__name__} during token validation",
                 headers={"WWW-Authenticate": "Bearer"},
             ) from err
 
@@ -312,7 +531,9 @@ class BasicAuth(Auth):
     """Basic Auth implementation using AuthSettings."""
 
     method: AuthMethod = field(default=AuthMethod("basic"), init=False)
-    settings: AuthSettings = field(default=AuthSettings())
+    # `factory` for the same reason as OIDCAuth.settings: a bare call here is
+    # evaluated once, at import, against whatever environment happens to exist.
+    settings: AuthSettings = field(factory=AuthSettings)
 
     def login(self, authorization: str = Header()) -> CredentialsBasic:
         """Validate Login credentials."""

--- a/titiler/openeo/client_compat.py
+++ b/titiler/openeo/client_compat.py
@@ -1,0 +1,108 @@
+"""Client-side compatibility patches for the openEO **Python client**.
+
+Nothing here runs as part of the backend. This module exists so a notebook or
+script talking *to* a titiler-openeo deployment can work around a defect in the
+`openeo` client library, in one import and one call:
+
+    from titiler.openeo.client_compat import patch_openeo_client_scopes
+    patch_openeo_client_scopes()
+
+Importing this module has no side effects -- the patch is applied only when the
+function is called, so it can never surprise the server or a test run.
+
+See docs/adr/upstream/openeo-python-client-scope-intersection.md for the
+upstream report this works around.
+"""
+
+import logging
+from typing import Any, List, Optional, Set
+
+__all__ = ["patch_openeo_client_scopes"]
+
+logger = logging.getLogger(__name__)
+
+#: Set on the patched class so a second call is a no-op rather than wrapping
+#: the wrapper -- notebooks get re-run, and a stack of wrappers would still be
+#: correct but would make a traceback harder to read.
+_MARKER = "_titiler_openeo_scopes_patched"
+
+
+def patch_openeo_client_scopes(provider_info_cls: Optional[Any] = None) -> bool:
+    """Stop the openEO Python client discarding scopes its backend asked for.
+
+    ``OidcProviderInfo.__init__`` narrows the backend's advertised scopes to
+    those the identity provider lists in its discovery document::
+
+        self._scopes = {"openid"}.union(scopes or []).intersection(self._supported_scopes)
+
+    Microsoft Entra's ``scopes_supported`` is fixed at
+    ``["openid", "profile", "email", "offline_access"]`` and, per Microsoft,
+    "there's no concept of custom resources or custom scopes here" -- so an
+    ``api://<client_id>/<scope>`` scope is always discarded. Entra then issues a
+    token audienced at Microsoft Graph, whose signature no third party can
+    verify, and login fails at the backend with a signature error.
+
+    This restores the scopes the backend actually advertised. ``openid`` is
+    still forced, matching upstream, and ``get_scopes_string`` keeps its own
+    ``offline_access`` handling.
+
+    Args:
+        provider_info_cls: The class to patch. Defaults to
+            ``openeo.rest.auth.oidc.OidcProviderInfo``; injectable so the
+            behaviour can be tested without the client installed.
+
+    Returns:
+        ``True`` if the patch was applied, ``False`` if it was already in place.
+
+    Raises:
+        ImportError: If the openEO client is not installed and no class was
+            passed explicitly.
+    """
+    if provider_info_cls is None:
+        try:
+            from openeo.rest.auth.oidc import (  # type: ignore[import-untyped]
+                OidcProviderInfo,
+            )
+        except ImportError as exc:  # pragma: nocover
+            raise ImportError(
+                "The openEO Python client is not installed, so there is nothing "
+                "to patch. Install it with `pip install openeo` (or "
+                "`uv sync --group notebook`)."
+            ) from exc
+
+        provider_info_cls = OidcProviderInfo
+
+    if getattr(provider_info_cls, _MARKER, False):
+        return False
+
+    original_init = provider_info_cls.__init__
+
+    def __init__(  # noqa: N807
+        self,
+        issuer: Optional[str] = None,
+        discovery_url: Optional[str] = None,
+        scopes: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> None:
+        original_init(
+            self,
+            issuer=issuer,
+            discovery_url=discovery_url,
+            scopes=scopes,
+            **kwargs,
+        )
+        # Patched after the fact rather than by reimplementing __init__: the
+        # rest of it (discovery fetch, issuer resolution, default_clients) is
+        # upstream's business and must keep working unchanged.
+        requested: Set[str] = {"openid"} | set(scopes or [])
+        if requested != set(self._scopes):
+            logger.debug(
+                "openEO client scope intersection undone: %s -> %s",
+                sorted(self._scopes),
+                sorted(requested),
+            )
+        self._scopes = requested
+
+    provider_info_cls.__init__ = __init__
+    setattr(provider_info_cls, _MARKER, True)
+    return True

--- a/titiler/openeo/settings.py
+++ b/titiler/openeo/settings.py
@@ -19,6 +19,22 @@ class OIDCConfig(BaseSettings):
     title: str = "OIDC"
     description: str = "OpenID Connect (OIDC) Authorization Code Flow with PKCE"
 
+    # Additional accepted `aud` values, space-separated, beyond `client_id`.
+    # Needed for providers that issue *access* tokens audienced at an API
+    # rather than at the client -- Microsoft Entra uses the application ID URI
+    # (`api://<client_id>`). Empty by default, which accepts exactly what this
+    # backend accepted before the setting existed.
+    # See docs/adr/0006-microsoft-entra-oidc.md S2.2 change 6.
+    audiences: list[str] = []
+
+    # Which token claim becomes `User.user_id`. Services, UDPs and tile
+    # assignments are all keyed on it, so changing this on a running deployment
+    # orphans everything already stored. `sub` is the specification's answer and
+    # the default; Entra's `sub` is pairwise (stable per user *per application
+    # registration*), so a deployment that expects to re-register its app may
+    # prefer the tenant-stable `oid`. See ADR 0006 S2.4.
+    user_id_claim: str = "sub"
+
     model_config = SettingsConfigDict(
         env_prefix="TITILER_OPENEO_AUTH_OIDC_",
         env_file=".env",
@@ -81,8 +97,8 @@ class OIDCConfig(BaseSettings):
             Returns:
                 Processed value for the field
             """
-            # allow space-separated list parsing for scopes
-            if field_name == "scopes":
+            # allow space-separated list parsing for scopes and audiences
+            if field_name in ("scopes", "audiences"):
                 return value.split(" ") if value else None
 
             return super().prepare_field_value(
@@ -116,15 +132,35 @@ class AuthSettings(BaseSettings):
     )
 
     def __init__(self, *args, **kwargs):
-        """Initialize settings."""
-        kwargs["oidc"] = OIDCConfig()
+        """Initialize settings, defaulting `oidc` from the environment.
+
+        `setdefault`, not an unconditional assignment: overwriting `kwargs`
+        made `AuthSettings(oidc=...)` silently ignored, which in turn made
+        `validate_oidc_config` below and the `if not settings.oidc` guards in
+        `auth.py` dead code (docs/adr/0006-microsoft-entra-oidc.md S1.2 gap 8).
+        """
+        kwargs.setdefault("oidc", OIDCConfig())
         super().__init__(*args, **kwargs)
 
     @model_validator(mode="after")
     def validate_oidc_config(self):
-        """Validate OIDC configuration when method is oidc."""
-        if self.method == "oidc" and not self.oidc:
+        """Fail at startup, not at the first request, on incomplete OIDC config."""
+        if self.method != "oidc":
+            return self
+
+        if not self.oidc:
             raise ValueError("OIDC configuration required when method is 'oidc'")
+
+        missing = [
+            f"TITILER_OPENEO_AUTH_OIDC_{name.upper()}"
+            for name in ("client_id", "wk_url")
+            if not getattr(self.oidc, name)
+        ]
+        if missing:
+            raise ValueError(
+                "OIDC authentication is enabled but incompletely configured. "
+                f"Missing: {', '.join(missing)}."
+            )
         return self
 
 


### PR DESCRIPTION
Makes Microsoft Entra ID a usable OIDC provider. Design:
[ADR 0006](docs/adr/0006-microsoft-entra-oidc.md). Pairs with #371 (Planetary
Computer asset access); independent — they touch different regions of
`settings.py` and either can merge first.

This is hardening, not a new provider. The backend already speaks OIDC and
drives a CDSE Keycloak realm in production.

## The blocker

**`_jwks_cache` never refreshed.** It was populated once and held for the life
of the process. Entra publishes six signing keys and rotates them continuously,
so the first token signed by a key minted after the cache was filled 401s — and
so does every login after it, until the process restarts.

This is a latent bug for Keycloak too; it has simply not been hit. An unknown
`kid` now triggers exactly one refetch, behind a lock and a cooldown so a flood
of junk kids cannot become a flood of requests to the provider.

## Gaps closed regardless of provider

- **`iss` was never validated.** A token from any issuer whose key happened to
  be in the cached JWKS passed.
- **The header was parsed and discarded**, so `alg` went unchecked while
  verification was hardcoded to RS256 — the algorithm-confusion shape.
- **`exp` was optional** (`if payload.get("exp") and ...`), so a token that
  never expires validated. Now required, with 60s skew allowance; `nbf` checked.
- **The discovery document was cached forever**, with the same permanent-failure
  mode if a provider moves its `jwks_uri`.
- **`AuthSettings.__init__` overwrote its own `oidc` argument**, so
  `AuthSettings(oidc=...)` was silently ignored — which made the settings
  validator and two `if not settings.oidc` guards in `auth.py` dead code, and
  let a deployment with `method=oidc` and no `wk_url` start cleanly and fail on
  the first request. Now fails at startup, naming the missing variable.

## Entra-specific

- **`audiences`** — its access tokens are audienced at an API (`api://<client_id>`),
  not the client. Empty by default, preserving today's behaviour exactly.
- **`user_id_claim`** — its `sub` is *pairwise* (stable per user per app
  registration), and every stored service is keyed on `user_id`. Default stays
  `sub`; documented as unsafe to change on a running deployment.
- **Templated issuer rejected at startup.** The multi-tenant `common` endpoint
  returns the literal `https://login.microsoftonline.com/{tenantid}/v2.0`, which
  cannot be compared against `iss` or advertised to clients. The error names the
  fix rather than failing obscurely later.

## Diagnosability

Signature failures reported `401: 401:` — `str(InvalidSignature())` is the empty
string, and `validate` wrapped an already-`HTTPException` a second time. They now
report the token's own facts: `alg`, `kid`, `nonce_in_header`, `aud`, `iss`,
`appid`. No secrets echoed; also logged at WARNING.

This matters because Entra's failure mode is genuinely confusing: with no
resource scope requested it issues a **Graph-audienced** token, which carries a
`nonce` header and is signed over a modified header, so no third party can
verify it — by design, as the audience-confusion defence. Proven with a real RSA
key: our verifier accepts a normal token and rejects a nonce'd one *with the
correct key*, reproducing the exact symptom.

## `client_compat`

`patch_openeo_client_scopes()` works around an openEO **Python client** defect
that makes any Entra-protected backend unusable: `OidcProviderInfo.__init__`
intersects backend-declared scopes against the provider's `scopes_supported`,
and Entra's is fixed at `["openid","profile","email","offline_access"]` —
[Microsoft confirms](https://github.com/AzureAD/microsoft-identity-web/discussions/1689)
it has "no concept of custom resources or custom scopes here". The custom API
scope is silently dropped, so Entra falls back to a Graph token.

Import-side-effect free and idempotent; tested against a stand-in reproducing
the upstream intersection, so it needs no dependency on the client. Upstream
report drafted at `docs/adr/upstream/openeo-python-client-scope-intersection.md`.
Delete the helper once a fixed release is our floor.

## Why not a JWT library

`PyJWT`/`joserfc` would give rotation and claim validation for free and is the
choice most projects should make. Not taken here because every gap above is
4–15 lines, and adding a dependency to rewrite a correct, tested RS256 verifier
is a wider blast radius than the fixes. The trigger to revisit is explicit in
ADR 0006 §2.1: **the first provider that signs with anything other than RS256.**

## Behaviour change worth flagging

Requiring `exp` will reject tokens from any provider that issues them without
one. That is intended — such a token is not safely verifiable — but it is a
change, called out here rather than buried.

`uv run pytest` → 1117 passed, 13 skipped. `pre-commit run --all-files` clean.
32 auth tests, including rotation (one refetch, then cooldown) and a rejection
test each for `iss`, `alg`, `exp` and `aud`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
