### PR TITLE
feat(api): resolve bands published inside one STAC asset

### DIFF
--- a/docs/adr/0007-multiband-assets.md
+++ b/docs/adr/0007-multiband-assets.md
@@ -1,0 +1,193 @@
+# ADR 0007 — Bands published inside one STAC asset
+
+- **Status:** Accepted
+- **Date:** 2026-08-14
+- **Deciders:** @emmanuelmathot
+- **Related:** issue #379
+
+---
+
+## 1. Context
+
+Every catalogue this backend read until now gave each band its own STAC
+asset: `B02`, `B03`, ... one asset key per band, so an openEO `bands` name is
+always an asset key. `_get_assets_resolutions`
+(`titiler/openeo/reader.py`) reads `item.assets` directly on that assumption
+— `if band_name not in item.assets: ...` falls through to the band-source
+registry (ADR 0002) and nowhere else.
+
+EOPF's Copernicus Sentinel-2 L2A catalogue does not fit that shape. A single
+`reflectance` asset (Zarr) holds twelve bands:
+
+```json
+"reflectance": {
+  "type": "application/vnd.zarr; version=3; profile=multiscales",
+  "gsd": 10,
+  "roles": ["data", "reflectance"],
+  "bands": [
+    {"name": "b01", "gsd": 20, "eo:common_name": "coastal", "eo:center_wavelength": 0.443},
+    {"name": "b02", "gsd": 10, "eo:common_name": "blue",    "eo:center_wavelength": 0.49}
+  ]
+}
+```
+
+Before this ADR, requesting `bands=["blue"]` against this item failed:
+`getdimensions` never advertised `blue` (only `reflectance`, the asset key),
+`_add_band_summaries` skipped the asset outright once it saw more than one
+`eo:bands` entry, and `_get_asset_info` raised `InvalidAssetName` for any name
+that was not a literal asset key.
+
+### 1.1 The read half already existed
+
+`SimpleSTACReader._get_options` already resolves an `AssetWithOptions["bands"]`
+list to `method_options["indexes"]`, matching against the asset's own
+`bands`/`eo:bands` metadata by `eo:common_name` first, then `common_name`,
+then `name`. `_get_asset_info` already accepts the dict form
+`{"name": "reflectance", "bands": ["blue"]}`. Nothing in three call sites
+(discovery, read, resolution estimation) ever constructed that dict from a
+bare band name — the mechanism existed, unreached.
+
+### 1.2 The trap: bands ≠ independently-addressable bands
+
+A true-colour `TCI` asset also carries several `eo:bands` entries —
+`[B04, B03, B02]` — describing the fixed RGB channels of *one* rendered
+image. Bare band count on its own cannot distinguish that from EOPF's
+`reflectance`, where each band is an independent variable a caller may
+request alone. Treating any asset with 2+ `bands` entries as expandable was
+tried first and broke exactly this case (`tests/test_band_summaries.py`
+already asserted a `TCI`-style asset must not expand).
+
+The distinguishing signal is not "how many bands" but "what kind of asset":
+a rendering/preview product versus a data product. STAC's own asset
+`roles` say exactly that — a TCI-style composite is conventionally tagged
+`visual` (sometimes `overview`/`thumbnail`); a genuinely multi-band data
+asset like `reflectance` is not. This codebase already draws the same line
+elsewhere (`getdimensions`'s `"data" in roles` check), and it does not
+depend on a catalogue touching the datacube extension — an earlier version
+of this ADR gated on `cube:variables` instead, which was rejected on review
+as unreliable: plenty of catalogues describe genuinely independent bands
+without ever declaring it, and requiring it would silently fall back to "one
+entry per asset" for them.
+
+## 2. Decision
+
+One resolver, `titiler/openeo/assetbands.py`, mirrors
+`bandsources`' `derive_bands`/`resolve_band` shape — the same shape already
+solving "a requested name is not a literal asset key" for band-source bands,
+already consumed by both discovery (`stacapi.py`) and read (`reader.py`).
+Everything here is derived from the item's own metadata; there is no
+registry, matching ADR 0002 §2.1's "no hand-written per-collection
+configuration" rule.
+
+```python
+def asset_band_facts(assets) -> List[Tuple[asset_key, bands]]: ...
+def resolve_asset_bands(facts) -> Dict[display_name, ResolvedAssetBand]: ...
+```
+
+**Expansion rule.** An asset expands only when it declares **two or more**
+bands and carries **no rendering role** (`visual`/`overview`/`thumbnail`).
+Everything else — no `bands` at all, exactly one band, a rendering-role
+asset regardless of band count — keeps its asset key untouched:
+
+- A single-band asset keeps its key even when the band's own `name` differs
+  from it (CDSE's `B02_10m` holds a band named `B02`; earth-search's `blue`
+  holds `B02` too) — expanding would rename bands existing process graphs and
+  services already reference, and collapse CDSE's per-resolution keys.
+- A composite carrying a rendering role keeps its key (§1.2).
+- Publishing a `bands` array at all, on an asset that is neither of the
+  above, is itself read as the catalogue's declaration that these bands are
+  worth describing individually — there is no further extension required on
+  top of that.
+
+**Naming precedence matches `_get_options` exactly**: `eo:common_name`, then
+`common_name`, then `name`. A resolved display name that `_get_options`
+cannot itself look back up would resolve at discovery time and fail at read
+time — the two must use one precedence, not two that happen to agree today.
+
+**Name collisions are qualified, not silently won.** If two multi-band
+assets on one item both publish `blue`, both become
+`{asset_key}_blue`; a unique name stays bare.
+
+### 2.1 One resolver, four call sites, no `LoadCollection` hook
+
+The issue that prompted this (#379) suggested an `asset_parser` callable on
+`LoadCollection`. That would not have reached `_get_assets_resolutions`,
+which needs the same mapping and operates below `LoadCollection` entirely,
+nor `getdimensions`, which runs at the *collection* level before any item
+exists. A backend-supplied parser and this module's own derivation would
+also have had to agree by construction, which is exactly the discipline a
+shared resolver enforces instead of trusting two independent
+implementations to.
+
+| call site | change |
+| --- | --- |
+| `stacapi.py::getdimensions` | expand a multi-band asset into its band names in `cube:dimensions.spectral`, instead of adding the asset key |
+| `stacapi.py::_add_band_summaries` | one `summaries.bands` entry per band, each with its own `eo:common_name`/wavelength/`gsd` — previously skipped for any asset with >1 `eo:bands` entry |
+| `reader.py::SimpleSTACReader._get_asset_info` | a name that is not a real asset key is checked against the item's own `_inner_bands` (precomputed once in `__attrs_post_init__`, same pattern as `_derived_bands`) *after* derived bands, *before* raising `InvalidAssetName` |
+| `reader.py::_get_assets_resolutions` | resolves through `src_dst._inner_bands` first, using the band's **own** declared `gsd` rather than the owning asset's (`reflectance` declares `gsd: 10`; `b01` is native 20m) |
+
+`load_collection`/`_process_spatial_extent` need **no change**: they already
+pass the flat requested-`bands` list straight through as `assets=bands`, and
+`_get_asset_info` now resolves each bare name transparently. This also keeps
+`_inherit_derived_band_masks`' invariant intact — one requested name still
+produces exactly one output band, so `kwargs["assets"]` stays index-aligned
+with `img.array`. Grouping several inner bands into one `{"bands": [...]}`
+open (avoiding re-opening the same asset once per band) is a real
+optimisation left for later: it would need `_inherit_derived_band_masks` to
+expand a group back into per-band indices, and is not needed for
+correctness.
+
+### 2.2 Precedence: derived bands, then inner bands, then asset keys
+
+`_get_asset_info` checks `_derived_bands` (ADR 0002) before `_inner_bands`.
+A band-source rule has already matched a specific annotation asset by the
+time it registers a name; an inner-band match on the same name must not
+shadow it. The two are not expected to collide on any real item — Sentinel-1
+GRD collections do not also carry EOPF-shaped reflectance assets — but the
+order is a deliberate, tested guarantee
+(`test_derived_bands_still_win_over_inner_bands_on_a_name_collision`), not an
+accident of insertion order.
+
+### 2.3 A pre-existing gap this surfaced: assets with only `gsd`
+
+`_get_asset_resolution` (unrelated to this ADR's own mechanism) had three
+fallbacks — `proj:transform`, `proj:shape` + item bbox, the reader's own
+transform — none of which consult an asset's declared `gsd`. EOPF's
+`AOT_10m`/`SCL_20m`/`WVP_10m` carry only `gsd` and none of those three, so
+before this ADR they silently contributed **no** resolution at all,
+regardless of multi-band assets. A fourth fallback — the asset's own `gsd` —
+closes this. It is a one-line, backward-compatible addition (every existing
+asset that reached this fallback previously had none of the first three
+either, and previously contributed nothing): without it, "supports EOPF"
+would have been only half true, since the same item's single-band assets
+would still fail to size.
+
+## 3. Consequences
+
+**Gained.** `load_collection`, discovery and resolution estimation now agree
+on every band name for a multi-band-asset catalogue, and titiler-eopf's need
+to fork `load_collection` for band addressing (#379) is answered without any
+new extension point. Existing catalogues (CDSE, earth-search, Planetary
+Computer) are provably unaffected — `resolve_asset_bands` returns `{}` for
+all three (verified against their fixtures).
+
+**Accepted costs.** One more precomputed dict on `SimpleSTACReader`
+(`_inner_bands`, same lifetime and cost class as `_derived_bands`). A second
+place — beside `_get_options` — that must agree on band-name precedence,
+documented and tested rather than merely hoped-for.
+
+**Deliberately not done.** Grouping several requested inner bands into one
+asset open (§2.1's noted follow-up). A `LoadCollection`-level parser hook —
+the resolver already reaches every call site that needs it, so a hook would
+only add a second answer that has to agree with the first. Any change to
+`_get_options`'s existing precedence itself.
+
+## 4. Related
+
+- [ADR 0002 — Band sources](0002-band-sources.md) — the registry shape this
+  reuses, and the precedence rule in §2.2.
+- [ADR 0004 — Sentinel-2 view/sun angle bands](0004-sentinel2-view-sun-angle-bands.md)
+  — the other backend that resolves a requested name against something other
+  than a literal asset key.
+- `titiler/openeo/assetbands.py`, `tests/test_assetbands.py`,
+  `tests/test_multiband_assets.py`.

--- a/tests/fixtures/eopf/items/sentinel2_l2a.json
+++ b/tests/fixtures/eopf/items/sentinel2_l2a.json
@@ -1,0 +1,492 @@
+{
+  "id": "S2B_MSIL2A_20260811T130259_N0512_R038_T27WXP_20260811T150113",
+  "bbox": [
+    -18.820373164294974,
+    65.66542003411917,
+    -16.2532509082769,
+    66.70256312388814
+  ],
+  "type": "Feature",
+  "links": [],
+  "assets": {
+    "AOT_10m": {
+      "gsd": 10,
+      "href": "https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2B_MSIL2A_20260811T130259_N0512_R038_T27WXP_20260811T150113.zarr/quality/atmosphere/r10m/aot",
+      "type": "application/vnd.zarr; version=3",
+      "roles": [
+        "data"
+      ],
+      "title": "Aerosol optical thickness (AOT)",
+      "nodata": 0,
+      "alternate": {
+        "s3": {
+          "href": "s3://esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2B_MSIL2A_20260811T130259_N0512_R038_T27WXP_20260811T150113.zarr/quality/atmosphere/r10m/aot",
+          "storage:refs": [
+            "standard"
+          ],
+          "objects_per_storage_class": {
+            "STANDARD": 2
+          }
+        }
+      },
+      "data_type": "uint16",
+      "description": "Aerosol Optical Thickness map at 10m (for 550nm) resampled from 20m AOT map",
+      "raster:scale": 0.001,
+      "raster:offset": 0
+    },
+    "SCL_20m": {
+      "gsd": 20,
+      "href": "https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2B_MSIL2A_20260811T130259_N0512_R038_T27WXP_20260811T150113.zarr/conditions/mask/l2a_classification/r20m/scl",
+      "type": "application/vnd.zarr; version=3",
+      "roles": [
+        "data"
+      ],
+      "title": "Scene classification map (SCL)",
+      "nodata": 0,
+      "alternate": {
+        "s3": {
+          "href": "s3://esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2B_MSIL2A_20260811T130259_N0512_R038_T27WXP_20260811T150113.zarr/conditions/mask/l2a_classification/r20m/scl",
+          "storage:refs": [
+            "standard"
+          ],
+          "objects_per_storage_class": {
+            "STANDARD": 2
+          }
+        }
+      },
+      "data_type": "uint8",
+      "description": "scene classification map at 20m",
+      "raster:scale": 1,
+      "raster:offset": 0
+    },
+    "WVP_10m": {
+      "gsd": 10,
+      "href": "https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2B_MSIL2A_20260811T130259_N0512_R038_T27WXP_20260811T150113.zarr/quality/atmosphere/r10m/wvp",
+      "type": "application/vnd.zarr; version=3",
+      "roles": [
+        "data"
+      ],
+      "title": "Water vapour (WVP)",
+      "nodata": 0,
+      "alternate": {
+        "s3": {
+          "href": "s3://esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2B_MSIL2A_20260811T130259_N0512_R038_T27WXP_20260811T150113.zarr/quality/atmosphere/r10m/wvp",
+          "storage:refs": [
+            "standard"
+          ],
+          "objects_per_storage_class": {
+            "STANDARD": 2
+          }
+        }
+      },
+      "data_type": "uint16",
+      "description": "Water Vapour Content map at 10m",
+      "raster:scale": 0.001,
+      "raster:offset": 0
+    },
+    "thumbnail": {
+      "href": "https://api.explorer.eopf.copernicus.eu/raster/collections/sentinel-2-l2a/items/S2B_MSIL2A_20260811T130259_N0512_R038_T27WXP_20260811T150113/preview?format=png&rescale=0%2C1&color_formula=gamma%20rgb%201.3%2C%20sigmoidal%20rgb%206%200.1%2C%20saturation%201.2&variables=%2Fmeasurements%2Freflectance%3Ab04&variables=%2Fmeasurements%2Freflectance%3Ab03&variables=%2Fmeasurements%2Freflectance%3Ab02&bidx=1",
+      "type": "image/png",
+      "roles": [
+        "thumbnail"
+      ],
+      "title": "Sentinel-2 L2A True Color Preview"
+    },
+    "reflectance": {
+      "gsd": 10,
+      "href": "https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2B_MSIL2A_20260811T130259_N0512_R038_T27WXP_20260811T150113.zarr/measurements/reflectance",
+      "type": "application/vnd.zarr; version=3; profile=multiscales",
+      "bands": [
+        {
+          "gsd": 20,
+          "name": "b01",
+          "description": "Coastal aerosol (band 1)",
+          "eo:common_name": "coastal",
+          "eo:center_wavelength": 0.443,
+          "eo:full_width_half_max": 0.027
+        },
+        {
+          "gsd": 10,
+          "name": "b02",
+          "description": "Blue (band 2)",
+          "eo:common_name": "blue",
+          "eo:center_wavelength": 0.49,
+          "eo:full_width_half_max": 0.098
+        },
+        {
+          "gsd": 10,
+          "name": "b03",
+          "description": "Green (band 3)",
+          "eo:common_name": "green",
+          "eo:center_wavelength": 0.56,
+          "eo:full_width_half_max": 0.045
+        },
+        {
+          "gsd": 10,
+          "name": "b04",
+          "description": "Red (band 4)",
+          "eo:common_name": "red",
+          "eo:center_wavelength": 0.665,
+          "eo:full_width_half_max": 0.038
+        },
+        {
+          "gsd": 20,
+          "name": "b05",
+          "description": "Red edge 1 (band 5)",
+          "eo:common_name": "rededge071",
+          "eo:center_wavelength": 0.704,
+          "eo:full_width_half_max": 0.019
+        },
+        {
+          "gsd": 20,
+          "name": "b06",
+          "description": "Red edge 2 (band 6)",
+          "eo:common_name": "rededge075",
+          "eo:center_wavelength": 0.74,
+          "eo:full_width_half_max": 0.018
+        },
+        {
+          "gsd": 20,
+          "name": "b07",
+          "description": "Red edge 3 (band 7)",
+          "eo:common_name": "rededge078",
+          "eo:center_wavelength": 0.783,
+          "eo:full_width_half_max": 0.028
+        },
+        {
+          "gsd": 10,
+          "name": "b08",
+          "description": "NIR 1 (band 8)",
+          "eo:common_name": "nir",
+          "eo:center_wavelength": 0.842,
+          "eo:full_width_half_max": 0.145
+        },
+        {
+          "gsd": 60,
+          "name": "b09",
+          "description": "NIR 3 (band 9)",
+          "eo:common_name": "nir09",
+          "eo:center_wavelength": 0.945,
+          "eo:full_width_half_max": 0.026
+        },
+        {
+          "gsd": 20,
+          "name": "b11",
+          "description": "SWIR 1 (band 11)",
+          "eo:common_name": "swir16",
+          "eo:center_wavelength": 1.61,
+          "eo:full_width_half_max": 0.143
+        },
+        {
+          "gsd": 20,
+          "name": "b12",
+          "description": "SWIR 2 (band 12)",
+          "eo:common_name": "swir22",
+          "eo:center_wavelength": 2.19,
+          "eo:full_width_half_max": 0.242
+        },
+        {
+          "gsd": 20,
+          "name": "b8a",
+          "description": "NIR 2 (band 8A)",
+          "eo:common_name": "nir08",
+          "eo:center_wavelength": 0.865,
+          "eo:full_width_half_max": 0.033
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ],
+      "title": "Surface Reflectance",
+      "alternate": {
+        "s3": {
+          "href": "s3://esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2B_MSIL2A_20260811T130259_N0512_R038_T27WXP_20260811T150113.zarr/measurements/reflectance",
+          "storage:refs": [
+            "performance"
+          ],
+          "objects_per_storage_class": {
+            "EXPRESS_ONEZONE": 199
+          }
+        }
+      },
+      "proj:code": "EPSG:32627",
+      "proj:shape": [
+        10980,
+        10980
+      ],
+      "cube:variables": {
+        "b01": {
+          "type": "data",
+          "dimensions": [
+            "y",
+            "x"
+          ],
+          "description": "Coastal aerosol (band 1)"
+        },
+        "b02": {
+          "type": "data",
+          "dimensions": [
+            "y",
+            "x"
+          ],
+          "description": "Blue (band 2)"
+        },
+        "b03": {
+          "type": "data",
+          "dimensions": [
+            "y",
+            "x"
+          ],
+          "description": "Green (band 3)"
+        },
+        "b04": {
+          "type": "data",
+          "dimensions": [
+            "y",
+            "x"
+          ],
+          "description": "Red (band 4)"
+        },
+        "b05": {
+          "type": "data",
+          "dimensions": [
+            "y",
+            "x"
+          ],
+          "description": "Red edge 1 (band 5)"
+        },
+        "b06": {
+          "type": "data",
+          "dimensions": [
+            "y",
+            "x"
+          ],
+          "description": "Red edge 2 (band 6)"
+        },
+        "b07": {
+          "type": "data",
+          "dimensions": [
+            "y",
+            "x"
+          ],
+          "description": "Red edge 3 (band 7)"
+        },
+        "b08": {
+          "type": "data",
+          "dimensions": [
+            "y",
+            "x"
+          ],
+          "description": "NIR 1 (band 8)"
+        },
+        "b09": {
+          "type": "data",
+          "dimensions": [
+            "y",
+            "x"
+          ],
+          "description": "NIR 3 (band 9)"
+        },
+        "b11": {
+          "type": "data",
+          "dimensions": [
+            "y",
+            "x"
+          ],
+          "description": "SWIR 1 (band 11)"
+        },
+        "b12": {
+          "type": "data",
+          "dimensions": [
+            "y",
+            "x"
+          ],
+          "description": "SWIR 2 (band 12)"
+        },
+        "b8a": {
+          "type": "data",
+          "dimensions": [
+            "y",
+            "x"
+          ],
+          "description": "NIR 2 (band 8A)"
+        }
+      },
+      "cube:dimensions": {
+        "x": {
+          "axis": "x",
+          "type": "spatial",
+          "reference_system": "EPSG:32627"
+        },
+        "y": {
+          "axis": "y",
+          "type": "spatial",
+          "reference_system": "EPSG:32627"
+        }
+      }
+    }
+  },
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          -18.73379463219546,
+          66.70256312388814
+        ],
+        [
+          -16.2532509082769,
+          66.64723134888527
+        ],
+        [
+          -16.43399242403142,
+          65.66542003411917
+        ],
+        [
+          -18.820373164294974,
+          65.7182494135375
+        ],
+        [
+          -18.73379463219546,
+          66.70256312388814
+        ]
+      ]
+    ]
+  },
+  "collection": "sentinel-2-l2a",
+  "properties": {
+    "gsd": 10.0,
+    "created": "2026-08-11T18:22:30.603516Z",
+    "expires": "2027-02-13T15:30:47Z",
+    "mission": "Sentinel-2",
+    "sci:doi": "10.5270/S2_-znk9xsj",
+    "updated": "2026-08-11T18:22:30.603516Z",
+    "datetime": "2026-08-11T13:02:59.024000Z",
+    "platform": "sentinel-2b",
+    "grid:code": "MGRS-27WXP",
+    "proj:bbox": [
+      600000.0,
+      7290240.0,
+      709800.0,
+      7400040.0
+    ],
+    "proj:code": "EPSG:32627",
+    "providers": [
+      {
+        "url": "https://commission.europa.eu/",
+        "name": "European Commission",
+        "roles": [
+          "licensor"
+        ]
+      },
+      {
+        "url": "https://sentinel.esa.int/web/sentinel/missions/sentinel-2",
+        "name": "ESA",
+        "roles": [
+          "producer",
+          "processor"
+        ]
+      },
+      {
+        "url": "https://zarr.eopf.copernicus.eu/",
+        "name": "EOPF Sentinel Zarr Samples Service",
+        "roles": [
+          "host",
+          "processor"
+        ]
+      }
+    ],
+    "published": "2026-08-11T18:22:30.603516Z",
+    "deprecated": false,
+    "instruments": [
+      "msi"
+    ],
+    "auth:schemes": {
+      "oidc": {
+        "type": "openIdConnect",
+        "openIdConnectUrl": "https://hub-eopf-explorer.eox.at/auth/realms/eoxhub/.well-known/openid-configuration"
+      }
+    },
+    "end_datetime": "2026-08-11T13:02:59.024000Z",
+    "product:type": "S02MSIL2A",
+    "constellation": "sentinel-2",
+    "eo:snow_cover": 0.783514,
+    "mgrs:utm_zone": 27,
+    "eo:cloud_cover": 6.06775,
+    "start_datetime": "2026-08-11T13:02:59.024000Z",
+    "sat:orbit_state": "descending",
+    "storage:schemes": {
+      "mixed": {
+        "type": "custom-s3",
+        "bucket": "esa-zarr-sentinel-explorer-fra",
+        "region": "de",
+        "platform": "https://s3.de.io.cloud.ovh.net/",
+        "storage_class": "MIXED",
+        "requester_pays": false
+      },
+      "glacier": {
+        "type": "custom-s3",
+        "bucket": "esa-zarr-sentinel-explorer-fra",
+        "region": "de",
+        "platform": "https://s3.de.io.cloud.ovh.net/",
+        "storage_class": "STANDARD_IA",
+        "requester_pays": false
+      },
+      "standard": {
+        "type": "custom-s3",
+        "bucket": "esa-zarr-sentinel-explorer-fra",
+        "region": "de",
+        "platform": "https://s3.de.io.cloud.ovh.net/",
+        "storage_class": "STANDARD",
+        "requester_pays": false
+      },
+      "performance": {
+        "type": "custom-s3",
+        "bucket": "esa-zarr-sentinel-explorer-fra",
+        "region": "de",
+        "platform": "https://s3.de.io.cloud.ovh.net/",
+        "storage_class": "EXPRESS_ONEZONE",
+        "requester_pays": false
+      }
+    },
+    "eopf:datatake_id": "GS2B_20260811T130259_049256_N05.12",
+    "mgrs:grid_square": "XP",
+    "processing:level": "L2A",
+    "view:sun_azimuth": 176.23515611007,
+    "eopf:datastrip_id": "S2B_OPER_MSI_L2A_DS_2BPS_20260811T150113_S20260811T130256_N05.12",
+    "mgrs:latitude_band": "W",
+    "processing:lineage": "systematic",
+    "processing:version": "05.12",
+    "product:timeliness": "PT3H",
+    "sat:absolute_orbit": 49256,
+    "sat:relative_orbit": 38,
+    "view:sun_elevation": 51.0709427037574,
+    "processing:facility": "ESA",
+    "processing:software": {
+      "EOPF-CPM": "2.7.0"
+    },
+    "eopf:instrument_mode": "INS-NOBS",
+    "product:timeliness_category": "NRT",
+    "sat:platform_international_designator": "2015-028A"
+  },
+  "stac_version": "1.1.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/timestamps/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/eo/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/mgrs/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/grid/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/processing/v1.2.0/schema.json",
+    "https://stac-extensions.github.io/product/v0.1.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+    "https://cs-si.github.io/eopf-stac-extension/v1.2.0/schema.json",
+    "https://stac-extensions.github.io/version/v1.2.0/schema.json",
+    "https://stac-extensions.github.io/raster/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/alternate-assets/v1.2.0/schema.json",
+    "https://stac-extensions.github.io/storage/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/authentication/v1.1.0/schema.json"
+  ]
+}

--- a/tests/test_assetbands.py
+++ b/tests/test_assetbands.py
@@ -1,0 +1,216 @@
+"""Unit tests for titiler.openeo.assetbands.
+
+`test_multiband_assets.py` covers the four call sites this module feeds
+(discovery, summaries, read, resolution) against a real EOPF fixture; this
+file is about the resolver itself -- the compatibility rules that keep
+existing single-band catalogues untouched, and the precedence a resolved band
+name must share with `SimpleSTACReader._get_options`.
+"""
+
+from typing import Any, Dict, List, Tuple
+
+from titiler.openeo.assetbands import (
+    asset_band_facts,
+    resolve_asset_band,
+    resolve_asset_bands,
+)
+
+Fact = Tuple[str, List[Dict[str, Any]]]
+
+#: A stand-in for EOPF's `reflectance`: several bands, no rendering role. The
+#: gate itself lives in `asset_band_facts`/`_bands_of` (tested separately
+#: below); these fixtures already carry only the `bands` array that survives
+#: it, since `resolve_asset_bands` is tested here in isolation from the gate.
+MULTI_BAND_CUBE: Fact = (
+    "reflectance",
+    [
+        {"name": "b02", "eo:common_name": "blue", "gsd": 10},
+        {"name": "b01", "eo:common_name": "coastal", "gsd": 20},
+    ],
+)
+
+SINGLE_BAND: Fact = ("B02_10m", [{"name": "B02"}])
+
+NO_BANDS: Fact = ("AOT_10m", [])
+
+
+def _facts(*entries):
+    """Build `AssetBandFacts` the way `asset_band_facts` would, from raw
+    (asset_key, bands) pairs already shaped like the module expects -- the
+    rendering-role gate lives in `_bands_of`/`asset_band_facts`, so callers
+    that already have the filtered `bands` array (as these tests do) bypass it
+    intentionally, to test `resolve_asset_bands` in isolation."""
+    return list(entries)
+
+
+# ---------------------------------------------------------------------------
+# asset_band_facts -- the rendering-role gate
+# ---------------------------------------------------------------------------
+
+
+def test_asset_band_facts_excludes_rendering_roles():
+    """A multi-band asset tagged `visual` produces no facts -- the signal that
+    distinguishes a TCI composite's fixed RGB channels from EOPF's
+    `reflectance`, whose bands are independently addressable. A plain `bands`
+    array with no rendering role is enough on its own; no further extension
+    (e.g. the datacube extension's `cube:variables`) is required."""
+    assets = {
+        "reflectance": {
+            "bands": [{"name": "b02"}, {"name": "b01"}],
+            "roles": ["data", "reflectance"],
+        },
+        "TCI_10m": {
+            "bands": [{"name": "B04"}, {"name": "B03"}, {"name": "B02"}],
+            "roles": ["visual"],
+        },
+        "overview_10m": {
+            "bands": [{"name": "B04"}, {"name": "B03"}, {"name": "B02"}],
+            "roles": ["overview"],
+        },
+        "AOT_10m": {"bands": [{"name": "B02"}], "roles": ["data"]},
+        "thumbnail": {"roles": ["thumbnail"]},
+    }
+
+    facts = dict(asset_band_facts(assets))
+
+    assert [b["name"] for b in facts["reflectance"]] == ["b02", "b01"]
+    assert facts["TCI_10m"] == []
+    assert facts["overview_10m"] == []
+    assert facts["AOT_10m"] == [{"name": "B02"}]
+    assert facts["thumbnail"] == []
+
+
+def test_asset_band_facts_accepts_pystac_assets():
+    """`pystac.Asset` exposes `roles` as a first-class attribute, not inside
+    `extra_fields` -- unlike a plain dict, where both live at the top level."""
+    import pystac
+
+    reflectance = pystac.Asset(
+        href="https://example.com/reflectance",
+        roles=["data", "reflectance"],
+        extra_fields={"bands": [{"name": "b02"}, {"name": "b01"}]},
+    )
+    tci = pystac.Asset(
+        href="https://example.com/tci",
+        roles=["visual"],
+        extra_fields={"bands": [{"name": "B04"}, {"name": "B03"}, {"name": "B02"}]},
+    )
+    facts = dict(asset_band_facts({"reflectance": reflectance, "TCI_10m": tci}))
+    assert [b["name"] for b in facts["reflectance"]] == ["b02", "b01"]
+    assert facts["TCI_10m"] == []
+
+
+# ---------------------------------------------------------------------------
+# resolve_asset_bands -- compatibility rules
+# ---------------------------------------------------------------------------
+
+
+def test_no_bands_asset_is_absent_from_the_result():
+    resolved = resolve_asset_bands(_facts(NO_BANDS))
+    assert resolved == {}
+
+
+def test_single_band_asset_is_absent_from_the_result():
+    """Keeps its asset key -- CDSE's `B02_10m` (holding a band named `B02`)
+    must not be renamed to `B02`, which would collide with earth-search's own
+    single-band asset key convention and rename saved graphs."""
+    resolved = resolve_asset_bands(_facts(SINGLE_BAND))
+    assert resolved == {}
+
+
+def test_a_rendering_role_asset_is_absent():
+    """Simulates a composite already filtered by the rendering-role gate --
+    `resolve_asset_bands` itself does not re-check the gate, so this exercises
+    the case only via an empty `bands` list, matching what
+    `asset_band_facts` would hand it for a TCI-style asset."""
+    resolved = resolve_asset_bands(_facts(("TCI_10m", [])))
+    assert resolved == {}
+
+
+def test_multi_band_cube_expands_every_band():
+    resolved = resolve_asset_bands(_facts(MULTI_BAND_CUBE))
+
+    assert set(resolved) == {"blue", "coastal"}
+    assert resolved["blue"].asset_key == "reflectance"
+    assert resolved["blue"].band_name == "blue"
+    assert resolved["blue"].metadata["gsd"] == 10
+    assert resolved["coastal"].metadata["gsd"] == 20
+
+
+def test_a_mix_of_shapes_only_expands_the_multi_band_cube():
+    resolved = resolve_asset_bands(_facts(MULTI_BAND_CUBE, SINGLE_BAND, NO_BANDS))
+    assert set(resolved) == {"blue", "coastal"}
+
+
+def test_colliding_band_names_across_two_assets_are_qualified():
+    """Two multi-band assets that happen to publish the same band name must
+    not have one silently shadow the other."""
+    resolved = resolve_asset_bands(
+        _facts(
+            ("reflectance_a", [{"name": "b02"}, {"name": "b01"}]),
+            ("reflectance_b", [{"name": "b02"}, {"name": "b03"}]),
+        )
+    )
+
+    assert set(resolved) == {"reflectance_a_b02", "b01", "reflectance_b_b02", "b03"}
+    assert resolved["reflectance_a_b02"].asset_key == "reflectance_a"
+    assert resolved["reflectance_b_b02"].asset_key == "reflectance_b"
+    # Unique names are left bare, so the common case is unaffected by a
+    # collision happening elsewhere in the same item.
+    assert resolved["b01"].asset_key == "reflectance_a"
+
+
+def test_resolve_asset_band_singular_matches_the_plural_result():
+    resolved = resolve_asset_band("blue", _facts(MULTI_BAND_CUBE))
+    assert resolved is not None
+    assert resolved.asset_key == "reflectance"
+
+    assert resolve_asset_band("nope", _facts(MULTI_BAND_CUBE)) is None
+
+
+# ---------------------------------------------------------------------------
+# Naming precedence -- must match SimpleSTACReader._get_options exactly, or a
+# resolved name is not one `_get_options` can itself look back up.
+# ---------------------------------------------------------------------------
+
+
+def test_eo_common_name_wins_over_name():
+    resolved = resolve_asset_bands(
+        _facts(
+            (
+                "reflectance",
+                [{"name": "b02", "eo:common_name": "blue"}, {"name": "b01"}],
+            )
+        )
+    )
+    assert "blue" in resolved
+    assert "b02" not in resolved
+
+
+def test_legacy_common_name_wins_over_name_when_no_eo_prefix():
+    resolved = resolve_asset_bands(
+        _facts(
+            (
+                "reflectance",
+                [{"name": "b02", "common_name": "blue"}, {"name": "b01"}],
+            )
+        )
+    )
+    assert "blue" in resolved
+    assert "b02" not in resolved
+
+
+def test_name_is_the_fallback_when_no_common_name_is_declared():
+    resolved = resolve_asset_bands(
+        _facts(("reflectance", [{"name": "b02"}, {"name": "b01"}]))
+    )
+    assert set(resolved) == {"b01", "b02"}
+
+
+def test_a_band_with_no_name_at_all_is_skipped():
+    """The asset still counts as multi-band by entry count (2 entries), so the
+    well-formed one is not penalised for its sibling's missing `name`."""
+    resolved = resolve_asset_bands(
+        _facts(("reflectance", [{"name": "b02"}, {"gsd": 20}]))
+    )
+    assert set(resolved) == {"b02"}

--- a/tests/test_multiband_assets.py
+++ b/tests/test_multiband_assets.py
@@ -1,0 +1,241 @@
+"""Multi-band assets end to end (titiler/openeo/assetbands.py), against a real
+EOPF Sentinel-2 L2A item (tests/fixtures/eopf/items/sentinel2_l2a.json).
+
+`test_assetbands.py` covers the resolver itself in isolation; this file covers
+the four call sites it feeds, and -- the property that matters most -- that
+discovery and the read path agree on every name.
+"""
+
+import json
+from pathlib import Path
+
+import pystac
+import pytest
+import rasterio
+
+from titiler.openeo.reader import SimpleSTACReader, _get_cube_resolutions
+from titiler.openeo.stacapi import stacApiBackend
+
+FIXTURE = Path("tests/fixtures/eopf/items/sentinel2_l2a.json")
+
+#: The band names `reflectance` publishes, keyed by their eo:common_name (the
+#: name `_get_options` resolves them by -- see assetbands.py's docstring).
+#: gsd matches the fixture: b01/b05/b06/b07/b11/b12/b8a are native 20m,
+#: b02/b03/b04/b08 are native 10m, b09 is 60m.
+EXPECTED_BANDS = {
+    "coastal": 20,
+    "blue": 10,
+    "green": 10,
+    "red": 10,
+    "rededge071": 20,
+    "rededge075": 20,
+    "rededge078": 20,
+    "nir": 10,
+    "nir09": 60,
+    "swir16": 20,
+    "swir22": 20,
+    "nir08": 20,
+}
+
+#: The item's other assets: single-band or band-less, so unaffected by any of
+#: this -- kept as their own asset key.
+UNCHANGED_ASSET_KEYS = {"AOT_10m", "SCL_20m", "WVP_10m"}
+
+
+@pytest.fixture
+def eopf_item() -> pystac.Item:
+    return pystac.Item.from_dict(json.loads(FIXTURE.read_text()))
+
+
+@pytest.fixture
+def eopf_collection(eopf_item: pystac.Item) -> pystac.Collection:
+    """A minimal collection whose item_assets mirror the fixture item's own
+    assets -- the shape `getdimensions`/`_add_band_summaries` read."""
+    collection = pystac.Collection(
+        id=eopf_item.collection_id or "sentinel-2-l2a",
+        description="EOPF Sentinel-2 L2A (test fixture)",
+        extent=pystac.Extent(
+            pystac.SpatialExtent([[0, 0, 1, 1]]),
+            pystac.TemporalExtent([[None, None]]),
+        ),
+    )
+    collection.extra_fields["item_assets"] = {
+        key: asset.to_dict() for key, asset in eopf_item.assets.items()
+    }
+    collection.set_self_href("https://example.com/collection.json")
+    return collection
+
+
+# ---------------------------------------------------------------------------
+# Discovery: getdimensions
+# ---------------------------------------------------------------------------
+
+
+def test_getdimensions_expands_reflectance_into_its_bands(eopf_collection):
+    backend = stacApiBackend.__new__(stacApiBackend)
+    dims = backend.getdimensions(eopf_collection)
+
+    spectral = set(dims["spectral"].to_dict()["values"])
+
+    assert spectral == set(EXPECTED_BANDS) | UNCHANGED_ASSET_KEYS
+    assert "reflectance" not in spectral, "the asset key must not itself be advertised"
+
+
+# ---------------------------------------------------------------------------
+# Discovery: _add_band_summaries
+# ---------------------------------------------------------------------------
+
+
+def test_add_band_summaries_expands_reflectance_with_spectral_metadata(
+    eopf_collection,
+):
+    collection = eopf_collection.to_dict()
+    stacApiBackend._add_band_summaries(collection)
+
+    summaries = {b["name"]: b for b in collection["summaries"]["bands"]}
+
+    assert set(EXPECTED_BANDS) <= set(summaries)
+    blue = summaries["blue"]
+    assert blue["eo:common_name"] == "blue"
+    assert blue["gsd"] == 10
+    assert "eo:center_wavelength" in blue
+
+    coastal = summaries["coastal"]
+    assert coastal["gsd"] == 20
+
+
+def test_add_band_summaries_leaves_bandless_assets_out(eopf_collection):
+    """Pre-existing behaviour, unaffected by multi-band expansion:
+    AOT_10m/SCL_20m/WVP_10m/thumbnail carry no `bands`/`eo:bands` at all, so
+    they were never eligible for a summaries.bands entry."""
+    collection = eopf_collection.to_dict()
+    stacApiBackend._add_band_summaries(collection)
+
+    names = {b["name"] for b in collection["summaries"]["bands"]}
+    assert names.isdisjoint(UNCHANGED_ASSET_KEYS | {"reflectance", "thumbnail"})
+
+
+# ---------------------------------------------------------------------------
+# Read: SimpleSTACReader._get_asset_info
+# ---------------------------------------------------------------------------
+
+
+def test_get_asset_info_resolves_every_expanded_band(eopf_item):
+    with SimpleSTACReader(eopf_item) as src:
+        for name in EXPECTED_BANDS:
+            info = src._get_asset_info(name)
+            assert info["name"] == "reflectance"
+            assert info["method_options"]["indexes"] == [
+                i + 1
+                for i, b in enumerate(
+                    eopf_item.assets["reflectance"].extra_fields["bands"]
+                )
+                if (b.get("eo:common_name") or b.get("common_name") or b.get("name"))
+                == name
+            ]
+
+
+def test_get_asset_info_still_serves_real_asset_keys_directly(eopf_item):
+    with SimpleSTACReader(eopf_item) as src:
+        info = src._get_asset_info("AOT_10m")
+        assert info["name"] == "AOT_10m"
+        assert "indexes" not in info["method_options"]
+
+
+def test_get_asset_info_rejects_an_unknown_name_and_lists_every_alternative(
+    eopf_item,
+):
+    with SimpleSTACReader(eopf_item) as src:
+        with pytest.raises(Exception) as excinfo:
+            src._get_asset_info("not-a-band")
+
+        message = str(excinfo.value)
+        assert "blue" in message
+        assert "AOT_10m" in message
+
+
+def test_derived_bands_still_win_over_inner_bands_on_a_name_collision(eopf_item):
+    """`_get_asset_info` checks `_derived_bands` before `_inner_bands`
+    (docs/adr/0002-band-sources.md), so a band-source rule that already
+    resolved a specific annotation asset must not be shadowed by a same-named
+    band living inside an unrelated multi-band asset. Forced via a direct
+    assignment rather than a real band-source item, since the two mechanisms
+    would not otherwise realistically collide on one item."""
+    from titiler.openeo.bandsources import ResolvedBand
+
+    with SimpleSTACReader(eopf_item) as src:
+        src._derived_bands = {
+            "blue": ResolvedBand(
+                asset_key="AOT_10m",
+                sibling_key=None,
+                quantity=None,
+                reader=src.reader,
+            )
+        }
+
+        info = src._get_asset_info("blue")
+        # `_get_derived_asset_info` names the AssetInfo after the requested
+        # band ("blue"), but its `url` comes from the resolved annotation
+        # asset -- AOT_10m's href, not reflectance's -- which is what proves
+        # the derived-band branch ran instead of the inner-band one.
+        aot_href = src.input.assets["AOT_10m"].get_absolute_href()
+        reflectance_href = src.input.assets["reflectance"].get_absolute_href()
+        assert info["url"].startswith(aot_href)
+        assert not info["url"].startswith(reflectance_href)
+
+
+# ---------------------------------------------------------------------------
+# Resolution: _get_cube_resolutions / the gsd fallback in _get_asset_resolution
+# ---------------------------------------------------------------------------
+
+
+def test_cube_resolutions_use_each_bands_own_gsd(eopf_item):
+    target_crs = rasterio.crs.CRS.from_epsg(32627)
+    target_bbox = list(eopf_item.bbox)
+
+    resolutions = _get_cube_resolutions(
+        [eopf_item], target_crs, target_bbox, list(EXPECTED_BANDS)
+    )
+    (per_band,) = resolutions.values()
+
+    for name, expected_gsd in EXPECTED_BANDS.items():
+        (x_res, y_res, _bbox) = per_band[name][0]
+        assert x_res == expected_gsd
+        assert y_res == expected_gsd
+
+
+def test_cube_resolutions_gsd_fallback_covers_assets_with_no_proj_transform(
+    eopf_item,
+):
+    """AOT_10m/SCL_20m/WVP_10m carry only `gsd`, no `proj:transform` or
+    `proj:shape` -- before the fallback in `_get_asset_resolution`, these
+    silently contributed no resolution at all."""
+    target_crs = rasterio.crs.CRS.from_epsg(32627)
+    target_bbox = list(eopf_item.bbox)
+
+    resolutions = _get_cube_resolutions(
+        [eopf_item], target_crs, target_bbox, ["AOT_10m", "SCL_20m", "WVP_10m"]
+    )
+    (per_band,) = resolutions.values()
+
+    assert per_band["AOT_10m"][0][:2] == (10.0, 10.0)
+    assert per_band["SCL_20m"][0][:2] == (20.0, 20.0)
+    assert per_band["WVP_10m"][0][:2] == (10.0, 10.0)
+
+
+# ---------------------------------------------------------------------------
+# The property that matters most: discovery and read must agree
+# ---------------------------------------------------------------------------
+
+
+def test_every_advertised_band_is_actually_readable(eopf_collection, eopf_item):
+    """A backend that advertises a band name it cannot read is worse than one
+    that advertises nothing -- the reason this module exists as one resolver
+    shared by every call site, rather than four independent guesses."""
+    backend = stacApiBackend.__new__(stacApiBackend)
+    dims = backend.getdimensions(eopf_collection)
+    advertised = set(dims["spectral"].to_dict()["values"])
+
+    with SimpleSTACReader(eopf_item) as src:
+        for name in advertised:
+            src._get_asset_info(name)  # must not raise

--- a/titiler/openeo/assetbands.py
+++ b/titiler/openeo/assetbands.py
@@ -1,0 +1,170 @@
+"""Bands published *inside* one STAC asset.
+
+Most catalogues give each band its own asset, so a band name is an asset key and
+nothing here applies. Some publish one asset holding many bands and describe them
+in the asset's ``bands`` array -- EOPF's Sentinel-2 ``reflectance`` asset carries
+all twelve, each with its own ``gsd`` and spectral metadata.
+
+This module is the one place that maps such a band name back to
+``(asset key, band within it)``. It is deliberately shared by all four callers
+that need the mapping -- collection discovery, band summaries, the read path and
+resolution estimation -- because a backend that advertises a band name it cannot
+read is worse than one that advertises nothing.
+
+Unlike :mod:`titiler.openeo.bandsources`, which matches hand-written rules
+against collection ids, everything here is derived from the item's own metadata.
+There is no registry: a catalogue that describes its assets gets this for free.
+
+Compatibility
+-------------
+
+Three rules keep existing catalogues' band names exactly as they were, and all
+are load-bearing rather than cautious:
+
+* An asset with **no** ``bands`` array keeps its asset key (EOPF's own
+  ``AOT_10m``/``SCL_20m``/``WVP_10m`` are this shape).
+* An asset with **exactly one** band keeps its asset key too. Single-band assets
+  routinely name the band differently from the key -- CDSE publishes
+  ``B02_10m`` holding a band named ``B02``, earth-search publishes ``blue``
+  holding ``B02`` -- so expanding them would silently rename bands that saved
+  process graphs and services already reference, and would collapse the several
+  resolutions CDSE distinguishes in the key.
+* An asset carrying a **rendering role** -- ``visual``, ``overview`` or
+  ``thumbnail`` -- keeps its asset key too, however many bands it declares. A
+  true-colour ``TCI`` asset lists ``[B04, B03, B02]`` in ``eo:bands`` to
+  describe one 3-channel rendered image, not three bands a caller could
+  request separately; its ``roles`` say so directly. This is a STAC-standard
+  signal (unlike the datacube extension's ``cube:variables``, which an
+  otherwise perfectly ordinary multi-band data asset is not obliged to carry)
+  and the one already used elsewhere in this codebase to draw the same
+  distinction (``stacapi.py``'s own ``"data" in roles`` check).
+
+Any other asset with two or more declared bands expands -- publishing a
+``bands`` array at all is itself the catalogue's declaration that these are
+worth describing individually, and there is no more reliable signal to
+require on top of that without excluding real catalogues that simply never
+touch the datacube extension.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+__all__ = [
+    "AssetBandFacts",
+    "ResolvedAssetBand",
+    "asset_band_facts",
+    "resolve_asset_bands",
+]
+
+#: ``(asset_key, bands)`` for one asset, where ``bands`` is its STAC ``bands``
+#: (or legacy ``eo:bands``) array -- the shape both entry points can produce,
+#: from an item's ``assets`` or a collection's ``item_assets``.
+AssetBandFacts = Tuple[str, Sequence[Mapping[str, Any]]]
+
+
+@dataclass(frozen=True)
+class ResolvedAssetBand:
+    """Which asset holds one band, and what it is called inside that asset."""
+
+    #: The asset to open, e.g. ``"reflectance"``.
+    asset_key: str
+    #: The band's name *within* that asset, e.g. ``"blue"``. Passed straight to
+    #: rio-tiler's per-asset ``bands`` option
+    #: (`SimpleSTACReader._get_options`/`_get_asset_info`), so this must be
+    #: resolved with the identical precedence that function uses to look a name
+    #: back up -- see `_band_display_name`. Using anything else here would
+    #: advertise a name `_get_options` cannot itself resolve.
+    band_name: str
+    #: The band's own entry from the asset's ``bands`` array. Carries the
+    #: per-band ``gsd`` and spectral fields that discovery advertises and
+    #: resolution estimation needs -- a multi-band asset's own ``gsd`` describes
+    #: only its finest band, so it is the wrong number for the others.
+    metadata: Mapping[str, Any]
+
+
+#: Asset roles that mark a rendering/preview product rather than independently
+#: addressable data bands -- see the module docstring's compatibility rules.
+_RENDERING_ROLES = frozenset({"visual", "overview", "thumbnail"})
+
+
+def _bands_of(asset: Any) -> Sequence[Mapping[str, Any]]:
+    """The ``bands`` array of one asset that is safe to treat as independently
+    addressable, whether the asset is a dict or a pystac Asset/AssetDefinition.
+
+    Excludes an asset carrying a rendering role -- see the module docstring's
+    compatibility rules. ``roles`` is handled separately from ``bands`` because
+    a real ``pystac.Asset`` exposes it as a first-class attribute, not inside
+    ``extra_fields`` (unlike a plain dict, e.g. an ``item_assets`` entry, where
+    both live at the top level alongside everything else).
+    """
+    if isinstance(asset, Mapping):
+        source: Mapping[str, Any] = asset
+        roles = source.get("roles")
+    else:
+        source = getattr(asset, "extra_fields", None) or {}
+        roles = getattr(asset, "roles", None)
+
+    if _RENDERING_ROLES & set(roles or ()):
+        return []
+
+    return source.get("bands") or source.get("eo:bands") or []
+
+
+def _band_display_name(band: Mapping[str, Any]) -> Optional[str]:
+    """A band's name, by the same precedence `_get_options` resolves it with:
+    ``eo:common_name`` (there is no standard precedence between it and
+    ``name`` in the STAC spec -- rio-tiler's convention, kept verbatim so a
+    resolved name is always a name `_get_options` can look back up), then the
+    legacy ``common_name``, then the band's own ``name``.
+    """
+    return band.get("eo:common_name") or band.get("common_name") or band.get("name")
+
+
+def asset_band_facts(assets: Mapping[str, Any]) -> List[AssetBandFacts]:
+    """Build this module's input from an item's ``assets`` or a collection's
+    ``item_assets``, accepting dicts and pystac objects alike."""
+    return [(key, _bands_of(asset)) for key, asset in assets.items()]
+
+
+def resolve_asset_bands(
+    assets: Iterable[AssetBandFacts],
+) -> Dict[str, ResolvedAssetBand]:
+    """Map each band published inside a multi-band asset to where it lives.
+
+    Assets keeping their key (see the module docstring) are absent from the
+    result, so a caller's ``band_name in resolved`` is exactly the question "is
+    this name something other than an asset key".
+
+    When two multi-band assets publish the same band name, every occurrence of
+    that name is qualified as ``{asset_key}_{band_name}`` rather than one of
+    them silently winning. Names unique across the item are left bare, so the
+    common case reads as the catalogue wrote it.
+    """
+    candidates: List[Tuple[str, ResolvedAssetBand]] = []
+    seen: Dict[str, int] = {}
+
+    for asset_key, bands in assets:
+        if len(bands) < 2:
+            continue
+
+        for band in bands:
+            name = _band_display_name(band)
+            if not name:
+                continue
+            candidates.append(
+                (name, ResolvedAssetBand(asset_key, name, band)),
+            )
+            seen[name] = seen.get(name, 0) + 1
+
+    return {
+        (name if seen[name] == 1 else f"{resolved.asset_key}_{name}"): resolved
+        for name, resolved in candidates
+    }
+
+
+def resolve_asset_band(
+    band_name: str,
+    assets: Iterable[AssetBandFacts],
+) -> Optional[ResolvedAssetBand]:
+    """``resolve_asset_bands`` for a single name, or ``None`` if it is not one."""
+    return resolve_asset_bands(assets).get(band_name)

--- a/titiler/openeo/reader.py
+++ b/titiler/openeo/reader.py
@@ -29,6 +29,7 @@ from rio_tiler.types import AssetInfo, AssetType, AssetWithOptions, BBox
 from rio_tiler.utils import cast_to_sequence, has_alpha_band, inherit_rasterio_env
 from typing_extensions import TypedDict
 
+from .assetbands import ResolvedAssetBand, asset_band_facts, resolve_asset_bands
 from .bandsources import (
     BAND_SOURCES,
     ResolvedBand,
@@ -277,6 +278,14 @@ class SimpleSTACReader(MultiBaseReader):
     #: don't repeat it. See docs/adr/0002-band-sources.md S2.3.
     _derived_bands: Dict[str, ResolvedBand] = attr.ib(init=False, factory=dict)
 
+    #: Bands published *inside* one of this item's own assets (e.g. EOPF's
+    #: Sentinel-2 `reflectance` asset, holding all twelve bands), precomputed
+    #: once from the item's own `bands` metadata -- no registry, no I/O. See
+    #: titiler/openeo/assetbands.py. Checked in `_get_asset_info` after
+    #: `_derived_bands`: a band-source rule already matched a specific asset,
+    #: so it must not be shadowed by a same-named inner band.
+    _inner_bands: Dict[str, ResolvedAssetBand] = attr.ib(init=False, factory=dict)
+
     #: Shared, per-instance memo for band-source readers' inverse maps
     #: (`BandReader.inverse_map_cache`). Every derived-band reader built for
     #: this item's `part()` calls gets *this same dict*: reads sharing one
@@ -328,6 +337,8 @@ class SimpleSTACReader(MultiBaseReader):
             )
             if resolved is not None:
                 self._derived_bands[name] = resolved
+
+        self._inner_bands = resolve_asset_bands(asset_band_facts(self.input.assets))
 
         proj = _extract_proj_info(self.input, assets=self.assets)
         if proj and _item_has_untrustworthy_proj(self.input, self.assets, self.signer):
@@ -471,10 +482,20 @@ class SimpleSTACReader(MultiBaseReader):
             return self._get_derived_asset_info(asset_name)
 
         if asset_name not in self.assets:
-            raise InvalidAssetName(
-                f"'{asset_name}' is not valid, should be one of "
-                f"{sorted(set(self.assets) | set(self._derived_bands))}"
-            )
+            # Not a real asset key -- maybe a band published *inside* one
+            # (titiler/openeo/assetbands.py), e.g. EOPF's `reflectance` holding
+            # `b01`..`b12`. Rewritten to the owning asset plus a `bands` option,
+            # which `_get_options` below already knows how to turn into
+            # `indexes` -- the same mechanism a caller-supplied `bands` list
+            # uses today, just reached from a bare name instead.
+            resolved = self._inner_bands.get(asset_name)
+            if resolved is None:
+                raise InvalidAssetName(
+                    f"'{asset_name}' is not valid, should be one of "
+                    f"{sorted(set(self.assets) | set(self._derived_bands) | set(self._inner_bands))}"
+                )
+            asset = {**asset, "name": resolved.asset_key, "bands": [resolved.band_name]}
+            asset_name = resolved.asset_key
 
         asset_info = self.input.assets[asset_name]
         extras = asset_info.extra_fields
@@ -688,6 +709,15 @@ def _get_asset_resolution(
     if src_dst.transform:
         return abs(src_dst.transform.a), abs(src_dst.transform.e)
 
+    # Last resort: the asset's own declared ground sample distance (STAC common
+    # metadata `gsd`), in the asset CRS's ground units. Catches an asset that
+    # carries neither `proj:transform`/`proj:shape` nor a usable item-level
+    # transform -- e.g. EOPF's `AOT_10m`/`SCL_20m`/`WVP_10m`, which declare only
+    # `gsd`. Without this, such an asset contributes no resolution at all and
+    # `_estimate_output_dimensions` silently ignores it.
+    if gsd := asset.extra_fields.get("gsd"):
+        return abs(float(gsd)), abs(float(gsd))
+
     return None, None
 
 
@@ -717,33 +747,49 @@ def _get_assets_resolutions(
 
     for band_name in assets_to_process:
         resolution_asset_name = band_name
+        # Set only for a band resolved via `_inner_bands` below: its own
+        # declared ground sample distance, which overrides the owning asset's
+        # (a multi-band asset's own metadata describes just its finest band --
+        # EOPF's `reflectance` declares 10m even though `b01` is native 20m).
+        band_gsd: Optional[float] = None
 
         if band_name not in item.assets:
-            # Not a real asset -- maybe a band-source-derived name (ADR
-            # 0002 S2.4). A derived band shares its sibling raster asset's
-            # grid, so fall back to that asset's resolution rather than
-            # silently contributing none (which would leave a derived-only
-            # request's output dimensions defaulting to 1024x1024).
-            if item_asset_facts is None:
-                item_asset_facts = [
-                    (key, a.media_type, a.roles or []) for key, a in item.assets.items()
-                ]
-                sibling_candidates = [
-                    (key, a.media_type, a.roles or [], a.extra_fields.get("gsd"))
-                    for key, a in item.assets.items()
-                ]
-            resolved = resolve_band(
-                collection_id,
-                band_name,
-                item_asset_facts,
-                BAND_SOURCES,
-                sibling_candidates=sibling_candidates,
-            )
-            if resolved is None or not resolved.sibling_key:
-                continue
-            resolution_asset_name = resolved.sibling_key
-            if resolution_asset_name not in item.assets:
-                continue
+            # Not a real asset key. Prefer a band published *inside* one of
+            # this item's own assets (titiler/openeo/assetbands.py) over a
+            # band-source-derived name below: `src_dst._inner_bands` is
+            # precomputed for this exact item, so this costs nothing extra to
+            # check first, and the two mechanisms cannot both match one name.
+            resolved_inner = src_dst._inner_bands.get(band_name)
+            if resolved_inner is not None:
+                resolution_asset_name = resolved_inner.asset_key
+                band_gsd = resolved_inner.metadata.get("gsd")
+            else:
+                # Maybe a band-source-derived name instead (ADR 0002 S2.4). A
+                # derived band shares its sibling raster asset's grid, so fall
+                # back to that asset's resolution rather than silently
+                # contributing none (which would leave a derived-only
+                # request's output dimensions defaulting to 1024x1024).
+                if item_asset_facts is None:
+                    item_asset_facts = [
+                        (key, a.media_type, a.roles or [])
+                        for key, a in item.assets.items()
+                    ]
+                    sibling_candidates = [
+                        (key, a.media_type, a.roles or [], a.extra_fields.get("gsd"))
+                        for key, a in item.assets.items()
+                    ]
+                resolved = resolve_band(
+                    collection_id,
+                    band_name,
+                    item_asset_facts,
+                    BAND_SOURCES,
+                    sibling_candidates=sibling_candidates,
+                )
+                if resolved is None or not resolved.sibling_key:
+                    continue
+                resolution_asset_name = resolved.sibling_key
+                if resolution_asset_name not in item.assets:
+                    continue
 
         asset = item.assets[resolution_asset_name]
         asset_proj_ext = None
@@ -753,8 +799,13 @@ def _get_assets_resolutions(
         # Get asset CRS or fall back to item CRS
         asset_crs = _get_asset_crs(item, asset, asset_proj_ext) or src_dst.crs
 
-        # Get asset resolution
-        x_res, y_res = _get_asset_resolution(item, asset, asset_proj_ext, src_dst)
+        # Get resolution: the band's own gsd when known, else the asset's.
+        x_res: Optional[float]
+        y_res: Optional[float]
+        if band_gsd is not None:
+            x_res, y_res = float(band_gsd), float(band_gsd)
+        else:
+            x_res, y_res = _get_asset_resolution(item, asset, asset_proj_ext, src_dst)
 
         # Skip if we couldn't determine resolution
         if x_res is None or y_res is None:

--- a/titiler/openeo/stacapi.py
+++ b/titiler/openeo/stacapi.py
@@ -27,6 +27,7 @@ from rio_tiler.mosaic.reader import mosaic_reader
 from rio_tiler.tasks import create_tasks
 from urllib3 import Retry
 
+from .assetbands import asset_band_facts, resolve_asset_bands
 from .bandsources import BAND_SOURCES, derive_bands
 from .errors import (
     ItemsLimitExceeded,
@@ -135,6 +136,12 @@ class stacApiBackend:
         values in ``getdimensions`` below. Asset keys are unique by
         construction, so every asset shows up (including the same physical
         band published at several resolutions) without name collisions.
+
+        The exception is an asset publishing several bands at once, which
+        becomes one entry *per band*, named as ``getdimensions`` names it
+        (titiler/openeo/assetbands.py). These must agree: a band advertised
+        here that ``load_collection`` cannot resolve is worse than one that is
+        never advertised.
         """
         summaries = collection.get("summaries")
         if not isinstance(summaries, dict):
@@ -144,36 +151,64 @@ class stacApiBackend:
             return
 
         item_assets = collection.get("item_assets") or {}
+        inner_bands = resolve_asset_bands(asset_band_facts(item_assets))
+        multi_band_assets = {r.asset_key for r in inner_bands.values()}
+
+        def _spectral(band: Dict[str, Any]) -> Dict[str, Any]:
+            """The eo:* fields a band entry carries, under their prefixed names."""
+            fields: Dict[str, Any] = {}
+
+            common_name = band.get("eo:common_name") or band.get("common_name")
+            if common_name:
+                fields["eo:common_name"] = common_name
+
+            center_wavelength = band.get("eo:center_wavelength") or band.get(
+                "center_wavelength"
+            )
+            if center_wavelength is not None:
+                fields["eo:center_wavelength"] = center_wavelength
+
+            fwhm = band.get("eo:full_width_half_max") or band.get("full_width_half_max")
+            if fwhm is not None:
+                fields["eo:full_width_half_max"] = fwhm
+
+            return fields
+
         band_summaries: List[Dict] = []
+
+        # One entry per band for assets holding several, named exactly as
+        # `getdimensions` names them. Each band carries its own spectral
+        # metadata and gsd, so unlike the composite case below there is no
+        # ambiguity about which band the fields describe.
+        for name, resolved in inner_bands.items():
+            band = dict(resolved.metadata)
+            entry: Dict[str, Any] = {
+                "name": name,
+                "description": band.get("description")
+                or band.get("title")
+                or f"{resolved.asset_key} band {resolved.band_name}",
+                **_spectral(band),
+            }
+            if band.get("gsd") is not None:
+                entry["gsd"] = band["gsd"]
+            band_summaries.append(entry)
+
         for key, asset in item_assets.items():
+            if key in multi_band_assets:
+                continue  # already expanded, band by band, above
+
             asset_bands = asset.get("eo:bands") or asset.get("bands")
             if not asset_bands:
                 continue
 
             description = asset.get("description") or asset.get("title") or key
-            entry: Dict[str, Any] = {"name": key, "description": description}
+            entry = {"name": key, "description": description}
 
             # Per-band spectral metadata (common name, wavelength, ...) only
             # unambiguously applies to single-band assets; composite assets
             # (e.g. a true-colour image with 3 component bands) skip it.
             if len(asset_bands) == 1:
-                band = asset_bands[0]
-
-                common_name = band.get("eo:common_name") or band.get("common_name")
-                if common_name:
-                    entry["eo:common_name"] = common_name
-
-                center_wavelength = band.get("eo:center_wavelength") or band.get(
-                    "center_wavelength"
-                )
-                if center_wavelength is not None:
-                    entry["eo:center_wavelength"] = center_wavelength
-
-                fwhm = band.get("eo:full_width_half_max") or band.get(
-                    "full_width_half_max"
-                )
-                if fwhm is not None:
-                    entry["eo:full_width_half_max"] = fwhm
+                entry.update(_spectral(asset_bands[0]))
 
             band_summaries.append(entry)
 
@@ -261,11 +296,24 @@ class stacApiBackend:
 
             band_names: Set[str] = set()
             asset_facts: List[Tuple[str, Optional[str], Sequence[str]]] = []
+            data_assets: Dict[str, Any] = {}
             for key, asset in collection.ext.item_assets.items():
                 roles = asset.roles or []
                 asset_facts.append((key, asset.media_type, roles))
                 if "data" in roles and asset.media_type not in _ARCHIVE_MEDIA_TYPES:
+                    # `.to_dict()`, not the `AssetDefinition` itself: it has no
+                    # `.extra_fields` (unlike `pystac.Asset`), so `bands` is
+                    # otherwise invisible to `assetbands.asset_band_facts`.
+                    data_assets[key] = asset.to_dict()
                     band_names.add(key)
+
+            # Assets publishing several bands at once advertise the bands, not
+            # the asset key -- see titiler/openeo/assetbands.py. Single-band and
+            # band-less assets are absent from this mapping and keep their key
+            # above, which is what stops existing catalogues being renamed.
+            inner_bands = resolve_asset_bands(asset_band_facts(data_assets))
+            band_names.difference_update(r.asset_key for r in inner_bands.values())
+            band_names.update(inner_bands)
 
             # Bands derived from non-raster assets (e.g. Sentinel-1 GRD's
             # calibration/noise annotation XML) -- see


### PR DESCRIPTION
Refs #379. Stacked on #382 — targets `refactor/sign-at-ingest`, not `main`.

## What

EOPF's Copernicus Sentinel-2 L2A catalogue publishes twelve bands inside one `reflectance` Zarr asset instead of one asset per band:

```json
"reflectance": {
  "roles": ["data", "reflectance"],
  "bands": [
    {"name": "b01", "gsd": 20, "eo:common_name": "coastal", ...},
    {"name": "b02", "gsd": 10, "eo:common_name": "blue", ...}
  ]
}
```

Before this, `load_collection(bands=["blue"])` failed outright: discovery never advertised `blue` (only `reflectance`, the asset key), `_add_band_summaries` skipped any asset with more than one `eo:bands` entry, and `_get_asset_info` raised `InvalidAssetName` for any name that wasn't a literal asset key.

**The read mechanism already existed and was unreached.** `_get_options` already resolves an asset's own `bands`/`eo:bands` metadata to `indexes`, and `_get_asset_info` already accepts `{"name": "reflectance", "bands": [...]}`. Nothing ever constructed that dict from a bare band name.

## Design

New `titiler/openeo/assetbands.py` mirrors `bandsources`' shape (derived purely from the item's own metadata, no registry) and is shared by all four places that need "is this name something other than an asset key": discovery (`getdimensions`, `_add_band_summaries`), the read path (`_get_asset_info`), and resolution estimation (`_get_assets_resolutions`). One resolver rather than four independent guesses — a band a backend advertises but cannot read is worse than one it never advertises, and `test_every_advertised_band_is_actually_readable` asserts that property directly.

**Expansion gate: 2+ bands, no rendering role.** A true-colour TCI asset also lists several `eo:bands` (its RGB channels), and a pre-existing test (`test_band_summaries.py`) already asserts that case must stay collapsed. I tried gating on the datacube extension's `cube:variables` first; on review that was rejected as unreliable — plenty of catalogues describe genuinely independent bands without ever touching it. The gate is now `roles` (`visual`/`overview`/`thumbnail` excluded), the same STAC-standard signal `getdimensions` already uses elsewhere in this file for the same "is this a data band" question.

**Naming precedence matches `_get_options` exactly**: `eo:common_name`, then `common_name`, then `name`. A resolved display name that `_get_options` can't itself look back up would resolve at discovery time and fail at read time.

**`load_collection` needed no change.** It already passes the flat requested-band list straight through as `assets=bands`, and `_get_asset_info` now resolves each bare name transparently. This also keeps `_inherit_derived_band_masks`'s one-name-per-output-band invariant intact — verified, not assumed, since a naive "group inner bands into one open" design would have broken it (documented as a deferred optimisation in ADR 0007 §2.1).

## A second gap this surfaced

`_get_assets_resolutions` needs each band's own declared `gsd` (`reflectance` says 10m but `b01` is native 20m) — but chasing that down showed `_get_asset_resolution` had no `gsd` fallback at all. EOPF's single-band `AOT_10m`/`SCL_20m`/`WVP_10m` (declaring only `gsd`, no `proj:transform`/`proj:shape`) silently contributed **no** resolution, regardless of multi-band assets. Fixed as a fourth fallback; every existing asset reaching it already had none of the first three either, so this is additive.

## Verification

- `uv run pytest` — 1252 passed (was 1229; +23 new), 13 skipped
- `uv run pre-commit run --all-files` — ruff, isort, mypy, markdownlint all pass
- Existing catalogues unaffected by construction: CDSE, earth-search and Planetary Computer fixtures all resolve to an empty mapping from `resolve_asset_bands`, checked directly
- New fixture `tests/fixtures/eopf/items/sentinel2_l2a.json`, a real item captured from `api.explorer.eopf.copernicus.eu`
- ADR 0007 records the design, including the `cube:variables` → `roles` revision

🤖 Generated with [Claude Code](https://claude.com/claude-code)