### PR TITLE
ci: drop GitHub Pages chart publishing, keep OCI only

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -189,6 +189,11 @@ jobs:
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:
           charts_dir: deployment/k8s
+          config: cr.yaml
+          # cr's own release is only an asset host for the GitHub Pages Helm
+          # repo (see RELEASE.md); it must not outrank the real "Latest"
+          # release-please release on the repo's releases page.
+          mark_as_latest: false
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -162,41 +162,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-  publish-helm-chart:
-    needs: release-please
-    runs-on: ubuntu-latest
-    if: ${{ needs.release-please.outputs.paths_released && contains(fromJSON(needs.release-please.outputs.paths_released), 'deployment/k8s/charts') }}
-    permissions:
-      contents: write
-    
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
-        with:
-          fetch-depth: 0
-
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
-      - name: Install Helm
-        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
-        with:
-          version: v3.15.2
-
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
-        with:
-          charts_dir: deployment/k8s
-          config: cr.yaml
-          # cr's own release is only an asset host for the GitHub Pages Helm
-          # repo (see RELEASE.md); it must not outrank the real "Latest"
-          # release-please release on the repo's releases page.
-          mark_as_latest: false
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-
   publish-helm-chart-oci:
     needs: release-please
     runs-on: ubuntu-latest

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -146,7 +146,12 @@ When a chart release PR (`chore(main): release titiler-openeo-chart …`) is mer
 the chart is published to **two** locations in parallel:
 
 1. **GitHub Pages (chart-releaser)** — kept for backward compatibility with
-   existing consumers using `helm repo add`.
+   existing consumers using `helm repo add`. `chart-releaser` (`cr`) needs its
+   own GitHub release to host the packaged `.tgz` for `index.yaml`; [cr.yaml](cr.yaml)
+   names that release `chart-<version>` (instead of the default
+   `titiler-openeo-<version>`, easy to mistake for a main-package release),
+   and `mark_as_latest: false` in the `publish-helm-chart` job keeps it from
+   outranking the real "Latest" release-please release.
 2. **OCI registry** at `oci://ghcr.io/developmentseed/charts/titiler-openeo`,
    so downstream GitOps repos (e.g. ArgoCD) can pin a specific version:
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -151,16 +151,26 @@ repos (e.g. ArgoCD) can pin a specific version:
 helm pull oci://ghcr.io/developmentseed/charts/titiler-openeo --version <chart-version>
 ```
 
+### ⚠️ Breaking change: GitHub Pages Helm repo dropped
+
 Previously the chart was also published to a GitHub Pages Helm repo via
 `helm/chart-releaser-action` (`cr`), for `helm repo add` consumers. That path
 was dropped: `cr` has no way to publish without creating its own GitHub
 release for every chart version, separate from and alongside
 release-please's own `titiler-openeo-chart-vX.Y.Z` release — on the releases
 page this showed up as a confusing extra `titiler-openeo-<version>` release
-that could even outrank the real "Latest" release. The `gh-pages` branch's
-existing `index.yaml` is now frozen at the last version chart-releaser
-published; any remaining `helm repo add` consumers should migrate to
-`helm pull oci://ghcr.io/developmentseed/charts/titiler-openeo`.
+that could even outrank the real "Latest" release.
+
+**Impact**: `https://sentinel-hub.github.io/titiler-openeo`'s `index.yaml` is
+now frozen at the last version chart-releaser published (`titiler-openeo-3.0.0`)
+and will **not** receive newer chart versions.
+
+**Migration**: anyone using `helm repo add`/`helm repo update` against that
+URL must switch to pulling from OCI instead:
+
+```bash
+helm pull oci://ghcr.io/developmentseed/charts/titiler-openeo --version <chart-version>
+```
 
 ### Required repository secret
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -143,21 +143,24 @@ The Helm chart version is managed separately and should be incremented manually 
 ## Helm Chart Publishing
 
 When a chart release PR (`chore(main): release titiler-openeo-chart …`) is merged,
-the chart is published to **two** locations in parallel:
+the chart is published to the **OCI registry** at
+`oci://ghcr.io/developmentseed/charts/titiler-openeo`, so downstream GitOps
+repos (e.g. ArgoCD) can pin a specific version:
 
-1. **GitHub Pages (chart-releaser)** — kept for backward compatibility with
-   existing consumers using `helm repo add`. `chart-releaser` (`cr`) needs its
-   own GitHub release to host the packaged `.tgz` for `index.yaml`; [cr.yaml](cr.yaml)
-   names that release `chart-<version>` (instead of the default
-   `titiler-openeo-<version>`, easy to mistake for a main-package release),
-   and `mark_as_latest: false` in the `publish-helm-chart` job keeps it from
-   outranking the real "Latest" release-please release.
-2. **OCI registry** at `oci://ghcr.io/developmentseed/charts/titiler-openeo`,
-   so downstream GitOps repos (e.g. ArgoCD) can pin a specific version:
+```bash
+helm pull oci://ghcr.io/developmentseed/charts/titiler-openeo --version <chart-version>
+```
 
-   ```bash
-   helm pull oci://ghcr.io/developmentseed/charts/titiler-openeo --version <chart-version>
-   ```
+Previously the chart was also published to a GitHub Pages Helm repo via
+`helm/chart-releaser-action` (`cr`), for `helm repo add` consumers. That path
+was dropped: `cr` has no way to publish without creating its own GitHub
+release for every chart version, separate from and alongside
+release-please's own `titiler-openeo-chart-vX.Y.Z` release — on the releases
+page this showed up as a confusing extra `titiler-openeo-<version>` release
+that could even outrank the real "Latest" release. The `gh-pages` branch's
+existing `index.yaml` is now frozen at the last version chart-releaser
+published; any remaining `helm repo add` consumers should migrate to
+`helm pull oci://ghcr.io/developmentseed/charts/titiler-openeo`.
 
 ### Required repository secret
 

--- a/cr.yaml
+++ b/cr.yaml
@@ -1,9 +1,0 @@
-# Config for helm/chart-releaser (cr), used by the publish-helm-chart job
-# in .github/workflows/release-please.yml.
-#
-# cr creates its own GitHub release to host the packaged chart .tgz for the
-# GitHub Pages Helm repo. Left at its default, that release is named
-# "{{ .Name }}-{{ .Version }}" (e.g. "titiler-openeo-3.0.0"), which is easy to
-# mistake for a main-package release (those are tagged "vX.Y.Z"). Prefixing
-# it keeps it clearly scoped to the chart.
-release-name-template: "chart-{{ .Version }}"

--- a/cr.yaml
+++ b/cr.yaml
@@ -1,0 +1,9 @@
+# Config for helm/chart-releaser (cr), used by the publish-helm-chart job
+# in .github/workflows/release-please.yml.
+#
+# cr creates its own GitHub release to host the packaged chart .tgz for the
+# GitHub Pages Helm repo. Left at its default, that release is named
+# "{{ .Name }}-{{ .Version }}" (e.g. "titiler-openeo-3.0.0"), which is easy to
+# mistake for a main-package release (those are tagged "vX.Y.Z"). Prefixing
+# it keeps it clearly scoped to the chart.
+release-name-template: "chart-{{ .Version }}"


### PR DESCRIPTION
## Summary
- `chart-releaser` (`cr`) creates its own GitHub release to host the packaged chart `.tgz` for the GitHub Pages Helm repo, every time the chart is published — completely separate from release-please's own `titiler-openeo-chart-vX.Y.Z` release.
- That extra release used cr's default naming (`titiler-openeo-<version>`, e.g. `titiler-openeo-3.0.0`) and was marked "Latest" by default, so it showed up on the [releases page](https://github.com/sentinel-hub/titiler-openeo/releases) looking like a real main-package release and outranking the actual latest release-please release.
- Checked `cr`'s source: there is no flag to make it reuse an existing release or skip creating one while still publishing — it's structurally required for its GitHub Pages hosting mechanism. Renaming it (an earlier iteration of this PR) only made it less confusing, not gone.
- Decision: drop the `publish-helm-chart` (chart-releaser → GitHub Pages) job entirely and keep only `publish-helm-chart-oci` (→ `oci://ghcr.io/developmentseed/charts/titiler-openeo`), which is already the documented modern path for GitOps consumers (ArgoCD, etc).
- `gh-pages`/`index.yaml` is left as-is (frozen at its last published chart version) — no new content will be pushed there. RELEASE.md now documents this and points any remaining `helm repo add` consumers at `helm pull oci://...`.

## ⚠️ Breaking changes

This is a `ci`/infra change touching only `.github/workflows` and `RELEASE.md`
(not `deployment/k8s/charts/**`), so it does **not** carry a conventional-commit
`!` marker — that would incorrectly attribute a breaking change to the main
`titiler-openeo` app's version, which is unaffected. The actual break is for
Helm chart consumers:

- **What breaks**: `https://sentinel-hub.github.io/titiler-openeo`'s
  `index.yaml` stops receiving updates as of this merge — it stays frozen at
  the last chart version chart-releaser published (`titiler-openeo-3.0.0`).
- **Who's affected**: anyone using `helm repo add https://sentinel-hub.github.io/titiler-openeo`
  / `helm repo update` to install or upgrade this chart.
- **Migration**: pull from OCI instead:
  ```bash
  helm pull oci://ghcr.io/developmentseed/charts/titiler-openeo --version <chart-version>
  ```

## Test plan
- [ ] Merge a chart-only change and confirm only `publish-helm-chart-oci` runs — no `publish-helm-chart` job, no extra `titiler-openeo-<version>` release created
- [ ] Confirm the release-please `titiler-openeo-chart-vX.Y.Z` release is still created normally and remains "Latest" appropriately
- [ ] Confirm `helm pull oci://ghcr.io/developmentseed/charts/titiler-openeo --version <chart-version>` works for the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)