### PR TITLE
fix: make the positional bands fallback reachable

### DIFF
--- a/tests/test_band_positional_fallback.py
+++ b/tests/test_band_positional_fallback.py
@@ -1,0 +1,63 @@
+"""`bands` positional fallback in SimpleSTACReader._get_options.
+
+`_get_options` builds a name -> index map from the asset's STAC band metadata,
+preferring `eo:common_name`, then `common_name`, then `name`, and falling back
+to the band's 1-based position when a band object carries none of those.
+
+The fallback key must be a string: `bands` values reach this code as strings
+(the openEO `bands` argument, rio-tiler's asset options), so an integer key can
+never match one and the fallback would be unreachable.
+"""
+
+import pystac
+import pytest
+
+from titiler.openeo.reader import SimpleSTACReader
+
+
+def _reader() -> SimpleSTACReader:
+    """A reader instance without running __attrs_post_init__ (no I/O needed)."""
+    return SimpleSTACReader.__new__(SimpleSTACReader)
+
+
+def _asset(bands: list[dict]) -> pystac.Asset:
+    return pystac.Asset(
+        href="s3://example/asset.tif",
+        media_type="image/tiff",
+        extra_fields={"bands": bands},
+    )
+
+
+def test_unnamed_bands_resolve_by_position():
+    """A band object with no name at all is selectable by its 1-based position."""
+    metadata = _asset([{"description": "first"}, {"description": "second"}])
+
+    _, method_options = _reader()._get_options(
+        {"name": "data", "bands": ["2"]}, metadata
+    )
+
+    assert method_options["indexes"] == [2]
+
+
+def test_named_bands_still_win_over_position():
+    """Names take precedence; the positional fallback only fills the gaps."""
+    metadata = _asset(
+        [
+            {"name": "red", "eo:common_name": "red"},
+            {"description": "unnamed"},
+        ]
+    )
+
+    _, method_options = _reader()._get_options(
+        {"name": "data", "bands": ["red", "2"]}, metadata
+    )
+
+    assert method_options["indexes"] == [1, 2]
+
+
+def test_unknown_band_still_raises():
+    """The fallback does not turn an unknown band name into a silent match."""
+    metadata = _asset([{"description": "first"}])
+
+    with pytest.raises(ValueError, match="not found in asset metadata"):
+        _reader()._get_options({"name": "data", "bands": ["nope"]}, metadata)

--- a/titiler/openeo/reader.py
+++ b/titiler/openeo/reader.py
@@ -383,11 +383,16 @@ class SimpleSTACReader(MultiBaseReader):
             # There is no standard for precedence between 'eo:common_name' and 'name'
             # in STAC specification, so we will use 'eo:common_name' if it exists,
             # otherwise fallback to 'name', and if not exist use the band index as last resource.
+            # The positional fallback key is stringified: `bands` values arrive as
+            # strings (the openEO `bands` argument, and rio-tiler's asset options),
+            # so an int key here can never be matched and the fallback was dead --
+            # requesting band "1" raised "not found in asset metadata" instead of
+            # selecting index 1.
             common_to_variable = {
                 b.get("eo:common_name")
                 or b.get("common_name")
                 or b.get("name")
-                or ix: ix
+                or str(ix): ix
                 for ix, b in enumerate(stac_bands, 1)
             }
             band_indexes: list[int] = []


### PR DESCRIPTION
## Problem

`SimpleSTACReader._get_options` maps requested band names to band indexes using the asset's STAC band metadata, preferring `eo:common_name`, then `common_name`, then `name`, and falling back to the band's 1-based position when a band object carries none of those:

```python
common_to_variable = {
    b.get("eo:common_name")
    or b.get("common_name")
    or b.get("name")
    or ix: ix                      # <- int key
    for ix, b in enumerate(stac_bands, 1)
}
```

The fallback key is an `int`, but the values it is looked up against are always strings — `bands` arrives as a list of strings from the openEO `bands` argument and from rio-tiler's asset options. `{1: 1}.get("1")` is `None`, so the fallback branch could never match and the documented "use the band index as last resource" behaviour was unreachable.

Reproducer against `main`:

```python
meta = pystac.Asset(
    href="x", media_type="image/tiff",
    extra_fields={"bands": [{"description": "a"}, {"description": "b"}]},
)
reader._get_options({"name": "data", "bands": ["1"]}, meta)
# ValueError: Band '1' not found in asset metadata, unable to use 'bands' option
```

## Fix

Stringify the fallback key. One character, plus a comment recording why it has to be a string.

## Scope

- Assets whose bands carry a name or common name are unaffected — names are matched before the fallback is consulted.
- An unknown band name still raises `ValueError`, so this does not turn a typo into a silent match.
- Full suite green: 1229 passed, 13 skipped.

## Tests

`tests/test_band_positional_fallback.py` covers the three cases: positional selection works, names still take precedence over position, and unknown names still raise. The first two fail on `main` and pass with the fix.

## Context

Found while auditing `titiler-eopf`'s copy of `_get_options` against upstream for a 0.14.1 → 0.17.0 migration. That copy already carries `str(ix)`; this brings the two back in line so the copy can be narrowed to the Zarr-specific part it actually needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)