### PR TITLE
ci: replace dead PyPI publish job with break-glass manual publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,43 +113,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-  publish:
-    needs: [tests]
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'release'
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
-      
-      - name: Install uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-        with:
-          version: "0.9.*" 
-          enable-cache: true
-          python-version: ${{ env.LATEST_PY_VERSION}}
-
-      - name: Install dependencies
-        run: |
-          uv sync
-
-      - name: Set tag version
-        id: tag
-        run: |
-          TAG_NAME="${GITHUB_REF#refs/*/}"
-          VERSION="${TAG_NAME#v}"
-          echo "version=${VERSION}"
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-
-      - name: Set module version
-        id: module
-        run: |
-          echo version=$(python -c'import titiler.openeo; print(titiler.openeo.__version__)') >> $GITHUB_OUTPUT
-
-      - name: Build and publish
-        if: steps.tag.outputs.version == steps.module.outputs.version
-        env:
-          UV_PUBLISH_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          UV_PUBLISH_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: |
-          rm -rf dist
-          uv build
-          uv publish dist/*
+# PyPI publishing lives in release-please.yml. It ran here on tag pushes, but
+# release-please creates tags with GITHUB_TOKEN, which does not start
+# workflows, so this job never ran. Use the `publish_tag` input of the
+# Release Please workflow to publish a tag by hand.

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,16 @@ on:
   push:
     branches:
       - main
+  # Break-glass: build an existing tag and publish it to PyPI when the
+  # automatic run failed. PyPI trusted publishing is bound to this workflow
+  # file name and to the pypi-release environment, so the manual path must
+  # stay in this file to use the same credentials.
+  workflow_dispatch:
+    inputs:
+      publish_tag:
+        description: "Existing tag to build and publish to PyPI (for example v0.17.0)"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -12,6 +22,7 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -27,12 +38,26 @@ jobs:
   build_package:
     needs: release-please
     runs-on: ubuntu-latest
-    if: ${{ needs.release-please.outputs.paths_released && contains(fromJSON(needs.release-please.outputs.paths_released), '.') }}
-    
+    # On push: run only when release-please cut a release for the root
+    # package. On workflow_dispatch: always run, for the tag given as input.
+    # release-please is skipped on workflow_dispatch, and a skipped dependency
+    # skips this job whatever the condition says, so the condition needs
+    # !cancelled() to stay reachable.
+    if: >-
+      ${{ !cancelled() && (
+        github.event_name == 'workflow_dispatch'
+        || (needs.release-please.result == 'success'
+            && needs.release-please.outputs.paths_released
+            && contains(fromJSON(needs.release-please.outputs.paths_released), '.'))
+      ) }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
-      
+        with:
+          # Empty on push, which checks out the default ref.
+          ref: ${{ inputs.publish_tag }}
+
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
@@ -42,6 +67,21 @@ jobs:
 
       - name: Install dependencies
         run: uv sync
+
+      # Guards against publishing a tag whose code carries a different
+      # version. Runs through `uv run` so it uses the project environment.
+      - name: Check that the tag matches the package version
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          PUBLISH_TAG: ${{ inputs.publish_tag }}
+        run: |
+          expected="${PUBLISH_TAG#v}"
+          actual="$(uv run python -c 'import titiler.openeo; print(titiler.openeo.__version__)')"
+          echo "tag=${expected} module=${actual}"
+          if [ "${expected}" != "${actual}" ]; then
+            echo "::error::Tag ${PUBLISH_TAG} holds version ${actual}"
+            exit 1
+          fi
 
       - name: Build package
         run: uv build

--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,6 @@ docs/src/notebooks/sar_backscatter_vv_vh_mask.tif
 docs/src/notebooks/band_sources_*.tif
 docs/src/notebooks/_tmp_decomposed_*.tif
 docs/src/notebooks/_tmp_fused_*.tif
+
+# local PyPI token used for break-glass publishing
+pypi.txt

--- a/uv.lock
+++ b/uv.lock
@@ -3709,7 +3709,7 @@ wheels = [
 
 [[package]]
 name = "titiler-openeo"
-version = "0.16.5"
+version = "0.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "defusedxml" },


### PR DESCRIPTION
## Why

v0.17.0 was tagged and released on 2026-08-11 but never reached PyPI. The upload job in `release-please.yml` did run, and it failed:

```
Checking dist/titiler_openeo-0.17.0-py3-none-any.whl:
ERROR InvalidDistribution: Invalid distribution metadata:
      '2.5' is not a valid metadata version
```

`hatchling` is unpinned above `>=1.25.0` and now emits `Metadata-Version: 2.5`. The pinned `pypa/gh-action-pypi-publish@v1.14.1` carried twine 6, which rejects 2.5. PyPI itself accepts 2.5, so only the local check blocked the upload. #369 already bumped the action to v1.14.2, which ships twine 7 for exactly this reason.

0.17.0 is now on PyPI, published by hand from the artifact that the failed run had already built.

## What this changes

**Removes the `publish` job from `ci.yml`.** It only ran on a `v*` tag push, and release-please creates tags with `GITHUB_TOKEN`, which does not start workflows. The job never ran — v0.16.5, v0.16.4 and v0.16.3 all reached PyPI with no tag-triggered CI run either. It also read the version with a bare `python -c 'import titiler.openeo'` outside the uv environment; a failed import yields an empty version, the comparison then fails, and the upload step is skipped while the job still reports success. It read as a fallback and was not one.

**Adds a `publish_tag` input to `release-please.yml`** through `workflow_dispatch`. It checks out that tag, confirms the tag matches `titiler.openeo.__version__` through `uv run`, builds, and uploads.

The manual path stays in `release-please.yml` on purpose. PyPI binds trusted publishing to the workflow file name and to the `pypi-release` environment, so a separate file would need a second publisher configured on pypi.org. This way there is nothing to set up, and recovery uses OIDC instead of a token on someone's laptop.

On `workflow_dispatch` the `release-please` job is skipped, which also skips the Docker and Helm jobs through their dependency. The manual path publishes to PyPI only.

## Notes

- The push path is unchanged. `build_package` needs `!cancelled()` in its condition because a skipped dependency otherwise skips the job whatever the condition says; the push branch of the condition still requires `needs.release-please.result == 'success'`.
- `actionlint` reports no errors. Its three shellcheck notes are pre-existing steps.
- Second commit syncs `uv.lock`, which still named 0.16.5 while `pyproject.toml` said 0.17.0. release-please does not update the lock file, so every `uv sync` produced a diff. Worth a follow-up to run `uv lock` in the release PR.

## Test plan

Merge, then run the Release Please workflow by hand with `publish_tag: v0.17.0`. It must fail at the upload with "File already exists", which proves the checkout, the version guard and the build all work without risking a bad publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)