### PR TITLE
fix: resolve a multi-band asset's own STAC name, not just its common name

### DIFF
--- a/docs/adr/0007-multiband-assets.md
+++ b/docs/adr/0007-multiband-assets.md
@@ -182,7 +182,31 @@ the resolver already reaches every call site that needs it, so a hook would
 only add a second answer that has to agree with the first. Any change to
 `_get_options`'s existing precedence itself.
 
-## 4. Related
+## 4. Amendment (2026-09-04, issue #397)
+
+`resolve_asset_bands` originally registered only the precedence-winning
+display name (§2's "naming precedence" rule). When a band carried both a
+display name and its own, different STAC `name` (EOPF's
+`{"name": "b04", "eo:common_name": "red"}`), only `"red"` was resolvable —
+`load_collection(bands=["b04"])` raised `InvalidAssetName` even though `b04`
+is the band's own declared identifier in the same catalogue metadata.
+
+`resolve_asset_bands` now registers **both** aliases when they differ, both
+mapping to the same `ResolvedAssetBand` — whose `.band_name` stays the
+precedence winner regardless of which alias reached it, so `_get_options`
+(§1.1) can still resolve it. Collision qualification (§2's "name
+collisions are qualified") now applies per alias rather than per band: an
+asset's raw `name` colliding with another multi-band asset's own alias is
+qualified independently of whether its display name also collides.
+
+No call site other than `assetbands.py` itself changed. Discovery
+(`getdimensions`, `_add_band_summaries`) now advertises both aliases too, as
+a direct consequence of sharing one resolver (§2.1) rather than a separate
+decision — the same "a band the read path accepts should be advertised, and
+vice versa" property `test_every_advertised_band_is_actually_readable`
+already enforced continues to hold for both names.
+
+## 5. Related
 
 - [ADR 0002 — Band sources](0002-band-sources.md) — the registry shape this
   reuses, and the precedence rule in §2.2.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -45,6 +45,7 @@ nav:
       - Tile Assignment: "tile-assignment.md"
       - SAR Backscatter: "sar-backscatter.md"
       - Sentinel-2 View/Sun Angle Bands: "sentinel2-view-angles.md"
+      - Multi-band STAC Assets: "multiband-assets.md"
   - Administrator Guide:
     - Overview: "admin-guide.md"
     - OpenID Connect: "openid-connect.md"

--- a/docs/src/concepts.md
+++ b/docs/src/concepts.md
@@ -159,6 +159,8 @@ The reduce process includes a parameter to choose the [pixel selection method](h
 
 openEO by TiTiler integrates with external STAC API services to provide collections. It uses [`pystac-client`](https://github.com/stac-utils/pystac-client) to proxy the STAC API, configured through the `TITILER_OPENEO_STORE_URL` environment variable.
 
+Most catalogues give each band its own STAC asset, so a `load_collection` band name is always an asset key. Some catalogues instead publish several bands inside one asset (e.g. a Zarr asset holding a whole reflectance cube) — see [Multi-band STAC Assets](multiband-assets.md) for how those bands are resolved and, where a band declares more than one name, made addressable by either.
+
 ### OpenEO Process Graph to CQL2-JSON Conversion
 
 The backend automatically converts OpenEO process graphs to CQL2-JSON format for STAC API filtering. Supported operators include:

--- a/docs/src/multiband-assets.md
+++ b/docs/src/multiband-assets.md
@@ -1,0 +1,111 @@
+# Multi-band STAC Assets
+
+Most catalogues give each band its own STAC asset (`B02`, `B03`, ... one
+asset key per band). Some catalogues instead publish several bands inside
+**one** asset — EOPF's Copernicus Sentinel-2 L2A collection stores all
+twelve reflectance bands as one Zarr asset, `reflectance`:
+
+```json
+"reflectance": {
+  "type": "application/vnd.zarr; version=3; profile=multiscales",
+  "roles": ["data", "reflectance"],
+  "bands": [
+    {"name": "b01", "gsd": 20, "eo:common_name": "coastal"},
+    {"name": "b04", "gsd": 10, "eo:common_name": "red"}
+  ]
+}
+```
+
+openEO by TiTiler resolves each band inside such an asset to its own,
+independently addressable band name, transparently to `load_collection` —
+`bands=["red"]` works exactly as if `red` were its own top-level asset, even
+though the underlying request opens `reflectance` and reads one of its
+Zarr variables.
+
+## Two names per band
+
+A band that declares **both** a common name (`eo:common_name`/`common_name`)
+and its own STAC `name` is addressable by **either**. The `reflectance`
+band above is valid as `bands=["red"]` *or* `bands=["b04"]` — `b04` being
+the band's own identifier in the catalogue's metadata, the same value
+Sentinel-2 documentation and tooling refer to it by.
+
+A band with no separate `name` (its display name already came from `name`,
+because no `eo:common_name`/`common_name` was declared) is addressable one
+way only, as before.
+
+## Where this shows up in collection discovery
+
+Both names are advertised, not just accepted — a client should not need to
+guess which one `load_collection` will honor:
+
+- `cube:dimensions.spectral.values`, the datacube extension's band
+  dimension
+- `summaries.bands`, with per-band metadata (common name, wavelength,
+  ground sample distance) attached identically under either name
+
+`GET /collections/sentinel-2-l2a` lists `red` and `b04` side by side, each
+with the same `gsd`/`eo:center_wavelength` values, rather than only the
+common name. The asset key itself (`reflectance`) is never advertised or
+directly addressable — only its individual bands are.
+
+## Name collisions
+
+If two different multi-band assets on the same item happen to publish the
+same alias, neither silently wins: both are qualified as
+`{asset_key}_{alias}` instead. This is independent per alias — a band's raw
+`name` colliding elsewhere does not force its common name to qualify too,
+and vice versa. An alias that is unique across the item is always left
+bare.
+
+## Worked example
+
+Requesting the same band by its common name and by its own STAC name reads
+identical pixels:
+
+```json
+{
+  "process_graph": {
+    "load1": {
+      "process_id": "load_collection",
+      "arguments": {
+        "id": "sentinel-2-l2a",
+        "spatial_extent": {"west": -1.5, "south": 62.0, "east": -1.0, "north": 62.3},
+        "temporal_extent": ["2026-08-07T00:00:00Z", "2026-08-08T00:00:00Z"],
+        "bands": ["b04"]
+      }
+    },
+    "save1": {
+      "process_id": "save_result",
+      "arguments": {
+        "data": {"from_node": "load1"},
+        "format": "GTiff"
+      },
+      "result": true
+    }
+  }
+}
+```
+
+`"bands": ["red"]` in the same graph returns the same raster.
+
+## Supported collections
+
+Any STAC catalogue configured for this backend gets this automatically —
+there is no per-collection configuration. An asset expands into its
+individual bands when it declares two or more entries in `bands` (or the
+legacy `eo:bands`) and carries no rendering role (`visual`, `overview`,
+`thumbnail`); a true-colour composite like `TCI` still resolves as one
+asset, since its bands are fixed RGB channels rather than independently
+requestable data. Today this applies to EOPF's Sentinel-2 L2A collection
+(`api.explorer.eopf.copernicus.eu/stac`); CDSE, Earth Search and Planetary
+Computer publish one asset per band already, so nothing changes for them.
+
+## Design reference
+
+The full compatibility rules and rationale are documented in
+[ADR 0007](https://github.com/sentinel-hub/titiler-openeo/blob/main/docs/adr/0007-multiband-assets.md),
+which also covers why an asset's rendering role — not its band count alone —
+decides whether it expands. ADRs are repo-only documentation (like
+`docs/audits/`) and are not published on this site — follow the link on
+GitHub.

--- a/tests/test_assetbands.py
+++ b/tests/test_assetbands.py
@@ -128,9 +128,12 @@ def test_a_rendering_role_asset_is_absent():
 
 
 def test_multi_band_cube_expands_every_band():
+    """Each band's own STAC `name` (`b02`/`b01`) resolves alongside its
+    display name (`blue`/`coastal`) -- issue #397."""
     resolved = resolve_asset_bands(_facts(MULTI_BAND_CUBE))
 
-    assert set(resolved) == {"blue", "coastal"}
+    assert set(resolved) == {"blue", "b02", "coastal", "b01"}
+    assert resolved["blue"] is resolved["b02"]
     assert resolved["blue"].asset_key == "reflectance"
     assert resolved["blue"].band_name == "blue"
     assert resolved["blue"].metadata["gsd"] == 10
@@ -139,7 +142,7 @@ def test_multi_band_cube_expands_every_band():
 
 def test_a_mix_of_shapes_only_expands_the_multi_band_cube():
     resolved = resolve_asset_bands(_facts(MULTI_BAND_CUBE, SINGLE_BAND, NO_BANDS))
-    assert set(resolved) == {"blue", "coastal"}
+    assert set(resolved) == {"blue", "b02", "coastal", "b01"}
 
 
 def test_colliding_band_names_across_two_assets_are_qualified():
@@ -160,6 +163,38 @@ def test_colliding_band_names_across_two_assets_are_qualified():
     assert resolved["b01"].asset_key == "reflectance_a"
 
 
+def test_a_raw_name_colliding_elsewhere_is_qualified_independently():
+    """A band's own `name` and its display name are collision-checked
+    separately: one colliding with another asset's alias does not force its
+    sibling alias to qualify too, and vice versa (issue #397)."""
+    resolved = resolve_asset_bands(
+        _facts(
+            # Its raw name "b02" collides with reflectance_b's own alias
+            # below, but its display name "blue" is unique across the item.
+            (
+                "reflectance_a",
+                [
+                    {"name": "b02", "eo:common_name": "blue"},
+                    {"name": "b01", "eo:common_name": "coastal"},
+                ],
+            ),
+            ("reflectance_b", [{"name": "b02"}, {"name": "b03"}]),
+        )
+    )
+
+    assert set(resolved) == {
+        "blue",
+        "reflectance_a_b02",
+        "coastal",
+        "b01",
+        "reflectance_b_b02",
+        "b03",
+    }
+    assert resolved["blue"].asset_key == "reflectance_a"
+    assert resolved["reflectance_a_b02"] is resolved["blue"]
+    assert resolved["reflectance_b_b02"].asset_key == "reflectance_b"
+
+
 def test_resolve_asset_band_singular_matches_the_plural_result():
     resolved = resolve_asset_band("blue", _facts(MULTI_BAND_CUBE))
     assert resolved is not None
@@ -174,7 +209,11 @@ def test_resolve_asset_band_singular_matches_the_plural_result():
 # ---------------------------------------------------------------------------
 
 
-def test_eo_common_name_wins_over_name():
+def test_eo_common_name_and_raw_name_both_resolve():
+    """A band with both a display name and its own, different `name` is
+    addressable either way (issue #397) -- both point at the same resolved
+    object, and `.band_name` stays the precedence winner (`_get_options` can
+    only look that one back up)."""
     resolved = resolve_asset_bands(
         _facts(
             (
@@ -184,10 +223,13 @@ def test_eo_common_name_wins_over_name():
         )
     )
     assert "blue" in resolved
-    assert "b02" not in resolved
+    assert "b02" in resolved
+    assert resolved["blue"] is resolved["b02"]
+    assert resolved["blue"].band_name == "blue"
+    assert resolved["b02"].band_name == "blue"
 
 
-def test_legacy_common_name_wins_over_name_when_no_eo_prefix():
+def test_legacy_common_name_and_raw_name_both_resolve():
     resolved = resolve_asset_bands(
         _facts(
             (
@@ -197,7 +239,9 @@ def test_legacy_common_name_wins_over_name_when_no_eo_prefix():
         )
     )
     assert "blue" in resolved
-    assert "b02" not in resolved
+    assert "b02" in resolved
+    assert resolved["blue"] is resolved["b02"]
+    assert resolved["blue"].band_name == "blue"
 
 
 def test_name_is_the_fallback_when_no_common_name_is_declared():

--- a/tests/test_multiband_assets.py
+++ b/tests/test_multiband_assets.py
@@ -37,6 +37,13 @@ EXPECTED_BANDS = {
     "nir08": 20,
 }
 
+#: Each band's own STAC `name`, keyed by its eo:common_name above -- resolves
+#: alongside it (issue #397), read straight from the fixture rather than
+#: hand-transcribed so the two stay honest with each other.
+_reflectance_bands = json.loads(FIXTURE.read_text())["assets"]["reflectance"]["bands"]
+EXPECTED_RAW_NAMES = {b["eo:common_name"]: b["name"] for b in _reflectance_bands}
+assert set(EXPECTED_RAW_NAMES) == set(EXPECTED_BANDS)
+
 #: The item's other assets: single-band or band-less, so unaffected by any of
 #: this -- kept as their own asset key.
 UNCHANGED_ASSET_KEYS = {"AOT_10m", "SCL_20m", "WVP_10m"}
@@ -72,12 +79,18 @@ def eopf_collection(eopf_item: pystac.Item) -> pystac.Collection:
 
 
 def test_getdimensions_expands_reflectance_into_its_bands(eopf_collection):
+    """Both a band's display name and its own STAC `name` are advertised
+    (issue #397) -- a name the read path accepts but discovery does not
+    advertise would be just as inconsistent as the reverse."""
     backend = stacApiBackend.__new__(stacApiBackend)
     dims = backend.getdimensions(eopf_collection)
 
     spectral = set(dims["spectral"].to_dict()["values"])
 
-    assert spectral == set(EXPECTED_BANDS) | UNCHANGED_ASSET_KEYS
+    assert (
+        spectral
+        == set(EXPECTED_BANDS) | set(EXPECTED_RAW_NAMES.values()) | UNCHANGED_ASSET_KEYS
+    )
     assert "reflectance" not in spectral, "the asset key must not itself be advertised"
 
 
@@ -102,6 +115,12 @@ def test_add_band_summaries_expands_reflectance_with_spectral_metadata(
 
     coastal = summaries["coastal"]
     assert coastal["gsd"] == 20
+
+    # Its own STAC name gets an entry too (issue #397), with the same
+    # metadata as its display name's entry.
+    assert set(EXPECTED_RAW_NAMES.values()) <= set(summaries)
+    assert summaries["b02"]["eo:common_name"] == "blue"
+    assert summaries["b02"]["gsd"] == 10
 
 
 def test_add_band_summaries_leaves_bandless_assets_out(eopf_collection):
@@ -133,6 +152,21 @@ def test_get_asset_info_resolves_every_expanded_band(eopf_item):
                 if (b.get("eo:common_name") or b.get("common_name") or b.get("name"))
                 == name
             ]
+
+
+def test_get_asset_info_resolves_raw_stac_names_too(eopf_item):
+    """The literal repro from issue #397: `load_collection(bands=["b04"])`
+    must resolve, the same way `bands=["red"]` already did, since `b04` is
+    the band's own declared `name` in the same catalogue metadata."""
+    with SimpleSTACReader(eopf_item) as src:
+        for common_name, raw_name in EXPECTED_RAW_NAMES.items():
+            by_common_name = src._get_asset_info(common_name)
+            by_raw_name = src._get_asset_info(raw_name)
+            assert by_raw_name["name"] == "reflectance"
+            assert (
+                by_raw_name["method_options"]["indexes"]
+                == by_common_name["method_options"]["indexes"]
+            )
 
 
 def test_get_asset_info_still_serves_real_asset_keys_directly(eopf_item):

--- a/titiler/openeo/assetbands.py
+++ b/titiler/openeo/assetbands.py
@@ -9,7 +9,9 @@ This module is the one place that maps such a band name back to
 ``(asset key, band within it)``. It is deliberately shared by all four callers
 that need the mapping -- collection discovery, band summaries, the read path and
 resolution estimation -- because a backend that advertises a band name it cannot
-read is worse than one that advertises nothing.
+read is worse than one that advertises nothing. A band carrying both a display
+name (``eo:common_name``/``common_name``) and its own, different STAC ``name``
+is addressable by either -- see `resolve_asset_bands`.
 
 Unlike :mod:`titiler.openeo.bandsources`, which matches hand-written rules
 against collection ids, everything here is derived from the item's own metadata.
@@ -73,7 +75,10 @@ class ResolvedAssetBand:
     #: (`SimpleSTACReader._get_options`/`_get_asset_info`), so this must be
     #: resolved with the identical precedence that function uses to look a name
     #: back up -- see `_band_display_name`. Using anything else here would
-    #: advertise a name `_get_options` cannot itself resolve.
+    #: advertise a name `_get_options` cannot itself resolve. This is always
+    #: the precedence-winning display name, even when a caller reached this
+    #: entry through the band's other alias (its own STAC ``name`` -- see
+    #: `resolve_asset_bands`), so `_get_options` can look it back up either way.
     band_name: str
     #: The band's own entry from the asset's ``bands`` array. Carries the
     #: per-band ``gsd`` and spectral fields that discovery advertises and
@@ -135,10 +140,22 @@ def resolve_asset_bands(
     result, so a caller's ``band_name in resolved`` is exactly the question "is
     this name something other than an asset key".
 
-    When two multi-band assets publish the same band name, every occurrence of
-    that name is qualified as ``{asset_key}_{band_name}`` rather than one of
-    them silently winning. Names unique across the item are left bare, so the
-    common case reads as the catalogue wrote it.
+    A band with **both** a display name (``eo:common_name``/``common_name``)
+    and its own, different STAC ``name`` is registered under *both* -- e.g.
+    EOPF's ``{"name": "b04", "eo:common_name": "red"}`` becomes resolvable as
+    either ``"red"`` or ``"b04"``, both mapping to the same
+    `ResolvedAssetBand` (whose `.band_name` stays ``"red"``, the one
+    `_get_options` can itself resolve -- see `ResolvedAssetBand.band_name`).
+    A band with no separate ``name`` (the display name already came from
+    ``name``) is registered once, as before.
+
+    When two multi-band assets publish the same alias -- a display name, a
+    raw ``name``, or one of each -- every occurrence of that alias is
+    qualified as ``{asset_key}_{alias}`` rather than one of them silently
+    winning. Each alias is qualified independently, so a band's raw name
+    colliding elsewhere does not force its display name to qualify too, and
+    vice versa. Aliases unique across the item are left bare, so the common
+    case reads as the catalogue wrote it.
     """
     candidates: List[Tuple[str, ResolvedAssetBand]] = []
     seen: Dict[str, int] = {}
@@ -151,14 +168,17 @@ def resolve_asset_bands(
             name = _band_display_name(band)
             if not name:
                 continue
-            candidates.append(
-                (name, ResolvedAssetBand(asset_key, name, band)),
-            )
-            seen[name] = seen.get(name, 0) + 1
+            resolved = ResolvedAssetBand(asset_key, name, band)
+            aliases = {name}
+            if raw_name := band.get("name"):
+                aliases.add(raw_name)
+            for alias in aliases:
+                candidates.append((alias, resolved))
+                seen[alias] = seen.get(alias, 0) + 1
 
     return {
-        (name if seen[name] == 1 else f"{resolved.asset_key}_{name}"): resolved
-        for name, resolved in candidates
+        (alias if seen[alias] == 1 else f"{resolved.asset_key}_{alias}"): resolved
+        for alias, resolved in candidates
     }
 
 


### PR DESCRIPTION
Fixes #397.

## What

`resolve_asset_bands` (`titiler/openeo/assetbands.py`) mapped each band published inside a multi-band asset (e.g. EOPF's Sentinel-2 `reflectance`, one Zarr asset holding twelve bands) to exactly one bare, addressable name, chosen by `_band_display_name`'s fixed precedence: `eo:common_name` → `common_name` → `name`.

A band carrying both a common name and its own, different `name` — e.g. `{"name": "b04", "eo:common_name": "red"}` — was only addressable as `red`. `load_collection(bands=["b04"])` raised `InvalidAssetName`, even though `b04` is the band's own declared identifier in the same catalogue metadata. Confirmed empirically against the real EOPF fixture before this change.

## Fix

`resolve_asset_bands` now registers **both** aliases when they differ, mapping to the *same* `ResolvedAssetBand` object. `.band_name` always stays the precedence-winning name (never the raw alias), so `_get_options` — which only ever resolves that one name — can still look it up regardless of which alias reached it. This means the read path (`_get_asset_info`) needed **no changes**, exactly as the issue anticipated.

Collision qualification (`{asset_key}_{alias}` when two multi-band assets publish the same name) now applies per alias rather than per band, so a raw name colliding elsewhere doesn't force its sibling display name to qualify too, and vice versa.

Because discovery (`getdimensions`, `_add_band_summaries`) consumes this same shared resolver, both aliases are now advertised there too — a direct, intended consequence of the module's "one resolver, four call sites" design (a band the read path accepts should be advertised, and vice versa), not a separate change.

One correction found during investigation: the issue states `_get_options` "already accepts `b04` today" via `{"name": "reflectance", "bands": ["b04"]}`. That's not the case — `_get_options`'s own `common_to_variable` map only ever builds a key for the precedence-winning name, so `bands=["b04"]` fails there too when `eo:common_name` is set. Doesn't change the fix (see above), just a note for the record.

## Docs

Added an amendment section to `docs/adr/0007-multiband-assets.md` documenting this behavior change and its rationale.

## Verification

- `uv run pytest tests/test_assetbands.py tests/test_multiband_assets.py -v` — all pass, including new tests for the dual-alias resolution, the per-alias collision case, and the literal `bands=["b04"]` repro from the issue
- `uv run pytest` — full suite, 1254 passed, 13 skipped
- `uv run pre-commit run --all-files` — ruff, isort, mypy, markdownlint all pass
- Manual repro against the real fixture:
  ```python
  with SimpleSTACReader(item) as r:
      r._get_asset_info("b04")  # no longer raises InvalidAssetName
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)