### PR TITLE
refactor!: sign asset hrefs at ingest instead of threading a signer

### DIFF
--- a/.env.planetarycomputer
+++ b/.env.planetarycomputer
@@ -9,9 +9,11 @@ TITILER_OPENEO_EXCLUDE_COLLECTIONS="noaa-c-cap"
 # https://planetarycomputer.microsoft.com/docs/concepts/sas/
 #
 # No credentials are needed. Blob assets are private, but the SAS tokens that
-# unlock them are minted anonymously and attached to each href automatically --
-# signing switches on because TITILER_OPENEO_STAC_API_URL points at Planetary
-# Computer. See docs/adr/0005-asset-href-signing.md.
+# unlock them are minted anonymously and attached to each href automatically.
+# This line is what switches that on -- required since 0.18.0, where signing
+# stopped being inferred from the STAC API hostname (issue #377).
+# See docs/adr/0005-asset-href-signing.md.
+TITILER_OPENEO_ASSET_SIGNER="planetary-computer"
 #
 # Optional: raises SAS API rate limits. It does not change what a token grants.
 # TITILER_OPENEO_PC_SUBSCRIPTION_KEY=<your_subscription_key>

--- a/deployment/k8s/charts/ci/planetarycomputer-values.yaml
+++ b/deployment/k8s/charts/ci/planetarycomputer-values.yaml
@@ -13,6 +13,10 @@ stac:
   apiUrl: "https://planetarycomputer.microsoft.com/api/stac/v1"
 
 env:
+  # Turns SAS signing on for this deployment's blob assets. Required since
+  # 0.18.0, where signing stopped being inferred from the STAC API hostname
+  # (issue #377, docs/adr/0005-asset-href-signing.md S2.3).
+  TITILER_OPENEO_ASSET_SIGNER: "planetary-computer"
   # `noaa-c-cap` advertises a provider url with no colon after the scheme,
   # which fails openEO response validation and takes the whole GET /collections
   # response with it. Verified upstream 2026-08-10.

--- a/docs/adr/0005-asset-href-signing.md
+++ b/docs/adr/0005-asset-href-signing.md
@@ -73,9 +73,20 @@ every user.
 
 ## 2. Decision
 
-Add one narrow protocol and a shipped in-code registry, keyed on an observable
-fact of the href — its host. Thread the resulting signer explicitly down the
-read path.
+Add one narrow protocol and a shipped in-code registry. A deployment names the
+signer it needs; ingest stamps that name onto every item; the read path resolves
+the name to a signer when it opens an href.
+
+> **Revised 2026-08-14 (issue #377).** As first implemented, §2.2–§2.3 and §2.6
+> said something different: activation was **derived** from the catalogue
+> hostname, and the resulting signer was **threaded** as a parameter through
+> `_reader`, `_get_target_crs_bbox`, `_get_cube_resolutions`,
+> `_estimate_output_dimensions` and `SimpleSTACReader`. Review rejected both
+> halves — the first put a cloud provider's hostname in the application's
+> decision logic, the second spread a deployment concern across the generic read
+> path. Those sections now describe the revision; §2.5 records what it cost. §1,
+> §2.1 and §2.4 are unchanged: the problem, the "no hand-written per-collection
+> configuration" rule and the signer itself all survived.
 
 ### 2.1 Why this is not the plugin system ADR 0002 rejected
 
@@ -88,52 +99,80 @@ configuration**, so the same catalogue served from two deployments could behave
 differently.
 
 This design keeps that rule. There is no configuration binding a signer to a
-collection. A rule matches on the href's host, which is a fact of the data, and
-the registry ships in code. Adding a catalogue means adding a rule and a test
-fixture, exactly as `bandsources/sources.py` does for band sources.
+*collection*. A deployment names one signer for its whole catalogue, the
+registry of implementations ships in code, and each signer decides per href
+whether it has anything to add. Adding a catalogue means adding a signer and a
+test fixture, exactly as `bandsources/sources.py` does for band sources.
 
 ### 2.2 The seam
 
 ```python
 HrefSigner = Callable[[str], str]        # href -> href
 
-@dataclass(frozen=True)
-class SignerRule:
-    host: "re.Pattern[str]"                          # matched against urlparse(href).netloc
-    factory: Callable[[Optional[User]], HrefSigner]
+ITEM_SIGNER_KEY = "titiler:sign"         # STAC property carrying the choice
+SIGNERS: Dict[str, Callable[[], HrefSigner]]
 
-def rules_for_catalogue(stac_api_url: str) -> Tuple[SignerRule, ...]: ...
-def get_href_signer(rules, user=None) -> Optional[HrefSigner]: ...
+def stamp_signer_key(item, key) -> item             # at ingest, once per item
+def signer_for_item(item) -> Optional[HrefSigner]   # at open, once per reader
+def get_signer(key) -> Optional[HrefSigner]         # memoised key -> signer
 ```
 
-`get_href_signer` returns `None` when `rules` is empty. `None` is threaded as
-the default everywhere, and `_resolve_asset_href` returns exactly the string it
-returns today when it receives `None`. This mirrors
+**The item is the channel.** The readers that open hrefs are built at three
+fixed points inside the mosaic (`_reader`, `_get_target_crs_bbox`,
+`_get_cube_resolutions`) and run on a `ThreadPoolExecutor` the request context
+does not reach. rio-tiler creates that pool without `contextvars.copy_context()`
+(`rio_tiler/tasks.py`), so a contextvar cannot carry the decision either. The
+item already travels to every one of those points, and is the task argument, so
+it is the one channel that works without threading a parameter.
+
+**The stamp is a key, never a signed href.** A SAS token minted at ingest would
+be reused by every lazily-evaluated task and every retry, so a graph outliving
+its ~45-minute token would fail. Resolving the key at open time means the retry
+loop in `_reader`, which rebuilds the reader, re-signs (§3.1). It also keeps the
+stamp a plain string, which is what lets it survive the `Item.to_dict()` that
+`load_stac` performs.
+
+`get_signer` returns `None` for an unstamped item, and `_resolve_asset_href`
+then returns exactly the string it returned before signing existed. This mirrors
 `build_per_request_registry`'s "return the base object unchanged" gate
 (`reader_requirements.py:216-217`, ADR 0002 §4 increment 5): the strongest form
 of "a deployment that does not need this must produce a byte-identical read" is
 no wrapper at all, not a wrapper that happens to be a no-op.
 
-The returned signer leaves any href whose host matches no rule untouched. This
-is what keeps PC's own `tilejson` and `rendered_preview` assets (§1.2) unsigned.
+Each signer leaves any href it has nothing to add to untouched. That is what
+keeps PC's own `tilejson` and `rendered_preview` assets (§1.2) unsigned, and it
+is why the stamp is applied to every item rather than only to items that look
+like they need it — one judgement, in one place.
 
-### 2.3 Activation is scoped to the configured catalogue
+### 2.3 Activation is configured, not derived
 
-`rules_for_catalogue` returns the PC rule only when
-`TITILER_OPENEO_STAC_API_URL` names `planetarycomputer.microsoft.com`, and `()`
-otherwise. No new setting is introduced for enablement.
+`TITILER_OPENEO_ASSET_SIGNER` names a key of `SIGNERS`; empty — the default —
+means no signing. An unknown key raises `SigningError` at first use rather than
+reading as "signing off", which would surface only as an opaque HTTP 409.
 
-Two alternatives were considered and rejected:
+The original decision derived activation instead: the PC signer switched on when
+`TITILER_OPENEO_STAC_API_URL` named `planetarycomputer.microsoft.com`. The
+argument was that it "keeps *point at PC and it works* true" without adding a
+knob whose only correct value is derivable. Review rejected it (#377) on two
+grounds:
 
-- **Match on host alone, always.** A deployment reading its own Azure blob
-  containers would then make an outbound call to `planetarycomputer.microsoft.com`
-  carrying its href. Leaking an href to a third party as a side effect of a
-  registry default is not acceptable.
-- **A dedicated `TITILER_OPENEO_ASSET_SIGNERS` setting.** More explicit, but it
-  adds a knob whose only correct value is derivable from a setting the operator
-  already provides. Deriving it keeps "point at PC and it works" true.
+- **It is provider knowledge in the application's decision logic.** A hostname
+  belonging to one cloud vendor decided application behaviour.
+- **It was not actually derivable.** A PC mirror on another hostname could not
+  turn signing on at all, and a deployment reading PC-hosted blobs through a
+  different catalogue could not either — the cost §3.1 had already recorded as
+  an open risk.
 
-The trade-off accepted is that the activation rule is implicit. §3 records this.
+The alternative rejected in the original — matching on href host alone, always —
+stands rejected, and for the same reason: a deployment reading its own Azure
+blob containers must never make an outbound call to
+`planetarycomputer.microsoft.com` carrying its href as a side effect of a
+registry default. Configuration, not the shipped registry, is what turns a
+signer on.
+
+**Migration.** Deployments on 0.17.x that read Planetary Computer must now set
+`TITILER_OPENEO_ASSET_SIGNER=planetary-computer`. Without it, reads of private
+blob assets fail with HTTP 409. The startup log states which signer is active.
 
 ### 2.4 `PlanetaryComputerSigner`
 
@@ -159,43 +198,50 @@ The cache is **not** keyed by user. That is correct precisely because §1.2 show
 tokens are identity-blind; a delegated signer must key its own cache by user,
 and the code says so at the cache definition.
 
-### 2.5 The per-user seam
+### 2.5 The per-user seam, and its removal
 
-`SignerRule.factory` takes the authenticated `User` even though
-`PlanetaryComputerSigner` ignores it, and the signer is built per request rather
-than once per process. This is deliberate, and it is the one piece of this ADR
-built ahead of a shipped consumer.
+The original design threaded the authenticated `User` to a `factory(user)` on
+each rule, building the signer per request even though `PlanetaryComputerSigner`
+ignores its user. It was the one piece of this ADR built ahead of a shipped
+consumer: the argument was that the plumbing, not the signer, is the expensive
+part, and that a delegated backend — Planetary Computer Pro, or private Azure
+containers reached by an on-behalf-of exchange — would need that channel later.
 
-The justification is that the expensive and risky part is not the signer — it is
-the plumbing. Threading a per-request object from the authenticated endpoint,
-through `load_collection`, into a lazily-evaluated closure, and across a
-`ThreadPoolExecutor` boundary touches six call sites in three modules. A
-genuinely delegated backend does exist as a near-term target — Planetary
-Computer Pro, and private Azure containers reached by an on-behalf-of token
-exchange — and for those the caller's identity does determine access. Building
-the channel once, while the read path is already being changed, avoids doing the
-same surgery twice.
+**That channel is gone.** It was the same threading §2.3's revision removed, and
+keeping it would have meant keeping the parameter on every function purely for a
+hypothetical consumer. `SIGNERS` maps a key to a signer with no user involved.
 
-`contextvars` were considered for this and rejected: `create_tasks` and
-`mosaic_reader` submit to a `ThreadPoolExecutor`, which does not propagate
-context. This is the same constraint that makes rio-tiler need
-`@inherit_rasterio_env`.
+The limit this accepts, recorded rather than solved: **signing is now
+user-independent.** That is correct for every shipped case, because §1.2 proves
+public PC's tokens are identity-blind — anonymous, bearer-token and
+subscription-key calls all return the same token, so there is no entitlement to
+delegate. A genuinely delegated backend would need the caller's identity inside
+the worker thread, which neither an item stamp (it must stay JSON-serialisable)
+nor a contextvar (§2.2: the pool does not propagate context) can carry. Designing
+that is deferred until such a backend exists, when its real requirements are
+known — rather than guessed, which is what the removed seam did.
 
-### 2.6 Threading
+The token cache is likewise **not** keyed by user, for the same §1.2 reason; a
+delegated signer must key its own cache by user, and the code says so at the
+cache definition.
+
+### 2.6 Where the decision is applied
 
 | Site | Change |
 | --- | --- |
-| `reader.py::_resolve_asset_href` | `signer=None` parameter, applied after the `STAC_ALTERNATE_KEY` branch |
-| `reader.py::_item_has_untrustworthy_proj` | `signer=None`; use `_resolve_asset_href` instead of the raw href (§1.1) |
-| `reader.py::SimpleSTACReader` | `signer` attrs field, default `None` |
-| `reader.py::_estimate_output_dimensions` and its two helpers | `signer=None`, forwarded to the `SimpleSTACReader` constructions |
-| `reader.py::_reader` | `kwargs.pop("signer", None)` before `part()` |
-| `stacapi.py::LoadCollection`, `LoadStac` | `signer_rules` field; build the signer from `named_parameters["_openeo_user"]` |
-| `processes/implementations/io.py::load_url` | process-wide unbound signer — the one path with no user context |
-| `main.py` | build the rules once from `backend_settings.stac_api_url` |
+| `signing.py` | `SIGNERS` key→signer registry; `stamp_signer_key` / `signer_for_item`; `get_signer` memoised |
+| `settings.py::SigningSettings` | `TITILER_OPENEO_ASSET_SIGNER`, empty by default |
+| `stacapi.py::LoadCollection._get_items` | stamps every item — the single funnel for `load_collection` |
+| `stacapi.py::LoadStac` | `signer_key` field; stamps its single-item path, which bypasses `_get_items`; passes the key to its `LoadCollection` delegate |
+| `reader.py::SimpleSTACReader` | `signer` resolved in `__attrs_post_init__` from the item; `init=False` |
+| `reader.py::_resolve_asset_href` | unchanged — still takes the signer, now from `self.signer` |
+| `reader.py::_item_has_untrustworthy_proj` | unchanged — uses `_resolve_asset_href` rather than the raw href (§1.1) |
+| `processes/implementations/io.py::load_url` | reads the key from settings: no catalogue behind it, so no ingest step to stamp its synthetic item |
+| `main.py` | reads the key once from settings and injects it |
 
-`mosaic_reader` and `create_tasks` already forward `**kwargs` to the reader
-callable, so no rio-tiler change is needed.
+`_reader`, `_get_target_crs_bbox`, `_get_cube_resolutions` and
+`_estimate_output_dimensions` take **no** signing parameter. That is the point of
+the revision.
 
 ---
 
@@ -208,48 +254,62 @@ view/sun angle bands work there. `_item_has_untrustworthy_proj`'s
 `STAC_ALTERNATE_KEY` inconsistency is fixed. Deployments not pointing at PC get
 `None` and are unchanged.
 
-**Accepted costs.** A new module, and a `signer` parameter on six functions that
-did not need one. One outbound dependency on `planetarycomputer.microsoft.com`
-in the read path, whose availability now gates reads that would otherwise only
-need blob storage. Signed hrefs carry a query string that changes every time the
-token is refreshed, so GDAL's `/vsicurl/` chunk cache is keyed on a URL with a
-roughly forty-minute lifetime; reads immediately after a refresh start cold.
+**Accepted costs.** A new module, and a convention — a namespaced STAC property
+— that a reader must know to look for. One outbound dependency on
+`planetarycomputer.microsoft.com` in the read path, whose availability now gates
+reads that would otherwise only need blob storage. Signed hrefs carry a query
+string that changes every time the token is refreshed, so GDAL's `/vsicurl/`
+chunk cache is keyed on a URL with a roughly forty-minute lifetime; reads
+immediately after a refresh start cold. Since the revision: one more environment
+variable, and a breaking change for 0.17.x deployments that read PC (§2.3).
 
 **Deliberately not done.** Delegated per-user SAS minting, which §1.2 proves is
-not expressible against public PC. Signing based on anything other than the
-href's host. A configuration file or environment variable binding signers to
-collections (ADR 0002 §2.1). Use of the `/api/sas/v1/sign` endpoint. Write or
-delete SAS permissions — the minted token is read+list, and nothing in this
-backend writes to a catalogue.
+not expressible against public PC (§2.5). A configuration file or environment
+variable binding signers to *collections* (ADR 0002 §2.1) — the setting names one
+signer for the deployment, not a mapping. Use of the `/api/sas/v1/sign` endpoint.
+Write or delete SAS permissions — the minted token is read+list, and nothing in
+this backend writes to a catalogue.
 
 ### 3.1 Open risks
 
-- **The activation rule is implicit.** A deployment pointing at a PC *mirror* on
-  another hostname gets no signing and reads fail with HTTP 409, with nothing in
-  the configuration explaining why. Mitigated by logging once, at startup, which
-  rules are active. If a second catalogue ever needs signing under a hostname
-  that cannot be recognised, §2.3's rejected explicit setting should be
-  revisited rather than special-cased.
+- ~~**The activation rule is implicit.**~~ **Resolved by the §2.3 revision.** The
+  risk as recorded — a PC *mirror* on another hostname getting no signing, "with
+  nothing in the configuration explaining why" — was what #377 called in. There
+  is now a setting; the mirror sets it like any other deployment. The startup log
+  still names the active signer, and an unknown key now fails loudly instead of
+  reading as "off".
 - **A short read may outlive its token.** The five-minute margin covers ordinary
   tile reads. A long mosaic that expires mid-read raises `RasterioIOError`,
-  which `_reader`'s existing ten-attempt retry loop (`reader.py:1286-1301`)
-  handles: each attempt reconstructs `SimpleSTACReader`, which re-resolves and
-  therefore re-signs every href. The recovery path is real but incidental, so it
-  is asserted by a test rather than left to chance.
-- **The per-user seam has no consumer.** §2.5 argues the plumbing is worth
-  building early. If a delegated backend does not materialise, the `user`
-  parameter on `SignerRule.factory` is dead weight — small, but dead. The
-  abandon condition is explicit: if no delegated signer exists by the time a
-  third catalogue needs signing, collapse `factory` to take no argument.
+  which `_reader`'s existing ten-attempt retry loop handles: each attempt
+  reconstructs `SimpleSTACReader`, whose `__attrs_post_init__` re-resolves the
+  signer and therefore re-signs every href. This is now load-bearing rather than
+  incidental — it is the reason §2.2 stamps a key rather than a signed href —
+  and is asserted directly by
+  `test_every_retry_rebuilds_the_reader_so_an_expired_token_is_reminted`.
+- ~~**The per-user seam has no consumer.**~~ **Closed by removing it** (§2.5).
+  The abandon condition recorded here — "collapse `factory` to take no argument"
+  — is what happened, earlier than anticipated and for an unrelated reason. The
+  replacement risk is that signing is user-independent with no channel to make it
+  otherwise; §2.5 states what a delegated backend would have to build.
 - **Rate limits are unmeasured.** §1.2 shows a subscription key changes nothing
   about the token itself, but a single probe cannot measure a rate limit. A
   deployment minting one token per container per forty minutes is far below any
   plausible threshold; a deployment that somehow defeats the cache is not. The
   cache is therefore the mechanism that keeps this safe, not an optimisation.
+- **The stamp is a convention.** Nothing validates that an item carrying
+  `titiler:sign` came from this backend's own ingest. A catalogue that published
+  the property itself would be believed. The blast radius is bounded by `SIGNERS`
+  — an unknown key raises rather than doing anything — so the worst case is a
+  catalogue selecting a signer this deployment already ships, which then still
+  only signs hrefs it recognises. Worth revisiting if the stamp ever carries
+  something richer than a key.
 
 ---
 
 ## 4. Implementation plan
+
+Kept as the record of how this shipped in 0.17.0. Increments 3 and 4 were undone
+by the §2.3/§2.6 revision — the threading they describe no longer exists.
 
 | # | Increment | Gate / abandon condition |
 | --- | --- | --- |

--- a/docs/src/admin-guide.md
+++ b/docs/src/admin-guide.md
@@ -26,11 +26,27 @@ TITILER_OPENEO_STORE_URL="path-to-services-config"
 TITILER_OPENEO_TILE_STORE_URL="optional-tile-store-url"
 ```
 
+#### Asset Signing ([`SigningSettings`](https://github.com/sentinel-hub/titiler-openeo/blob/main/titiler/openeo/settings.py))
+
+Which signer this deployment's private assets need. Empty — the default — means
+no signing. Setting an unregistered name fails loudly at first use.
+
+```bash
+TITILER_OPENEO_ASSET_SIGNER=""  # "planetary-computer" for Microsoft Planetary Computer
+```
+
+> **Changed in 0.18.0.** Signing used to switch on by itself when
+> `TITILER_OPENEO_STAC_API_URL` named `planetarycomputer.microsoft.com`. It is
+> now configured explicitly
+> ([#377](https://github.com/sentinel-hub/titiler-openeo/issues/377)), so
+> deployments upgrading from 0.17.x must set this variable or their private asset
+> reads will fail with HTTP 409.
+
 #### Planetary Computer Settings ([`PlanetaryComputerSettings`](https://github.com/sentinel-hub/titiler-openeo/blob/main/titiler/openeo/settings.py))
 
-Only consulted when `TITILER_OPENEO_STAC_API_URL` points at Microsoft Planetary
-Computer, which is what activates asset signing. All optional — the defaults
-work with no credentials. See [Microsoft Planetary Computer](planetary-computer.md).
+Only consulted when `TITILER_OPENEO_ASSET_SIGNER` is `"planetary-computer"`. All
+optional — the defaults work with no credentials. See
+[Microsoft Planetary Computer](planetary-computer.md).
 
 ```bash
 TITILER_OPENEO_PC_SUBSCRIPTION_KEY=""  # Optional; raises SAS API rate limits

--- a/docs/src/planetary-computer.md
+++ b/docs/src/planetary-computer.md
@@ -31,21 +31,35 @@ from.
 
 ## How signing switches on
 
-There is no enable flag. Signing activates when `TITILER_OPENEO_STAC_API_URL`
-names `planetarycomputer.microsoft.com`, and the rule only ever fires for hrefs
-on `*.blob.core.windows.net`. Any other catalogue, and any asset served from
-somewhere else, is untouched.
+Set the signer your catalogue needs:
+
+```bash
+TITILER_OPENEO_ASSET_SIGNER=planetary-computer
+```
+
+Signing is off unless you set it. Once set, the signer only ever fires for hrefs
+on `*.blob.core.windows.net`; any asset served from somewhere else is untouched,
+including Planetary Computer's own `tilejson` and `rendered_preview`, which come
+from the API host.
 
 At startup the log says so:
 
 ```text
-Asset href signing enabled for https://planetarycomputer.microsoft.com/api/stac/v1: \.blob\.core\.windows\.net$
+Asset href signing enabled for https://planetarycomputer.microsoft.com/api/stac/v1: planetary-computer
 ```
 
-If you point at a Planetary Computer **mirror on a different hostname**, that
-line will be absent and reads will fail with HTTP 409. That is the known cost of
-deriving activation instead of configuring it — see
-[ADR 0005](https://github.com/sentinel-hub/titiler-openeo/blob/main/docs/adr/0005-asset-href-signing.md) §3.1.
+If that line is absent and your reads fail with HTTP 409, the variable is not
+set. A mistyped value fails loudly at first use rather than reading as "signing
+off".
+
+> **Changed in 0.18.0.** Earlier versions had no setting: signing switched on by
+> itself when `TITILER_OPENEO_STAC_API_URL` named
+> `planetarycomputer.microsoft.com`. That put a cloud provider's hostname in the
+> application's decision logic, and it left Planetary Computer **mirrors on other
+> hostnames** with no way to turn signing on at all
+> ([#377](https://github.com/sentinel-hub/titiler-openeo/issues/377)).
+> Deployments upgrading from 0.17.x must now set the variable above — see
+> [ADR 0005](https://github.com/sentinel-hub/titiler-openeo/blob/main/docs/adr/0005-asset-href-signing.md) §2.3.
 
 Tokens are container-scoped, read-only, and last about 45 minutes. One token is
 minted per storage container and reused for every asset in it, refreshed five

--- a/scripts/debug_graph.py
+++ b/scripts/debug_graph.py
@@ -99,8 +99,7 @@ def maybe_register_loaders() -> None:
         )
         return
 
-    from titiler.openeo.settings import BackendSettings
-    from titiler.openeo.signing import rules_for_catalogue, set_default_rules
+    from titiler.openeo.settings import BackendSettings, SigningSettings
     from titiler.openeo.stacapi import LoadCollection, LoadStac, stacApiBackend
 
     settings = BackendSettings()  # type: ignore[call-arg]
@@ -108,25 +107,22 @@ def maybe_register_loaders() -> None:
         str(settings.stac_api_url),
         exclude_collections=settings.exclude_collections,
     )
-    # Same derivation main.py does. Without it this script reads assets
+    # Same configuration main.py reads. Without it this script reads assets
     # unsigned, which on a credential-gated catalogue fails with an opaque
     # HTTP 409 that has nothing to do with the graph being debugged.
-    signer_rules = rules_for_catalogue(str(settings.stac_api_url))
-    set_default_rules(signer_rules)
+    signer_key = SigningSettings().asset_signer or None
 
     process_registry["load_collection"] = Process(
         spec=PROCESS_SPECIFICATIONS["load_collection"],
-        implementation=LoadCollection(
-            client, signer_rules=signer_rules
-        ).load_collection,
+        implementation=LoadCollection(client, signer_key=signer_key).load_collection,
     )
     process_registry["load_stac"] = Process(
         spec=PROCESS_SPECIFICATIONS["load_stac"],
-        implementation=LoadStac(signer_rules=signer_rules).load_stac,
+        implementation=LoadStac(signer_key=signer_key).load_stac,
     )
     print(
         f"[debug_graph] load_collection registered against {settings.stac_api_url}"
-        + (f" (href signing: {len(signer_rules)} rule(s))" if signer_rules else ""),
+        + (f" (href signing: {signer_key})" if signer_key else ""),
         file=sys.stderr,
     )
 

--- a/tests/test_reader_signing.py
+++ b/tests/test_reader_signing.py
@@ -1,33 +1,51 @@
 """The href-signing seam inside reader.py (docs/adr/0005-asset-href-signing.md S2.6).
 
 `titiler.openeo.signing` is unit-tested on its own in `test_signing.py`. These
-tests are about the *threading*: that a signer handed to `SimpleSTACReader`
-reaches every href the reader opens, and -- more importantly -- that `None`
-leaves every one of those hrefs exactly as it was before signing existed.
+tests are about how the reader *gets* its signer: from the key the item was
+stamped with at ingest, resolved at construction time -- and -- more importantly
+-- that an unstamped item leaves every href exactly as it was before signing
+existed.
 """
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
+import numpy
 import pystac
 import pytest
 from pystac import Item
+from rasterio.errors import RasterioIOError
 
-from titiler.openeo import reader
+from titiler.openeo import reader, signing
 from titiler.openeo.reader import (
     SimpleSTACReader,
     _item_has_untrustworthy_proj,
     _resolve_asset_href,
 )
+from titiler.openeo.signing import get_signer, stamp_signer_key
 
 HREF = "https://example.com/B02.tif"
 ALTERNATE = "s3://bucket/B02.tif"
+
+#: Key the tests below stamp items with, registered by the fixture.
+TEST_KEY = "test-signer"
 
 
 def _tag(href: str) -> str:
     """A signer that is obvious in an assertion."""
     return f"{href}?signed=1"
+
+
+@pytest.fixture(autouse=True)
+def register_test_signer():
+    """Make `TEST_KEY` resolvable, and keep the memoised resolver clean."""
+    signing.SIGNERS[TEST_KEY] = lambda: _tag
+    get_signer.cache_clear()
+    yield
+    signing.SIGNERS.pop(TEST_KEY, None)
+    get_signer.cache_clear()
 
 
 def _item(assets: dict, properties: dict | None = None) -> Item:
@@ -125,14 +143,24 @@ def test_untrustworthy_proj_check_still_skips_non_sar_items():
 
 
 def test_reader_defaults_to_no_signer():
+    """An unstamped item -- every deployment that needs no signing."""
     with SimpleSTACReader(_item({"B02": {"href": HREF}})) as src:
         assert src.signer is None
         assert src._get_asset_info("B02")["url"] == HREF
 
 
 def test_reader_signs_a_real_asset_url():
-    with SimpleSTACReader(_item({"B02": {"href": HREF}}), signer=_tag) as src:
+    item = stamp_signer_key(_item({"B02": {"href": HREF}}), TEST_KEY)
+    with SimpleSTACReader(item) as src:
         assert src._get_asset_info("B02")["url"] == f"{HREF}?signed=1"
+
+
+def test_reader_takes_no_signer_argument():
+    """The signer is derived from the item, never passed in (issue #377). A
+    caller that still tries to hand one over should fail loudly rather than
+    have it silently ignored."""
+    with pytest.raises(TypeError):
+        SimpleSTACReader(_item({"B02": {"href": HREF}}), signer=_tag)
 
 
 def test_reader_signs_derived_band_and_sibling_hrefs():
@@ -146,9 +174,11 @@ def test_reader_signs_derived_band_and_sibling_hrefs():
     raw = json.loads(
         (Path("tests/fixtures/sar/items/planetary_computer.json")).read_text()
     )
-    item = pystac.Item.from_dict({**raw, "collection": "sentinel-1-grd"})
+    item = stamp_signer_key(
+        pystac.Item.from_dict({**raw, "collection": "sentinel-1-grd"}), TEST_KEY
+    )
 
-    with SimpleSTACReader(item, signer=_tag) as src:
+    with SimpleSTACReader(item) as src:
         assert src._derived_bands, "fixture should resolve band-source bands"
         band = next(iter(src._derived_bands))
         info = src._get_derived_asset_info(band)
@@ -158,12 +188,12 @@ def test_reader_signs_derived_band_and_sibling_hrefs():
 
 
 # ---------------------------------------------------------------------------
-# _reader -- the kwargs boundary
+# _reader -- the kwargs boundary and the retry contract (ADR 0005 S3.1)
 # ---------------------------------------------------------------------------
 
 
 class _FakeSrc:
-    """Records the kwargs `part()` was given."""
+    """Records the kwargs it was built with and the ones `part()` was given."""
 
     def __init__(self, item, **kwargs):
         self.kwargs = kwargs
@@ -180,8 +210,9 @@ class _FakeSrc:
         raise RuntimeError("stop here")
 
 
-@pytest.mark.parametrize("signer", [None, _tag])
-def test_reader_consumes_signer_and_does_not_forward_it_to_part(monkeypatch, signer):
+def test_reader_passes_no_signer_to_the_reader_or_to_part(monkeypatch):
+    """`signer` is gone from this boundary entirely: the reader reads it off the
+    item, and `part()` never saw it in the first place."""
     built = {}
 
     def factory(item, **kwargs):
@@ -193,7 +224,45 @@ def test_reader_consumes_signer_and_does_not_forward_it_to_part(monkeypatch, sig
 
     item = {"id": "x", "properties": {"datetime": "2025-01-01T00:00:00Z"}}
     with pytest.raises(RuntimeError, match="stop here"):
-        reader._reader(item, (0, 0, 1, 1), assets=["B02"], signer=signer)
+        reader._reader(item, (0, 0, 1, 1), assets=["B02"])
 
-    assert built["src"].kwargs == {"signer": signer}
+    assert built["src"].kwargs == {}
     assert built["src"].part_kwargs == {"assets": ["B02"]}
+
+
+def test_every_retry_rebuilds_the_reader_so_an_expired_token_is_reminted(monkeypatch):
+    """The regression guard for stamping a *key* rather than a signed href.
+
+    A credential resolved once at ingest would be reused by every retry; because
+    the retry loop rebuilds the reader, and construction is what resolves the
+    signer, an attempt after a `RasterioIOError` signs afresh (ADR 0005 S3.1).
+    """
+    constructions = []
+    img = SimpleNamespace(
+        width=1, height=1, count=1, data=numpy.zeros((1, 1, 1), dtype="uint8")
+    )
+
+    class _FlakySrc(_FakeSrc):
+        def part(self, bbox, **kwargs):
+            constructions.append(self.signer_at_build)
+            if len(constructions) < 3:
+                raise RasterioIOError("transient")
+            return img
+
+    def factory(item, **kwargs):
+        src = _FlakySrc(item, **kwargs)
+        # What the real reader does in __attrs_post_init__, per construction.
+        src.signer_at_build = signing.signer_for_item(item)
+        return src
+
+    monkeypatch.setattr(reader, "SimpleSTACReader", factory)
+    monkeypatch.setattr(reader.time, "sleep", lambda _: None)
+
+    item = stamp_signer_key(
+        {"id": "x", "properties": {"datetime": "2025-01-01T00:00:00Z"}}, TEST_KEY
+    )
+    assert reader._reader(item, (0, 0, 1, 1)) is img
+
+    # Three attempts, each having resolved the signer for itself.
+    assert len(constructions) == 3
+    assert all(signer is _tag for signer in constructions)

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -12,12 +12,16 @@ import pytest
 from titiler.openeo import signing
 from titiler.openeo.settings import PlanetaryComputerSettings
 from titiler.openeo.signing import (
-    PLANETARY_COMPUTER,
+    ITEM_SIGNER_KEY,
+    SIGNERS,
     PlanetaryComputerSigner,
     SigningError,
-    get_href_signer,
-    rules_for_catalogue,
+    get_signer,
+    signer_for_item,
+    stamp_signer_key,
 )
+
+PC_KEY = "planetary-computer"
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -31,10 +35,16 @@ TILEJSON_HREF = (
 
 @pytest.fixture(autouse=True)
 def clear_token_cache():
-    """The token cache is module-level; keep tests independent of each other."""
+    """Both caches are module-level; keep tests independent of each other.
+
+    `get_signer` is memoised, so a signer built from one test's settings would
+    otherwise leak into the next.
+    """
     signing._TOKEN_CACHE.clear()
+    get_signer.cache_clear()
     yield
     signing._TOKEN_CACHE.clear()
+    get_signer.cache_clear()
 
 
 def _sas_response(token: str = "st=X&se=Y&sig=abc%3D", minutes: int = 45):
@@ -59,36 +69,67 @@ def _sas_response(token: str = "st=X&se=Y&sig=abc%3D", minutes: int = 45):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-    "url",
-    [
-        PC_STAC_API,
-        "https://planetarycomputer.microsoft.com/api/stac/v1/",
-        "https://PLANETARYCOMPUTER.microsoft.com/api/stac/v1",
-    ],
-)
-def test_rules_for_catalogue_matches_planetary_computer(url):
-    assert rules_for_catalogue(url) == (PLANETARY_COMPUTER,)
+def test_no_key_means_no_signer():
+    """The gate: no key -> None, so call sites run their unchanged path."""
+    assert get_signer(None) is None
+    assert get_signer("") is None
 
 
-@pytest.mark.parametrize(
-    "url",
-    [
-        "https://stac.dataspace.copernicus.eu/v1",
-        "https://earth-search.aws.element84.com/v1",
-        "https://stac.eoapi.dev",
-        "https://planetarycomputer.microsoft.com.evil.example/api/stac/v1",
-        "",
-    ],
-)
-def test_rules_for_catalogue_ignores_other_catalogues(url):
-    assert rules_for_catalogue(url) == ()
+def test_a_registered_key_resolves_to_its_signer():
+    assert isinstance(get_signer(PC_KEY), PlanetaryComputerSigner)
+    assert PC_KEY in SIGNERS
 
 
-def test_no_rules_means_no_signer():
-    """The gate: no rules -> None, so call sites run their unchanged path."""
-    assert get_href_signer(()) is None
-    assert get_href_signer([]) is None
+def test_an_unknown_key_raises_rather_than_silently_disabling_signing():
+    """A typo must not read as "signing off" -- that surfaces as an opaque 409
+    from blob storage, which is what SigningError exists to prevent."""
+    with pytest.raises(SigningError, match="planetary-computer"):
+        get_signer("planetray-computer")
+
+
+def test_activation_no_longer_depends_on_the_catalogue_hostname():
+    """Issue #377: a Planetary Computer URL does not by itself turn signing on,
+    and no hostname decides anything -- only the configured key does."""
+    assert not hasattr(signing, "rules_for_catalogue")
+    assert not hasattr(signing, "_PC_STAC_HOST")
+
+
+# ---------------------------------------------------------------------------
+# The item stamp (ADR 0005 S2.2)
+# ---------------------------------------------------------------------------
+
+
+def test_stamping_without_a_key_leaves_the_item_untouched():
+    item = {"type": "Feature", "id": "x", "properties": {}}
+    assert stamp_signer_key(item, None) == {
+        "type": "Feature",
+        "id": "x",
+        "properties": {},
+    }
+    assert signer_for_item(item) is None
+
+
+@pytest.mark.parametrize("as_dict", [True, False], ids=["dict", "pystac.Item"])
+def test_a_stamped_item_resolves_its_signer(as_dict):
+    """Both shapes reach the read path: load_collection carries pystac.Items,
+    load_stac hands `_reader` the output of `Item.to_dict()`."""
+    item = pystac.Item.from_dict(
+        json.loads((FIXTURES / "sentinel2/items/planetary_computer.json").read_text())
+    )
+    stamp_signer_key(item, PC_KEY)
+
+    subject = item.to_dict() if as_dict else item
+    assert isinstance(signer_for_item(subject), PlanetaryComputerSigner)
+
+
+def test_the_stamp_survives_a_dict_round_trip():
+    """The stamp is a plain string precisely so `to_dict()` preserves it."""
+    item = pystac.Item.from_dict(
+        json.loads((FIXTURES / "sentinel2/items/planetary_computer.json").read_text())
+    )
+    stamp_signer_key(item, PC_KEY)
+
+    assert item.to_dict()["properties"][ITEM_SIGNER_KEY] == PC_KEY
 
 
 # ---------------------------------------------------------------------------
@@ -99,7 +140,7 @@ def test_no_rules_means_no_signer():
 def test_signs_blob_href():
     with patch("titiler.openeo.signing.urllib.request.urlopen") as urlopen:
         urlopen.return_value = _sas_response(token="st=A&se=B&sig=zzz")
-        signer = get_href_signer(rules_for_catalogue(PC_STAC_API))
+        signer = get_signer(PC_KEY)
         signed = signer(BLOB_HREF)
 
     assert signed == f"{BLOB_HREF}?st=A&se=B&sig=zzz"
@@ -108,7 +149,7 @@ def test_signs_blob_href():
 def test_leaves_non_blob_hosts_untouched():
     """PC's own tilejson/rendered_preview assets are not on blob storage."""
     with patch("titiler.openeo.signing.urllib.request.urlopen") as urlopen:
-        signer = get_href_signer(rules_for_catalogue(PC_STAC_API))
+        signer = get_signer(PC_KEY)
         assert signer(TILEJSON_HREF) == TILEJSON_HREF
         assert (
             signer("https://sentinel-cogs.s3.us-west-2.amazonaws.com/x.tif")
@@ -123,7 +164,7 @@ def test_signing_is_idempotent():
     """An already-signed href is never given a second token."""
     already = f"{BLOB_HREF}?st=A&se=B&sig=existing"
     with patch("titiler.openeo.signing.urllib.request.urlopen") as urlopen:
-        signer = get_href_signer(rules_for_catalogue(PC_STAC_API))
+        signer = get_signer(PC_KEY)
         assert signer(already) == already
 
     urlopen.assert_not_called()
@@ -132,7 +173,7 @@ def test_signing_is_idempotent():
 def test_preserves_an_existing_query_string():
     with patch("titiler.openeo.signing.urllib.request.urlopen") as urlopen:
         urlopen.return_value = _sas_response(token="sig=zzz")
-        signer = get_href_signer(rules_for_catalogue(PC_STAC_API))
+        signer = get_signer(PC_KEY)
         signed = signer(f"{BLOB_HREF}?versionid=2")
 
     assert signed == f"{BLOB_HREF}?versionid=2&sig=zzz"
@@ -141,7 +182,7 @@ def test_preserves_an_existing_query_string():
 def test_blob_url_without_a_container_is_untouched():
     href = "https://sentinel2l2a01.blob.core.windows.net/"
     with patch("titiler.openeo.signing.urllib.request.urlopen") as urlopen:
-        signer = get_href_signer(rules_for_catalogue(PC_STAC_API))
+        signer = get_signer(PC_KEY)
         assert signer(href) == href
 
     urlopen.assert_not_called()
@@ -205,15 +246,15 @@ def test_token_is_reused_outside_the_expiry_margin():
     assert urlopen.call_count == 1
 
 
-def test_cache_is_shared_across_users():
-    """Public PC tokens are identity-blind, so one entry per container is right."""
-    from titiler.openeo.models.auth import User
-
-    rules = rules_for_catalogue(PC_STAC_API)
+def test_cache_is_shared_across_independently_resolved_signers():
+    """Public PC tokens are identity-blind, so one entry per container is right
+    however many readers resolve a signer for the same container (ADR 0005 S2.5).
+    """
     with patch("titiler.openeo.signing.urllib.request.urlopen") as urlopen:
         urlopen.return_value = _sas_response()
-        get_href_signer(rules, User(user_id="alice"))(BLOB_HREF)
-        get_href_signer(rules, User(user_id="bob"))(BLOB_HREF)
+        get_signer(PC_KEY)(BLOB_HREF)
+        get_signer.cache_clear()  # as if a separate reader resolved it afresh
+        get_signer(PC_KEY)(BLOB_HREF)
 
     assert urlopen.call_count == 1
 
@@ -303,7 +344,7 @@ def test_signs_every_blob_asset_of_a_real_item(fixture):
 
     with patch("titiler.openeo.signing.urllib.request.urlopen") as urlopen:
         urlopen.return_value = _sas_response(token="sig=tok")
-        signer = get_href_signer(rules_for_catalogue(PC_STAC_API))
+        signer = get_signer(PC_KEY)
         results = {
             key: signer(asset.get_absolute_href() or asset.href)
             for key, asset in item.assets.items()
@@ -326,7 +367,7 @@ def test_sar_annotation_assets_are_signed():
 
     with patch("titiler.openeo.signing.urllib.request.urlopen") as urlopen:
         urlopen.return_value = _sas_response(token="sig=tok")
-        signer = get_href_signer(rules_for_catalogue(PC_STAC_API))
+        signer = get_signer(PC_KEY)
         annotation = {
             key: signer(asset.href)
             for key, asset in item.assets.items()
@@ -337,12 +378,16 @@ def test_sar_annotation_assets_are_signed():
     assert all(href.endswith("?sig=tok") for href in annotation.values())
 
 
-def test_default_signer_is_none_until_rules_are_set():
-    signing.set_default_rules(())
-    assert signing.get_default_href_signer() is None
+def test_signing_is_off_by_default_and_on_only_when_configured(monkeypatch):
+    """The `load_url` path reads the deployment's choice straight from settings,
+    since it has no catalogue behind it to stamp an item (ADR 0005 S2.6)."""
+    from titiler.openeo.settings import SigningSettings
 
-    signing.set_default_rules(rules_for_catalogue(PC_STAC_API))
-    try:
-        assert signing.get_default_href_signer() is not None
-    finally:
-        signing.set_default_rules(())
+    monkeypatch.delenv("TITILER_OPENEO_ASSET_SIGNER", raising=False)
+    assert SigningSettings().asset_signer == ""
+    assert get_signer(SigningSettings().asset_signer or None) is None
+
+    monkeypatch.setenv("TITILER_OPENEO_ASSET_SIGNER", PC_KEY)
+    assert isinstance(
+        get_signer(SigningSettings().asset_signer or None), PlanetaryComputerSigner
+    )

--- a/tests/test_stacapi_signing.py
+++ b/tests/test_stacapi_signing.py
@@ -1,26 +1,27 @@
-"""The signer's journey from the authenticated request to the read path.
+"""The signing decision's journey from configuration to the read path.
 
 `test_signing.py` covers the signer itself and `test_reader_signing.py` covers
-`reader.py`'s end of the seam. This file covers the middle: that
-`load_collection`/`load_stac` build a signer from the `_openeo_user` named
-parameter, and that it survives into the lazily-evaluated mosaic task, which
-runs on a worker thread no request context reaches
-(docs/adr/0005-asset-href-signing.md S2.5).
+`reader.py`'s end of the seam. This file covers the middle: that ingest stamps
+the deployment's signer key onto every item, and that the stamp -- not a
+threaded parameter -- is what survives into the lazily-evaluated mosaic task,
+which runs on a worker thread no request context reaches
+(docs/adr/0005-asset-href-signing.md S2.2).
 """
 
-import re
 from unittest.mock import patch
 
+import pystac
 import pytest
 from openeo_pg_parser_networkx.pg_schema import BoundingBox
 from pystac import Item
 from rio_tiler.models import ImageData
 
 from titiler.openeo.models.auth import User
-from titiler.openeo.signing import SignerRule, rules_for_catalogue
+from titiler.openeo.signing import ITEM_SIGNER_KEY
 from titiler.openeo.stacapi import LoadCollection, LoadStac, stacApiBackend
 
 PC_STAC_API = "https://planetarycomputer.microsoft.com/api/stac/v1"
+PC_KEY = "planetary-computer"
 
 ITEM = {
     "type": "Feature",
@@ -50,49 +51,39 @@ ITEM = {
 
 
 # ---------------------------------------------------------------------------
-# _signer_for
+# Ingest stamps the items
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("loader_cls", [LoadCollection, LoadStac])
-def test_no_rules_means_no_signer(loader_cls):
-    loader = (
-        loader_cls(stac_api=stacApiBackend(url="https://example.com"))
-        if loader_cls is LoadCollection
-        else loader_cls()
-    )
-    assert loader._signer_for({"_openeo_user": User(user_id="alice")}) is None
-    assert loader._signer_for(None) is None
-
-
-def test_signer_is_built_from_the_authenticated_user():
-    """The user reaches the factory. Uses a synthetic rule rather than the
-    shipped one -- `SignerRule.factory` is a direct reference captured at import,
-    so the registry is passed in, exactly as `derive_bands` takes its own."""
-    seen = []
-
-    rule = SignerRule(
-        host=re.compile(r"example\.com$"),
-        factory=lambda user: (seen.append(user), lambda href: href)[1],
+@pytest.mark.parametrize("signer_key", [PC_KEY, None], ids=["configured", "unset"])
+def test_get_items_stamps_every_item_with_the_configured_key(monkeypatch, signer_key):
+    """`_get_items` is the single funnel every `load_collection` read passes
+    through, so the deployment's decision is applied there and nowhere below."""
+    monkeypatch.setattr(
+        stacApiBackend, "get_items", lambda *a, **k: [Item.from_dict(ITEM)]
     )
     loader = LoadCollection(
-        stac_api=stacApiBackend(url="https://example.com"), signer_rules=(rule,)
+        stac_api=stacApiBackend(url=PC_STAC_API), signer_key=signer_key
     )
 
-    user = User(user_id="alice")
-    assert loader._signer_for({"_openeo_user": user}) is not None
+    items = loader._get_items("test")
 
-    assert seen == [user]
+    assert len(items) == 1
+    if signer_key:
+        assert items[0].properties[ITEM_SIGNER_KEY] == signer_key
+    else:
+        assert ITEM_SIGNER_KEY not in items[0].properties
 
 
-def test_signer_is_still_built_for_an_unauthenticated_request():
-    """Public Planetary Computer needs no user; a missing one is not an error."""
-    loader = LoadCollection(
-        stac_api=stacApiBackend(url=PC_STAC_API),
-        signer_rules=rules_for_catalogue(PC_STAC_API),
+def test_an_unstamped_item_is_indistinguishable_from_before_signing_existed(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        stacApiBackend, "get_items", lambda *a, **k: [Item.from_dict(ITEM)]
     )
-    assert loader._signer_for(None) is not None
-    assert loader._signer_for({}) is not None
+    loader = LoadCollection(stac_api=stacApiBackend(url="https://example.com"))
+
+    assert loader._get_items("test")[0].to_dict()["properties"] == ITEM["properties"]
 
 
 # ---------------------------------------------------------------------------
@@ -109,17 +100,16 @@ def _mock_image(*args, **kwargs):
     )
 
 
-@pytest.mark.parametrize("with_rules", [True, False])
-def test_signer_reaches_the_mosaic_task(monkeypatch, with_rules):
-    """The task runs lazily on a worker thread, so the signer must be captured
-    in its closure -- not looked up when it runs."""
+@pytest.mark.parametrize("signer_key", [PC_KEY, None], ids=["configured", "unset"])
+def test_the_stamp_reaches_the_mosaic_task(monkeypatch, signer_key):
+    """The task runs lazily on a worker thread, so what it needs must travel on
+    the items themselves -- and `signer` must be gone from the kwargs, or a
+    credential resolved at ingest would be reused past its expiry."""
     monkeypatch.setattr(
-        LoadCollection, "_get_items", lambda *a, **k: [Item.from_dict(ITEM)]
+        stacApiBackend, "get_items", lambda *a, **k: [Item.from_dict(ITEM)]
     )
-
-    rules = rules_for_catalogue(PC_STAC_API) if with_rules else ()
     loader = LoadCollection(
-        stac_api=stacApiBackend(url=PC_STAC_API), signer_rules=rules
+        stac_api=stacApiBackend(url=PC_STAC_API), signer_key=signer_key
     )
 
     with patch(
@@ -138,38 +128,67 @@ def test_signer_reaches_the_mosaic_task(monkeypatch, with_rules):
         # RasterStack is lazy; force the task to run.
         dict(stack)
 
-    signer = mosaic.call_args.kwargs["signer"]
-    if with_rules:
-        assert callable(signer)
+    assert "signer" not in mosaic.call_args.kwargs
+
+    (mosaic_items,) = (mosaic.call_args.args[0],)
+    if signer_key:
+        assert all(i.properties[ITEM_SIGNER_KEY] == signer_key for i in mosaic_items)
     else:
-        assert signer is None
+        assert all(ITEM_SIGNER_KEY not in i.properties for i in mosaic_items)
+
+
+# ---------------------------------------------------------------------------
+# load_stac
+# ---------------------------------------------------------------------------
 
 
 def test_load_stac_accepts_named_parameters():
-    """`load_stac` had no `named_parameters` before this seam; the process
-    registry passes it positionally by name, so the signature must carry it."""
+    """The process registry passes it positionally by name, so the signature
+    must carry it."""
     import inspect
 
     assert "named_parameters" in inspect.signature(LoadStac().load_stac).parameters
 
 
-def test_load_stac_passes_its_rules_to_the_delegate():
+def test_load_stac_stamps_a_single_item(monkeypatch):
+    """This path never passes through `LoadCollection._get_items`, so it does
+    its own stamping -- otherwise a single-item URL would silently read
+    unsigned."""
+    loader = LoadStac(signer_key=PC_KEY)
+    monkeypatch.setattr(
+        LoadStac, "_load_stac_object", lambda self, url: Item.from_dict(ITEM)
+    )
+
+    captured = {}
+
+    def _capture(self, items, *a, **k):
+        captured["items"] = items
+        return "stack"
+
+    monkeypatch.setattr(LoadStac, "_process_spatial_extent", _capture)
+
+    loader.load_stac(
+        url="https://example.com/item.json",
+        spatial_extent=BoundingBox(west=0, south=0, east=1, north=1, crs="EPSG:4326"),
+    )
+
+    assert captured["items"][0]["properties"][ITEM_SIGNER_KEY] == PC_KEY
+
+
+def test_load_stac_passes_its_signer_to_the_delegate():
     """A Collection/Catalog URL hands off to LoadCollection -- which must not
     silently lose the credential path."""
-    rules = rules_for_catalogue(PC_STAC_API)
-    loader = LoadStac(signer_rules=rules)
+    loader = LoadStac(signer_key=PC_KEY)
 
     captured = {}
 
     class _Delegate:
-        def __init__(self, stac_api, signer_rules=()):
-            captured["rules"] = signer_rules
+        def __init__(self, stac_api, signer_key=None):
+            captured["signer_key"] = signer_key
 
         def load_collection(self, **kwargs):
             captured["named_parameters"] = kwargs.get("named_parameters")
             return "stack"
-
-    import pystac
 
     collection = pystac.Collection(
         id="c",
@@ -189,5 +208,5 @@ def test_load_stac_passes_its_rules_to_the_delegate():
             == "stack"
         )
 
-    assert captured["rules"] == rules
+    assert captured["signer_key"] == PC_KEY
     assert captured["named_parameters"] == user

--- a/titiler/openeo/main.py
+++ b/titiler/openeo/main.py
@@ -18,8 +18,7 @@ from .health import register_health_endpoints
 from .middleware import DynamicCacheControlMiddleware
 from .processes import PROCESS_SPECIFICATIONS, process_registry
 from .services import get_store, get_tile_store, get_udp_store
-from .settings import ApiSettings, AuthSettings, BackendSettings
-from .signing import rules_for_catalogue, set_default_rules
+from .settings import ApiSettings, AuthSettings, BackendSettings, SigningSettings
 from .stacapi import LoadCollection, LoadStac, stacApiBackend
 
 STAC_VERSION = "1.0.0"
@@ -51,11 +50,11 @@ tile_store = (
 )
 auth = get_auth(auth_settings, store=service_store)
 
-# Which asset hrefs this deployment must attach a credential to, decided once
-# from the configured catalogue (docs/adr/0005-asset-href-signing.md S2.3).
-# Empty for every catalogue that needs none, which is the unchanged path.
-signer_rules = rules_for_catalogue(str(backend_settings.stac_api_url))
-set_default_rules(signer_rules)
+# Which signer this deployment's assets need, read once from configuration --
+# not inferred from the catalogue's hostname (docs/adr/0005-asset-href-signing.md
+# S2.3, issue #377). `None` for every deployment that needs none, which is the
+# unchanged path.
+signer_key = SigningSettings().asset_signer or None
 
 
 def create_app():
@@ -111,23 +110,23 @@ def create_app():
         ],
     )
 
-    # The activation rule is derived, not configured, so say out loud which
-    # rules are live -- otherwise a deployment pointing at a Planetary Computer
-    # mirror on another hostname silently gets none (ADR 0005 S3.1).
-    if signer_rules:
+    # Say out loud whether signing is on: a deployment that reads private assets
+    # but forgot the setting otherwise finds out through an opaque HTTP 409 from
+    # the storage host (ADR 0005 S3.1).
+    if signer_key:
         logger.info(
             "Asset href signing enabled for %s: %s",
             backend_settings.stac_api_url,
-            ", ".join(rule.host.pattern for rule in signer_rules),
+            signer_key,
         )
 
     # Register backend specific load_collection methods
-    loaders = LoadCollection(stac_client, signer_rules=signer_rules)  # type: ignore
+    loaders = LoadCollection(stac_client, signer_key=signer_key)  # type: ignore
     process_registry["load_collection"] = Process(
         spec=PROCESS_SPECIFICATIONS["load_collection"],
         implementation=loaders.load_collection,
     )
-    loaders = LoadStac(signer_rules=signer_rules)  # type: ignore
+    loaders = LoadStac(signer_key=signer_key)  # type: ignore
     process_registry["load_stac"] = Process(
         spec=PROCESS_SPECIFICATIONS["load_stac"],
         implementation=loaders.load_stac,

--- a/titiler/openeo/processes/implementations/io.py
+++ b/titiler/openeo/processes/implementations/io.py
@@ -14,7 +14,8 @@ from rio_tiler.models import ImageData
 from rio_tiler.tasks import create_tasks
 
 from ...reader import _reader
-from ...signing import get_default_href_signer
+from ...settings import SigningSettings
+from ...signing import get_signer, stamp_signer_key
 from .data_model import RasterStack
 
 __all__ = ["save_result", "SaveResultData", "load_url"]
@@ -36,21 +37,22 @@ def load_url(
     Raises:
         ValueError: If the URL is invalid
     """
-    # Unlike every other read path, this one has no user in scope: `load_url`
-    # is a plain process implementation running inside an already-evaluating
-    # graph. It therefore uses the process-wide rules resolved at startup
-    # (docs/adr/0005-asset-href-signing.md S2.6). The signer still only fires
-    # when the URL's host matches a rule, so a user-supplied URL cannot widen
-    # what gets signed.
-    signer = get_default_href_signer()
-    if signer is not None:
-        url = signer(url)
+    # Unlike every other read path, this one has no catalogue behind it:
+    # `load_url` is a plain process implementation running inside an
+    # already-evaluating graph, so there is no ingest step to stamp its item and
+    # no `LoadCollection` holding the deployment's choice. It reads that choice
+    # straight from settings instead (docs/adr/0005-asset-href-signing.md S2.6).
+    # The signer still returns any href it has nothing to add to untouched, so a
+    # user-supplied URL cannot widen what gets signed.
+    signer_key = SigningSettings().asset_signer or None
 
-    # Create a dummy STAC item for the COG
+    # Create a dummy STAC item for the COG, stamped so the read path resolves
+    # the same credential the metadata open below uses.
     item: Dict[str, Any] = {
         "type": "Feature",
         "id": "cog",
         "bbox": None,  # Will be set from the COG metadata
+        "properties": {},
         "assets": {
             "data": {
                 "href": url,
@@ -58,9 +60,12 @@ def load_url(
             }
         },
     }
+    stamp_signer_key(item, signer_key)
 
-    # Get metadata from COG to set bbox, dimensions, and CRS
-    with COGReader(url) as cog:
+    # Get metadata from COG to set bbox, dimensions, and CRS. This open is
+    # outside any reader, so it signs the href itself.
+    signer = get_signer(signer_key)
+    with COGReader(signer(url) if signer else url) as cog:
         item["bbox"] = [float(x) for x in cog.bounds]
         cog_width = cog.dataset.width
         cog_height = cog.dataset.height

--- a/titiler/openeo/reader.py
+++ b/titiler/openeo/reader.py
@@ -38,7 +38,7 @@ from .bandsources import (
 )
 from .errors import OutputLimitExceeded
 from .settings import ProcessingSettings
-from .signing import HrefSigner
+from .signing import HrefSigner, signer_for_item
 
 logger = logging.getLogger(__name__)
 
@@ -258,13 +258,18 @@ class SimpleSTACReader(MultiBaseReader):
     #: above, which is shared by every asset this reader constructs).
     band_source_fetcher: Any = attr.ib(default=None)
 
-    #: Optional href signer, bound to the authenticated user by the process
-    #: that built this reader. Applied by `_resolve_asset_href` to every href
-    #: this reader opens -- real assets, band-source annotation assets and
-    #: their sibling measurement hrefs alike, which is why one seam covers all
-    #: three (docs/adr/0005-asset-href-signing.md S2.6). `None` means "this
-    #: deployment needs no credential on its hrefs", and is the default.
-    signer: Optional[HrefSigner] = attr.ib(default=None)
+    #: Optional href signer, resolved in `__attrs_post_init__` from the key the
+    #: item was stamped with at ingest -- never passed in. Applied by
+    #: `_resolve_asset_href` to every href this reader opens: real assets,
+    #: band-source annotation assets and their sibling measurement hrefs alike,
+    #: which is why one seam covers all three
+    #: (docs/adr/0005-asset-href-signing.md S2.6).
+    #:
+    #: Resolving here rather than receiving it is what makes the credential
+    #: fresh: `_reader` rebuilds this reader on every retry, so an expired token
+    #: is re-minted rather than reused (ADR 0005 S3.1). `None` -- an unstamped
+    #: item -- means "this deployment needs no credential on its hrefs".
+    signer: Optional[HrefSigner] = attr.ib(init=False, default=None)
 
     #: Derived band names this item's own assets resolve to, precomputed once
     #: (pure, no I/O -- regex matching over `self.input.assets`) so
@@ -290,6 +295,11 @@ class SimpleSTACReader(MultiBaseReader):
 
     def __attrs_post_init__(self) -> None:
         """Set reader spatial infos and list of valid assets."""
+        # Before anything that resolves an href: `_item_has_untrustworthy_proj`
+        # below opens an asset for real, and must see the same credential the
+        # pixels will be read with (ADR 0005 S1.1).
+        self.signer = signer_for_item(self.input)
+
         self.assets = self.input.get_assets().keys()
         if not self.assets:
             raise MissingAssets(
@@ -906,7 +916,6 @@ def _get_target_crs_bbox(
     items: List[pystac.Item],
     spatial_extent: Optional[BoundingBox],
     target_crs: Optional[Union[int, str, rasterio.crs.CRS]] = None,
-    signer: Optional[HrefSigner] = None,
 ) -> Tuple[rasterio.crs.CRS, rasterio.crs.CRS, List[float]]:
     """Get bounds CRS, target CRS, and bbox from items and spatial extent.
 
@@ -914,7 +923,6 @@ def _get_target_crs_bbox(
         items: List of STAC items
         spatial_extent: Optional bounding box for the output
         target_crs: Optional target CRS for the output. If None, uses native CRS from first item.
-        signer: Optional href signer for the readers this builds
 
     Returns:
         Tuple of (bounds_crs, target_crs, bbox) where:
@@ -945,7 +953,7 @@ def _get_target_crs_bbox(
 
     # Process each item to update bbox and find native CRS
     for item in items:
-        with SimpleSTACReader(item, signer=signer) as src_dst:
+        with SimpleSTACReader(item) as src_dst:
             item_bbox = src_dst.bounds
             if item_bbox:
                 if not spatial_extent:
@@ -991,13 +999,12 @@ def _get_cube_resolutions(
     target_crs: rasterio.crs.CRS,
     target_bbox: List[float],
     bands: Optional[list[str]],
-    signer: Optional[HrefSigner] = None,
 ) -> Dict[str, Dict[str, List[Tuple[float, float, List[float]]]]]:
     """Get resolutions for each datetime and band combination."""
     cube_resolutions: Dict[str, Dict[str, List[Tuple[float, float, List[float]]]]] = {}
 
     for item in items:
-        with SimpleSTACReader(item, signer=signer) as src_dst:
+        with SimpleSTACReader(item) as src_dst:
             asset_resolutions = _get_assets_resolutions(item, src_dst, bands)
             for band_name, (x_res, y_res, asset_crs) in asset_resolutions.items():
                 if x_res is None or y_res is None:
@@ -1041,7 +1048,6 @@ def _estimate_output_dimensions(
     height: Optional[int] = None,
     check_max_pixels: bool = True,
     target_crs: Optional[Union[int, str, rasterio.crs.CRS]] = None,
-    signer: Optional[HrefSigner] = None,
 ) -> Dims:
     """
     Estimate output dimensions based on items and spatial extent.
@@ -1054,9 +1060,6 @@ def _estimate_output_dimensions(
         height: Optional user-specified height
         check_max_pixels: Whether to check pixel count limit
         target_crs: Optional target CRS for the output. If None, uses native CRS from first item.
-        signer: Optional href signer for the readers this builds. Needed here
-            too, not only on the read path: estimating dimensions opens assets
-            to read their projection metadata.
 
     Returns:
         Dictionary containing:
@@ -1065,10 +1068,15 @@ def _estimate_output_dimensions(
             - bounds_crs: CRS of the input bounding box
             - crs: Target CRS to use for output
             - bbox: Bounding box as a list [west, south, east, north]
+
+    Note:
+        This path opens assets to read their projection metadata, so it needs the
+        same credential the read path does. It gets it the same way: from the key
+        the item was stamped with at ingest (ADR 0005 S2.2).
     """
     # Get bounds CRS, target CRS, and bbox
     bounds_crs, output_crs, target_bbox = _get_target_crs_bbox(
-        items, spatial_extent, target_crs, signer=signer
+        items, spatial_extent, target_crs
     )
 
     # Reproject bbox to output CRS for resolution/dimension calculations
@@ -1080,9 +1088,7 @@ def _estimate_output_dimensions(
         output_bbox = target_bbox
 
     # Get resolutions for each datetime and band
-    cube_resolutions = _get_cube_resolutions(
-        items, output_crs, output_bbox, bands, signer=signer
-    )
+    cube_resolutions = _get_cube_resolutions(items, output_crs, output_bbox, bands)
 
     # Find the minimum resolution across all bands
     x_resolution: Optional[float] = None
@@ -1252,20 +1258,17 @@ def _reader(item: Dict[str, Any], bbox: BBox, **kwargs: Any) -> ImageData:
     Args:
         item: STAC item dictionary (converted to pystac.Item by SimpleSTACReader)
         bbox: Bounding box to read
-        **kwargs: Additional keyword arguments to pass to the reader. ``signer``
-            is consumed here rather than forwarded to ``part()``; it reaches
-            this function through ``mosaic_reader``/``create_tasks``, which
-            forward their own ``**kwargs`` to the reader callable.
+        **kwargs: Additional keyword arguments to pass to the reader
 
     Returns:
         ImageData object with cutline_mask set from item geometry if available
-    """
-    # Popped before the retry loop: the signer belongs to the reader's
-    # construction, not to the read call, and every retry below rebuilds the
-    # reader -- which is what re-signs hrefs whose token expired mid-read
-    # (docs/adr/0005-asset-href-signing.md S3.1).
-    signer: Optional[HrefSigner] = kwargs.pop("signer", None)
 
+    Note:
+        Any credential these hrefs need comes from ``item`` itself, stamped at
+        ingest and resolved inside ``SimpleSTACReader``. Because the retry loop
+        below rebuilds the reader, a token that expired mid-read is re-minted
+        rather than reused (docs/adr/0005-asset-href-signing.md S3.1).
+    """
     max_retries = 10
     retry_delay = 1.0  # seconds
     retries = 0
@@ -1286,7 +1289,7 @@ def _reader(item: Dict[str, Any], bbox: BBox, **kwargs: Any) -> ImageData:
 
     while True:
         try:
-            with SimpleSTACReader(item, signer=signer) as src_dst:
+            with SimpleSTACReader(item) as src_dst:
                 img = src_dst.part(bbox, **kwargs)
 
                 requested = kwargs.get("assets")

--- a/titiler/openeo/settings.py
+++ b/titiler/openeo/settings.py
@@ -313,8 +313,37 @@ class Sentinel2Settings(BaseSettings):
     )
 
 
+class SigningSettings(BaseSettings):
+    """Which signer this deployment's assets need.
+
+    Deliberately a setting rather than something the application infers. An
+    earlier version turned signing on when the configured STAC API URL happened
+    to be `planetarycomputer.microsoft.com`, which put a cloud provider's
+    hostname in the application's decision logic (issue #377). A deployment
+    knows its own data provider; the application should not guess.
+
+    Empty -- the default -- means no signing, which is the behaviour every
+    deployment had before signing existed. Valid values are the keys of
+    `signing.SIGNERS`; an unknown one fails loudly at first use rather than
+    reading as "signing off" (see `signing.get_signer`).
+
+    See docs/adr/0005-asset-href-signing.md for the design this configures.
+    """
+
+    asset_signer: str = ""
+
+    model_config = SettingsConfigDict(
+        env_prefix="TITILER_OPENEO_",
+        env_file=".env",
+        extra="ignore",
+    )
+
+
 class PlanetaryComputerSettings(BaseSettings):
     """Microsoft Planetary Computer asset-signing settings.
+
+    Only consulted when `SigningSettings.asset_signer` names
+    `"planetary-computer"`.
 
     See docs/adr/0005-asset-href-signing.md for the design this configures.
     """

--- a/titiler/openeo/signing.py
+++ b/titiler/openeo/signing.py
@@ -11,15 +11,22 @@ the *href*, so no environment variable can express it.
 This module is that mechanism, kept behind a narrow protocol so it is swappable
 and testable -- see docs/adr/0005-asset-href-signing.md.
 
-Two things keep this from becoming the plugin system ADR 0002 S2.1 rejects.
-Rules match on the href's **host**, which is a fact of the data rather than
-hand-written per-collection configuration, and the registry ships in code. A new
-catalogue means a new rule and a fixture, exactly as ``bandsources/sources.py``
-does for band sources.
+**Which signer applies is deployment configuration, not something this module
+infers.** An earlier version activated signing when the configured STAC API URL
+happened to be ``planetarycomputer.microsoft.com``; that put a cloud provider's
+hostname in the application's decision logic (issue #377). Now a deployment names
+a signer key, core maps the key to an implementation, and nothing here knows
+which catalogue a deployment reads.
 
-``get_href_signer`` returns ``None`` when no rule applies, and ``None`` is what
-every threading site defaults to, so a deployment that needs no signing runs the
-identical code path it ran before this module existed.
+The key travels to the read path on the **item**, stamped once at ingest
+(``ITEM_SIGNER_KEY``), because the readers that open hrefs are constructed deep
+inside the mosaic and run on worker threads no parameter or contextvar reaches.
+The key is resolved to a signer at *open* time, per read and per retry, so a
+token that expires mid-graph is re-minted rather than reused (ADR 0005 S3.1) --
+which is why the stamp carries a key and never a signed href.
+
+``get_signer`` returns ``None`` for an unstamped item, so a deployment that needs
+no signing runs the identical code path it ran before this module existed.
 """
 
 import json
@@ -27,25 +34,23 @@ import logging
 import re
 import urllib.error
 import urllib.request
-from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+from functools import lru_cache
 from threading import Lock
-from typing import Callable, Dict, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, Optional, Tuple
 from urllib.parse import urlsplit, urlunsplit
 
-from .models.auth import User
 from .settings import PlanetaryComputerSettings
 
 __all__ = [
     "HrefSigner",
-    "SignerRule",
     "SigningError",
     "PlanetaryComputerSigner",
-    "PLANETARY_COMPUTER",
-    "rules_for_catalogue",
-    "get_href_signer",
-    "set_default_rules",
-    "get_default_href_signer",
+    "ITEM_SIGNER_KEY",
+    "SIGNERS",
+    "get_signer",
+    "stamp_signer_key",
+    "signer_for_item",
 ]
 
 logger = logging.getLogger(__name__)
@@ -62,25 +67,6 @@ class SigningError(RuntimeError):
     read that would follow fails with an opaque HTTP 409 from blob storage,
     which tells an operator nothing about the real cause.
     """
-
-
-@dataclass(frozen=True)
-class SignerRule:
-    """One rule: which hrefs need signing, and what signs them.
-
-    ``host`` is pre-compiled and matched with :meth:`re.Pattern.search` against
-    the href's hostname, so a registry with many entries does not recompile per
-    lookup.
-
-    ``factory`` takes the authenticated user, even though the only shipped
-    signer ignores it. See ADR 0005 S2.5: the per-request channel is built now
-    because threading it is the expensive part, and a genuinely delegated
-    backend (Planetary Computer Pro, private Azure containers reached by an
-    on-behalf-of exchange) would otherwise need the same surgery a second time.
-    """
-
-    host: "re.Pattern[str]"
-    factory: Callable[[Optional[User]], HrefSigner]
 
 
 # ---------------------------------------------------------------------------
@@ -147,17 +133,19 @@ class PlanetaryComputerSigner:
 
     def __init__(
         self,
-        user: Optional[User] = None,
         settings: Optional[PlanetaryComputerSettings] = None,
     ) -> None:
-        """Bind a signer to ``user``, which public Planetary Computer ignores.
+        """Build a signer for this deployment's Planetary Computer settings.
 
-        ``user`` is stored but never read: PC grants every caller the same
+        Deliberately takes no ``User``. PC grants every caller the same
         container-scoped, read+list token regardless of identity (ADR 0005
-        S1.2), so there is no entitlement to delegate. It is kept so the seam
-        has a real shape for a backend where identity does decide access.
+        S1.2), so there is no entitlement to delegate, and the item stamp that
+        selects this signer cannot carry a live user into the worker threads
+        that open assets. A genuinely delegated backend (PC Pro, private Azure
+        via on-behalf-of) needs a per-user channel that does not exist here --
+        see ADR 0005 S2.5, which records this as an accepted limit rather than
+        a solved problem.
         """
-        self.user = user
         self.settings = settings or PlanetaryComputerSettings()
 
     def __call__(self, href: str) -> str:
@@ -229,72 +217,91 @@ class PlanetaryComputerSigner:
         ) from last_error
 
 
-#: The shipped registry. One entry today; a new catalogue adds a rule here and a
-#: fixture, per ADR 0005 S2.1.
-PLANETARY_COMPUTER = SignerRule(
-    host=re.compile(r"\.blob\.core\.windows\.net$", re.IGNORECASE),
-    factory=PlanetaryComputerSigner,
-)
+#: The STAC property an item carries to say which signer its assets need.
+#: Written once at ingest (`stacapi.py`), read at open time by
+#: `reader._signer_for_item`. Namespaced like a STAC extension field so it reads
+#: as metadata rather than folklore, and a plain string so it survives
+#: `Item.to_dict()` -- `load_stac` hands `_reader` dicts, and a callable would
+#: not make that round trip (ADR 0005 S2.2).
+ITEM_SIGNER_KEY = "titiler:sign"
 
-#: Host of the Planetary Computer STAC API, which is what activates the rule
-#: above (ADR 0005 S2.3). Signing is scoped to the configured catalogue so a
-#: deployment reading its own Azure blob containers never makes an outbound call
-#: to microsoft.com as a side effect of a registry default.
-_PC_STAC_HOST = "planetarycomputer.microsoft.com"
-
-
-def rules_for_catalogue(stac_api_url: str) -> Tuple[SignerRule, ...]:
-    """Return the signing rules that apply to a deployment's STAC API."""
-    host = (urlsplit(stac_api_url).hostname or "").lower()
-    if host == _PC_STAC_HOST or host.endswith(f".{_PC_STAC_HOST}"):
-        return (PLANETARY_COMPUTER,)
-    return ()
+#: The shipped signers, by key. A deployment names one of these keys; core never
+#: infers it from a hostname. A new catalogue adds an entry here and a fixture.
+SIGNERS: Dict[str, Callable[[], HrefSigner]] = {
+    "planetary-computer": PlanetaryComputerSigner,
+}
 
 
-def get_href_signer(
-    rules: Sequence[SignerRule],
-    user: Optional[User] = None,
-) -> Optional[HrefSigner]:
-    """Build a signer for ``user`` from ``rules``, or ``None`` if there are none.
+@lru_cache(maxsize=None)
+def get_signer(key: Optional[str]) -> Optional[HrefSigner]:
+    """Return the signer registered under ``key``, or ``None`` for no key.
 
-    Returning ``None`` rather than an identity function is the point: it is what
-    lets every call site keep ``signer=None`` as its default and run byte-identical
-    code when nothing needs signing, mirroring ``build_per_request_registry``'s
-    "return the base object unchanged" gate (ADR 0005 S2.2).
+    Returning ``None`` rather than an identity function is the point: it lets
+    every call site keep signing off by default and run byte-identical code when
+    no item is stamped (ADR 0005 S2.2).
 
-    An href whose host matches no rule is returned untouched -- which is how
-    Planetary Computer's own ``tilejson`` and ``rendered_preview`` assets, served
-    from the API host rather than blob storage, stay unsigned.
+    Memoised because this is now resolved per href opened, not once per request:
+    building a signer constructs a pydantic settings object, which reads the
+    environment. The signers themselves hold no per-request state -- the SAS
+    token cache above is module-level and already shared.
+
+    Unknown keys raise rather than silently returning ``None``: a typo'd key
+    would otherwise read as "signing off" and surface as an opaque HTTP 409 from
+    blob storage, which is exactly what `SigningError` exists to prevent.
     """
-    if not rules:
+    if not key:
         return None
 
-    signers = [(rule.host, rule.factory(user)) for rule in rules]
+    factory = SIGNERS.get(key)
+    if factory is None:
+        raise SigningError(
+            f"No signer registered under '{key}'. Known signers: "
+            f"{', '.join(sorted(SIGNERS)) or '(none)'}."
+        )
 
-    def sign(href: str) -> str:
-        host = urlsplit(href).hostname or ""
-        for pattern, signer in signers:
-            if pattern.search(host):
-                return signer(href)
-        return href
-
-    return sign
+    return factory()
 
 
-_default_rules: Tuple[SignerRule, ...] = ()
+def stamp_signer_key(item: Any, key: Optional[str]) -> Any:
+    """Record on ``item`` which signer its assets need, and return it.
 
+    Called once per item at ingest. A falsy ``key`` leaves the item untouched,
+    so a deployment with no signer configured produces items indistinguishable
+    from those this backend produced before signing existed.
 
-def set_default_rules(rules: Sequence[SignerRule]) -> None:
-    """Record the process-wide rules, resolved once from settings at startup.
+    Accepts a ``pystac.Item`` or a plain STAC dict because both reach the read
+    path: `load_collection` carries `pystac.Item`s while `load_stac` hands
+    `_reader` the output of `Item.to_dict()`.
 
-    Only ``load_url`` needs this. Every other read path carries a signer bound
-    to the authenticated user; ``load_url`` takes a user-supplied URL from
-    inside an already-evaluating process graph and has no user in scope.
+    The stamp is deliberately **not** scoped to hrefs that look like they need
+    signing. Each signer already returns an href untouched when it has nothing
+    to add -- which is how Planetary Computer's own `tilejson` and
+    `rendered_preview` assets, served from the API host rather than blob
+    storage, stay unsigned -- so narrowing here would duplicate that judgement
+    in a second place and let the two disagree.
     """
-    global _default_rules
-    _default_rules = tuple(rules)
+    if not key:
+        return item
+
+    if isinstance(item, dict):
+        item.setdefault("properties", {})[ITEM_SIGNER_KEY] = key
+    else:
+        item.properties[ITEM_SIGNER_KEY] = key
+
+    return item
 
 
-def get_default_href_signer() -> Optional[HrefSigner]:
-    """Return an unbound signer built from the process-wide rules."""
-    return get_href_signer(_default_rules)
+def signer_for_item(item: Any) -> Optional[HrefSigner]:
+    """Return the signer ``item`` was stamped with at ingest, if any.
+
+    Resolved per call rather than cached on the item: this runs at *open* time,
+    once per reader construction, so a retry after a `RasterioIOError` re-mints
+    an expired token instead of reusing the one the first attempt used
+    (ADR 0005 S3.1). Resolution itself is memoised in `get_signer`.
+    """
+    if isinstance(item, dict):
+        properties = item.get("properties") or {}
+    else:
+        properties = getattr(item, "properties", None) or {}
+
+    return get_signer(properties.get(ITEM_SIGNER_KEY))

--- a/titiler/openeo/stacapi.py
+++ b/titiler/openeo/stacapi.py
@@ -40,7 +40,7 @@ from .processes.implementations.data_model import RasterStack
 from .processes.implementations.utils import _props_to_datetime, to_rasterio_crs
 from .reader import _estimate_output_dimensions, _reader
 from .settings import CacheSettings, ProcessingSettings, PySTACSettings
-from .signing import HrefSigner, SignerRule, get_href_signer
+from .signing import stamp_signer_key
 
 pystac_settings = PySTACSettings()
 cache_config = CacheSettings()
@@ -365,25 +365,16 @@ class LoadCollection:
 
     stac_api: stacApiBackend = field()
 
-    #: Href-signing rules for this deployment's catalogue, injected by
-    #: `main.py` rather than read from a module global so this class stays
-    #: constructible in tests. Empty -- the default -- means every href is
-    #: opened exactly as the catalogue published it
-    #: (docs/adr/0005-asset-href-signing.md S2.2).
-    signer_rules: Sequence[SignerRule] = field(factory=tuple)
-
-    def _signer_for(
-        self, named_parameters: Optional[dict] = None
-    ) -> Optional[HrefSigner]:
-        """Build the href signer for the user this graph is running as.
-
-        The authenticated `User` arrives as the `_openeo_user` named parameter,
-        injected by `factory.py`'s executing endpoints. It is `None` for an
-        unauthenticated request, which is fine: the shipped signer ignores it
-        (ADR 0005 S2.5).
-        """
-        user = (named_parameters or {}).get("_openeo_user")
-        return get_href_signer(self.signer_rules, user)
+    #: Which signer this deployment's catalogue needs, injected by `main.py`
+    #: rather than read from a module global so this class stays constructible
+    #: in tests. `None` -- the default -- means every href is opened exactly as
+    #: the catalogue published it (docs/adr/0005-asset-href-signing.md S2.2).
+    #:
+    #: Stamped onto every item this class retrieves rather than threaded down to
+    #: the readers: the readers are built deep inside the mosaic and run on
+    #: worker threads that no parameter reaches, and resolving the key at open
+    #: time is what keeps a short-lived credential fresh across retries.
+    signer_key: Optional[str] = field(default=None)
 
     def _resolve_parameter_reference(
         self,
@@ -507,7 +498,14 @@ class LoadCollection:
             query_params["filter"] = filter_expr
             query_params["filter_lang"] = "cql2-json"
 
-        return self.stac_api.get_items(**query_params)
+        # The single funnel every `load_collection` read passes through, which
+        # is why the deployment's signing decision is applied here and nowhere
+        # below: from this point on an item carries what the read path needs
+        # (docs/adr/0005-asset-href-signing.md S2.2).
+        return [
+            stamp_signer_key(item, self.signer_key)
+            for item in self.stac_api.get_items(**query_params)
+        ]
 
     def _handle_comparison_operator(
         self,
@@ -882,8 +880,6 @@ class LoadCollection:
         if bands is None and items and items[0].assets:
             bands = list(items[0].assets.keys())[:1]  # Take the first asset as default
 
-        signer = self._signer_for(named_parameters)
-
         # Estimate dimensions based on items and spatial extent
         dimensions = _estimate_output_dimensions(
             items,
@@ -892,7 +888,6 @@ class LoadCollection:
             width,
             height,
             target_crs=target_crs,
-            signer=signer,
         )
 
         # Extract values from the result
@@ -930,7 +925,6 @@ class LoadCollection:
             width: int,
             height: int,
             tile_buffer: Optional[float],
-            signer: Optional[HrefSigner],
         ):
             """Create a closure that loads data for a date group."""
 
@@ -938,12 +932,6 @@ class LoadCollection:
                 # Build kwargs for mosaic_reader
                 mosaic_kwargs = {
                     "threads": 0,
-                    # Consumed by `_reader`, not forwarded to `part()`. Captured
-                    # in this closure at graph-evaluation time, while the user
-                    # is still in scope -- the task itself runs lazily, and on
-                    # a worker thread that no request context reaches
-                    # (ADR 0005 S2.5).
-                    "signer": signer,
                     "bounds_crs": bounds_crs,
                     "assets": bands,
                     "dst_crs": output_crs,
@@ -986,7 +974,6 @@ class LoadCollection:
                 width,
                 height,
                 tile_buffer,
-                signer,
             )
             # Collect all geometries from items for cutline mask computation (union of footprints)
             geometries = [
@@ -1026,17 +1013,12 @@ class LoadCollection:
 class LoadStac:
     """Backend Specific STAC loaders."""
 
-    #: See `LoadCollection.signer_rules`. `load_stac` reads a user-supplied
-    #: catalogue rather than the configured one, so a rule only fires when the
-    #: asset host matches -- the URL the user passed does not widen it.
-    signer_rules: Sequence[SignerRule] = field(factory=tuple)
-
-    def _signer_for(
-        self, named_parameters: Optional[dict] = None
-    ) -> Optional[HrefSigner]:
-        """Build the href signer for the user this graph is running as."""
-        user = (named_parameters or {}).get("_openeo_user")
-        return get_href_signer(self.signer_rules, user)
+    #: See `LoadCollection.signer_key`. `load_stac` reads a user-supplied
+    #: catalogue rather than the configured one, so the stamp does not by itself
+    #: widen what gets signed: the signer it names still returns any href it has
+    #: nothing to add to untouched, so a URL the user passed cannot pull a
+    #: credential onto a host this deployment never meant to reach.
+    signer_key: Optional[str] = field(default=None)
 
     def _load_stac_object(self, url: str) -> pystac.STACObject:
         """Load a STAC object from a URL.
@@ -1085,12 +1067,10 @@ class LoadStac:
         """
         collection_id = stac_obj.id
         stac_api = stacApiBackend(url=stac_obj.get_root_link().href)
-        # The delegate inherits this instance's rules: signing is decided by the
-        # asset host, so handing off to a LoadCollection for a user-supplied
-        # catalogue must not silently drop the credential path.
-        load_collection = LoadCollection(
-            stac_api=stac_api, signer_rules=self.signer_rules
-        )
+        # The delegate inherits this instance's signer: handing off to a
+        # LoadCollection for a user-supplied catalogue must not silently drop
+        # the credential path.
+        load_collection = LoadCollection(stac_api=stac_api, signer_key=self.signer_key)
 
         return load_collection.load_collection(
             id=collection_id,
@@ -1179,18 +1159,17 @@ class LoadStac:
         width: Optional[int] = None,
         height: Optional[int] = None,
         tile_buffer: Optional[float] = None,
-        signer: Optional[HrefSigner] = None,
     ) -> RasterStack:
         """Process spatial extent and create tasks.
 
         Args:
-            items: List of STAC items
+            items: List of STAC items, already stamped with this deployment's
+                signer key by the caller
             spatial_extent: Bounding box to limit the data
             bands: Optional list of band names to include
             width: Optional width of the output image in pixels
             height: Optional height of the output image in pixels
             tile_buffer: Optional buffer around the tile in pixels
-            signer: Optional href signer, consumed by `_reader`
 
         Returns:
             A RasterStack containing the tasks
@@ -1218,7 +1197,6 @@ class LoadStac:
             width=int(width) if width else width,
             height=int(height) if height else height,
             buffer=float(tile_buffer) if tile_buffer is not None else tile_buffer,
-            signer=signer,
         )
 
         return RasterStack(
@@ -1257,8 +1235,7 @@ class LoadStac:
             width: Optional width of the output image in pixels
             height: Optional height of the output image in pixels
             tile_buffer: Optional buffer around the tile in pixels
-            named_parameters: Named parameters for process graph evaluation.
-                Carries `_openeo_user`, from which the href signer is built.
+            named_parameters: Named parameters for process graph evaluation
 
         Returns:
             A RasterStack containing the loaded data
@@ -1268,8 +1245,6 @@ class LoadStac:
             TemporalExtentEmpty: If the temporal extent is empty
             NotImplementedError: If spatial_extent is not provided
         """
-        signer = self._signer_for(named_parameters)
-
         # Load the STAC catalog or item from the URL
         stac_obj = self._load_stac_object(url)
 
@@ -1287,9 +1262,11 @@ class LoadStac:
                 named_parameters=named_parameters,
             )
 
-        # For a single item, use it directly
+        # For a single item, use it directly. Stamped here because this path
+        # never passes through `LoadCollection._get_items`, which is where every
+        # other read gets its stamp.
         elif isinstance(stac_obj, pystac.Item):
-            items = [stac_obj.to_dict()]
+            items = [stamp_signer_key(stac_obj.to_dict(), self.signer_key)]
         else:
             raise UnsupportedSTACObject(str(type(stac_obj)))
 
@@ -1316,12 +1293,11 @@ class LoadStac:
                 width=width,
                 height=height,
                 tile_buffer=tile_buffer,
-                signer=signer,
             )
 
         # Estimate dimensions based on items and spatial extent
         dimensions = _estimate_output_dimensions(
-            items, spatial_extent, bands, width, height, signer=signer
+            items, spatial_extent, bands, width, height
         )
 
         # Extract values from the result
@@ -1340,6 +1316,5 @@ class LoadStac:
             width=int(width) if width else width,
             height=int(height) if height else height,
             buffer=float(tile_buffer) if tile_buffer is not None else tile_buffer,
-            signer=signer,
         )
         return img


### PR DESCRIPTION
Closes #377.

## What

A deployment now names its signer; ingest stamps that name onto every item as a `titiler:sign` STAC property; the read path resolves the name to a signer when it opens an href.

```text
_get_items()          ← the deployment's decision, applied ONCE, at the edge
   asset stamp: properties["titiler:sign"] = "planetary-computer"
        │
        ▼   no signing parameter anywhere below this line
_estimate_output_dimensions ── _get_target_crs_bbox ── _get_cube_resolutions ── _reader
        ▼
SimpleSTACReader.__attrs_post_init__  →  signer_for_item(self.input)
```

## Why

#371 threaded an `HrefSigner` down through five functions and activated it by checking whether `TITILER_OPENEO_STAC_API_URL` named `planetarycomputer.microsoft.com`. @vincentsarago's review rejected both halves — the hostname check put a cloud provider in the application's decision logic, and the threading spread a deployment concern across the generic read path.

Two design points worth review:

**The item is the channel, not a preference.** The readers are built at three fixed points inside the mosaic and run on a `ThreadPoolExecutor` that rio-tiler creates without `copy_context()` (`rio_tiler/tasks.py`), so a contextvar cannot carry the decision either. The item already travels to all three points and is the task argument.

**The stamp is a key, never a signed href.** A SAS token minted at ingest would be reused by every lazily-evaluated task and every retry, so a graph outliving its ~45-minute token would fail. Resolving at open time means `_reader`'s retry loop — which rebuilds the reader — re-signs. That was ADR 0005 §3.1's "real but incidental" recovery path; it is now load-bearing, and `test_every_retry_rebuilds_the_reader_so_an_expired_token_is_reminted` asserts it.

## Breaking change

Signing no longer switches on by itself. Deployments reading Planetary Computer must set:

```bash
TITILER_OPENEO_ASSET_SIGNER=planetary-computer
```

Set in `.env.planetarycomputer` and `deployment/k8s/charts/ci/planetarycomputer-values.yaml`; anyone with their own values file needs the same line. An unknown key raises `SigningError` at first use rather than reading as "signing off", which would surface only as an opaque HTTP 409.

This also fixes the case ADR 0005 §3.1 had recorded as an open risk: a PC **mirror on another hostname** previously had no way to enable signing at all.

Removed from the public surface: `SignerRule`, `rules_for_catalogue`, `get_href_signer`, `set_default_rules`, `get_default_href_signer`.

## The per-user seam is removed, not moved

`SignerRule.factory(user)` was built ahead of a delegated backend. Keeping it would have meant keeping the parameter on every function for a hypothetical consumer, which is the thing this PR exists to undo. ADR 0005 §2.5 now records signing as **user-independent** — correct for every shipped case, since public PC's SAS API is identity-blind (§1.2) — and states what a delegated backend (PC Pro, on-behalf-of) would have to build instead: neither an item stamp (must stay JSON-serialisable) nor a contextvar (see above) can carry a user into the worker threads.

This is a real capability removal and the part most worth a second opinion.

## Verification

- `uv run pytest` — 1229 passed, 13 skipped, with `TITILER_OPENEO_ASSET_SIGNER` both unset and set
- `uv run pre-commit run --all-files` — ruff, isort, mypy, markdownlint all pass
- The unsigned path is byte-identical: an unstamped item yields no signer, and `_resolve_asset_href` returns exactly the string it returned before signing existed

ADR 0005 is revised in place with a dated note; §1, §2.1 and §2.4 (the problem, the anti-plugin-system rule, and the signer itself) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)